### PR TITLE
fix: WebSocket task leak and CI notarytool keychain path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,12 @@ jobs:
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
+          KEYCHAIN_PATH="$(security list-keychains -d user | head -1 | tr -d '[:space:]"')"
           xcrun notarytool store-credentials "$APP_NAME" \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --keychain "$KEYCHAIN_NAME"
+            --keychain "$KEYCHAIN_PATH"
 
       - name: Generate Xcode project (XcodeGen)
         if: env.USES_XCODEGEN == 'true'
@@ -130,9 +131,10 @@ jobs:
         run: |
           ditto -c -k --keepParent "$EXPORT_DIR/$APP_BUNDLE_NAME" "build/${APP_NAME}-notary.zip"
 
+          KEYCHAIN_PATH="$(security list-keychains -d user | head -1 | tr -d '[:space:]"')"
           xcrun notarytool submit "build/${APP_NAME}-notary.zip" \
             --keychain-profile "$APP_NAME" \
-            --keychain "$KEYCHAIN_NAME" \
+            --keychain "$KEYCHAIN_PATH" \
             --wait
 
           xcrun stapler staple "$EXPORT_DIR/$APP_BUNDLE_NAME"

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		AA8C95710FD8D22B9FF8242A /* AudioMixerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE04DF44C896CD368ED16901 /* AudioMixerService.swift */; };
 		ACAD1265239FA9A32565242B /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7074B6A737CE72D77BD9AE8F /* AccountSettingsView.swift */; };
 		B11EF2458AEAF401E1A03FD2 /* HistoryPaletteWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9357A98372102BF3B285A2AD /* HistoryPaletteWindowController.swift */; };
+		BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */; };
 		C24B6F611448AF8CAD8E3DB9 /* MeetingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA64DC6EAB5D1FB38CF7F517 /* MeetingSettingsView.swift */; };
 		C5FA530A98A4A76DD9DEA952 /* AppDelegate+MeetingRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */; };
 		C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */; };
@@ -112,6 +113,7 @@
 		1999FC4728C79F46A514A1E4 /* AppDelegate+MeetingTranslationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingTranslationRecording.swift"; sourceTree = "<group>"; };
 		1A1643A987A23A64D7D9F7B8 /* DoubleCopyDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleCopyDetector.swift; sourceTree = "<group>"; };
 		1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
+		22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		2430641841403AB68C61B536 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		26809CA162E096F4EA668768 /* ServiceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
 		2A69C86E608DDD0D38D8AB54 /* WhisperBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WhisperBridge.h; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 		54C08AEA7B3D9495385E0990 /* LiveTranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptView.swift; sourceTree = "<group>"; };
 		583D24D80FE19BB49505E371 /* TextTranslationWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTranslationWindowController.swift; sourceTree = "<group>"; };
 		58445C3A1AF119838326EC9F /* RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfig.swift; sourceTree = "<group>"; };
+		5B4AFAFBB376B839E41C6BDA /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTranscriptionService.swift; sourceTree = "<group>"; };
 		622FD84CF56FC17420114B9C /* NotchContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchContentView.swift; sourceTree = "<group>"; };
 		67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToTalkKey.swift; sourceTree = "<group>"; };
@@ -366,6 +369,8 @@
 			isa = PBXGroup;
 			children = (
 				AB584F0BDA9252D1D71CE50D /* Logger.swift */,
+				5B4AFAFBB376B839E41C6BDA /* ObjCExceptionCatcher.h */,
+				22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -605,6 +610,7 @@
 				DB3964EFB7C60E392C41A920 /* MenuBarIconView.swift in Sources */,
 				8CAA1C227A9788C6A9687E7D /* NotchContentView.swift in Sources */,
 				9876807751B2F948878C2BDF /* NotchManager.swift in Sources */,
+				BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */,
 				214683A40F227DDAE1D64C8B /* OnboardingComponents.swift in Sources */,
 				22F85E040AEC97503AF68835 /* OnboardingContainerView.swift in Sources */,
 				03EBBAC2178925692C5B0F28 /* OnboardingManager.swift in Sources */,
@@ -722,7 +728,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -808,7 +814,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -874,7 +880,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.11.0;
+				MARKETING_VERSION = 1.12.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -465,8 +465,16 @@ extension AppDelegate {
                 Log.app.warning("stopMeetingRecording: state changed during processing (now \(self.appState.meetingRecordingState)), dropping error")
                 return
             }
+
+            let userMessage: String
+            if let transcriptionError = error as? TranscriptionError {
+                userMessage = transcriptionError.localizedDescription
+            } else {
+                userMessage = "Transcription failed: \(error.localizedDescription). Audio saved to Recordings."
+            }
+
             await MainActor.run {
-                appState.errorMessage = error.localizedDescription
+                appState.errorMessage = userMessage
                 appState.meetingRecordingState = .error
                 appState.meetingRecordingStartTime = nil
                 handleMeetingStateChange(.error)

--- a/Diduny/App/AppDelegate+MeetingTranslationRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingTranslationRecording.swift
@@ -155,7 +155,7 @@ extension AppDelegate {
             try await meetingRecorderService.startRecording()
             Log.app.info("Meeting translation recording started")
 
-            // Stream realtime meeting translation (EN -> UK)
+            // Stream realtime meeting translation
             let store = await setupRealtimeMeetingTranslation()
 
             // Only set recording state AFTER confirmed working
@@ -252,13 +252,16 @@ extension AppDelegate {
 
         // Connect WebSocket (recording continues even if translation socket is unavailable)
         do {
+            let sourceLanguage = SettingsStorage.shared.translationLanguageA
+            let targetLanguage = SettingsStorage.shared.translationLanguageB
+
             var languageHints = SettingsStorage.shared.favoriteLanguages
 
-            if !languageHints.contains("en") {
-                languageHints.append("en")
+            if !languageHints.contains(sourceLanguage) {
+                languageHints.append(sourceLanguage)
             }
-            if !languageHints.contains("uk") {
-                languageHints.append("uk")
+            if !languageHints.contains(targetLanguage) {
+                languageHints.append(targetLanguage)
             }
 
             try await rtService.connect(
@@ -266,13 +269,13 @@ extension AppDelegate {
                 strictLanguageHints: !languageHints.isEmpty,
                 audioConfig: .defaultPCM16kMono,
                 translationConfig: RealtimeTranslationConfig(
-                    mode: .oneWay(sourceLanguage: "en", targetLanguage: "uk")
+                    mode: .oneWay(sourceLanguage: sourceLanguage, targetLanguage: targetLanguage)
                 ),
             )
             await MainActor.run {
                 store.isActive = true
             }
-            Log.transcription.info("Meeting real-time translation connected successfully (EN -> UK)")
+            Log.transcription.info("Meeting real-time translation connected successfully (\(sourceLanguage.uppercased()) -> \(targetLanguage.uppercased()))")
         } catch {
             Log.transcription.error("Meeting real-time translation FAILED to connect: \(error.localizedDescription)")
             await MainActor.run {
@@ -320,8 +323,9 @@ extension AppDelegate {
         }
 
         // Additional fallback: prefer target-language tokens if status exists but format changed.
+        let targetLang = SettingsStorage.shared.translationLanguageB
         let targetLanguageTokens = tokens.filter {
-            $0.language?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "uk"
+            $0.language?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == targetLang
         }
         if !targetLanguageTokens.isEmpty {
             return targetLanguageTokens
@@ -386,7 +390,7 @@ extension AppDelegate {
                 let audioData = try await loadAudioData(from: audioURL)
                 Log.app.info("Meeting translation recording size = \(audioData.count) bytes")
 
-                text = try await transcriptionService.translateAndTranscribe(audioData: audioData, targetLanguage: "uk")
+                text = try await transcriptionService.translateAndTranscribe(audioData: audioData)
                 Log.app.info("Async meeting translation received (\(text.count) chars)")
             }
 
@@ -468,8 +472,16 @@ extension AppDelegate {
                 Log.app.warning("stopMeetingTranslationRecording: state changed during processing (now \(self.appState.meetingTranslationRecordingState)), dropping error")
                 return
             }
+
+            let userMessage: String
+            if let transcriptionError = error as? TranscriptionError {
+                userMessage = transcriptionError.localizedDescription
+            } else {
+                userMessage = "Translation failed: \(error.localizedDescription). Audio saved to Recordings."
+            }
+
             await MainActor.run {
-                appState.errorMessage = error.localizedDescription
+                appState.errorMessage = userMessage
                 appState.meetingTranslationRecordingState = .error
                 appState.meetingTranslationRecordingStartTime = nil
                 handleMeetingTranslationStateChange(.error)

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -222,9 +222,9 @@ extension AppDelegate {
         }
 
         do {
-            // Configure realtime websocket BEFORE starting recorder.
-            // AudioRecorderService snapshots onRealtimeAudioData at start time.
-            await setupVoiceRealtimeTranscriptionIfNeeded()
+            // Set up realtime callback BEFORE starting recorder (AudioRecorderService
+            // snapshots onRealtimeAudioData at start time). WebSocket connects in background.
+            setupVoiceRealtimeTranscriptionIfNeeded()
 
             Log.app.info("startRecording: Starting audio recording")
             try await audioRecorder.startRecording(device: device)
@@ -351,49 +351,19 @@ extension AppDelegate {
             Log.app.info("stopRecording: Got audio data, size = \(audioData.count) bytes")
 
             let realtimeResult = await stopVoiceRealtimeSession(finalize: true)
-            let recordingDurationSeconds = recordingStartTime.map { stopTime.timeIntervalSince($0) } ?? 0
 
             let text: String
-            let useRealtimeWithoutFinalize = shouldUseRealtimeFallbackText(
-                realtimeResult.text,
-                didReceiveFinalization: realtimeResult.didReceiveFinalization,
-                recordingDurationSeconds: recordingDurationSeconds
-            )
-
-            if useRealtimeWithoutFinalize {
+            if !realtimeResult.text.isEmpty {
                 text = realtimeResult.text
-                if realtimeResult.didReceiveFinalization {
-                    Log.app.info("stopRecording: Using realtime transcription (\(realtimeResult.text.count) chars)")
-                } else {
-                    Log.app.warning(
-                        "stopRecording: Finalize delayed, using realtime fallback text (\(realtimeResult.text.count) chars)"
-                    )
-                }
+                Log.app.info("stopRecording: Using realtime transcription (\(text.count) chars)")
+            } else if SettingsStorage.shared.transcriptionProvider == .local {
+                // Local Whisper — no WebSocket, transcribe from audio
+                text = try await whisperTranscriptionService.transcribe(audioData: audioData)
+                Log.app.info("stopRecording: Local Whisper transcription (\(text.count) chars)")
+            } else if let connectionError = voiceRealtimeConnectionError {
+                throw TranscriptionError.cloudConnectionFailed(connectionError)
             } else {
-                let service = activeTranscriptionService
-
-                if !realtimeResult.didReceiveFinalization {
-                    Log.app.warning("stopRecording: Realtime finalize was incomplete, forcing async transcription fallback")
-                } else if realtimeResult.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Log.app.info("stopRecording: Realtime transcription empty, using async fallback")
-                } else {
-                    Log.app.warning(
-                        "stopRecording: Realtime finalized text too short (\(realtimeResult.text.count) chars) for \(String(format: "%.2f", recordingDurationSeconds))s recording, using async fallback"
-                    )
-                }
-
-                do {
-                    text = try await service.transcribe(audioData: audioData)
-                } catch {
-                    if !realtimeResult.text.isEmpty {
-                        Log.app.warning(
-                            "stopRecording: Async fallback failed, using partial realtime text (\(realtimeResult.text.count) chars)"
-                        )
-                        text = realtimeResult.text
-                    } else {
-                        throw error
-                    }
-                }
+                throw TranscriptionError.emptyTranscription
             }
             Log.app.info("stopRecording: Transcription received (\(text.count) chars)")
 
@@ -552,10 +522,8 @@ extension AppDelegate {
 
     // MARK: - Realtime Transcription (WebSocket)
 
-    private func setupVoiceRealtimeTranscriptionIfNeeded() async {
-        guard SettingsStorage.shared.transcriptionProvider == .cloud,
-              SettingsStorage.shared.transcriptionRealtimeSocketEnabled
-        else {
+    private func setupVoiceRealtimeTranscriptionIfNeeded() {
+        guard SettingsStorage.shared.transcriptionProvider == .cloud else {
             audioRecorder.onRealtimeAudioData = nil
             voiceRealtimeSessionEnabled = false
             voiceRealtimeAccumulator = nil
@@ -592,24 +560,34 @@ extension AppDelegate {
             Log.transcription.error("Dictation RT error: \(error.localizedDescription)")
         }
 
-        do {
-            let languageHints = SettingsStorage.shared.favoriteLanguages
+        voiceRealtimeConnectionError = nil
 
-            try await rtService.connect(
-                languageHints: languageHints,
-                strictLanguageHints: !languageHints.isEmpty,
-                audioConfig: .defaultPCM16kMono,
-            )
+        // Connect WebSocket in background — don't block recording start
+        Task {
+            do {
+                let languageHints = SettingsStorage.shared.favoriteLanguages
 
-            voiceRealtimeSessionEnabled = true
-            Log.transcription.info("Dictation RT connected")
-        } catch {
-            audioRecorder.onRealtimeAudioData = nil
-            voiceRealtimeSessionEnabled = false
-            voiceRealtimeAccumulator = nil
-            Log.transcription.warning(
-                "Dictation RT unavailable (\(error.localizedDescription)); fallback to async transcription will be used"
-            )
+                try await rtService.connect(
+                    languageHints: languageHints,
+                    strictLanguageHints: !languageHints.isEmpty,
+                    audioConfig: .defaultPCM16kMono,
+                )
+
+                await MainActor.run {
+                    self.voiceRealtimeSessionEnabled = true
+                }
+                Log.transcription.info("Dictation RT connected")
+            } catch {
+                await MainActor.run {
+                    self.audioRecorder.onRealtimeAudioData = nil
+                    self.voiceRealtimeSessionEnabled = false
+                    self.voiceRealtimeAccumulator = nil
+                    self.voiceRealtimeConnectionError = error.localizedDescription
+                }
+                Log.transcription.warning(
+                    "Dictation RT connection failed: \(error.localizedDescription)"
+                )
+            }
         }
     }
 
@@ -680,51 +658,4 @@ extension AppDelegate {
         escapeService.activate()
     }
 
-    private func shouldUseRealtimeFallbackText(
-        _ text: String,
-        didReceiveFinalization: Bool,
-        recordingDurationSeconds: TimeInterval
-    ) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-
-        let wordCount = trimmed.split { $0.isWhitespace || $0.isNewline }.count
-        let charCount = trimmed.count
-        let hasSentenceEnding = trimmed.hasSuffix(".")
-            || trimmed.hasSuffix("!")
-            || trimmed.hasSuffix("?")
-            || trimmed.contains("\n")
-
-        if didReceiveFinalization {
-            // Finalized realtime output can occasionally be a very short fragment (e.g. "But.").
-            // For recordings longer than a short utterance, require a minimal text quality bar
-            // and fall back to async full-audio transcription otherwise.
-            if recordingDurationSeconds <= 1.2 {
-                return true
-            }
-            if wordCount >= 2 {
-                return true
-            }
-            if charCount >= 12 {
-                return true
-            }
-            return false
-        }
-
-        // Fallback policy when finalize is delayed:
-        // 1) sentence-like chunk with at least 4 words
-        // 2) or sufficiently long chunk (>= 8 words)
-        // 3) or raw length safety net (>= 48 chars)
-        if hasSentenceEnding, wordCount >= 4 {
-            return true
-        }
-        if wordCount >= 8 {
-            return true
-        }
-        if charCount >= 48 {
-            return true
-        }
-
-        return false
-    }
 }

--- a/Diduny/App/AppDelegate+TranslationRecording.swift
+++ b/Diduny/App/AppDelegate+TranslationRecording.swift
@@ -501,7 +501,7 @@ extension AppDelegate {
         translationRealtimeConnectionError = nil
 
         // Connect WebSocket in background — don't block recording start
-        Task {
+        translationRealtimeConnectionTask = Task {
             do {
                 try await rtService.connect(
                     languageHints: [pair.languageA, pair.languageB],
@@ -515,7 +515,7 @@ extension AppDelegate {
                 await MainActor.run {
                     self.translationRealtimeSessionEnabled = true
                 }
-                Log.transcription.info("Translation RT connected (\(pair.languageA) <-> \(pair.languageB))")
+                NSLog("[Transcription] Translation RT connected (%@ <-> %@)", pair.languageA, pair.languageB)
             } catch {
                 await MainActor.run {
                     self.audioRecorder.onRealtimeAudioData = nil
@@ -523,14 +523,14 @@ extension AppDelegate {
                     self.translationRealtimeAccumulator = nil
                     self.translationRealtimeConnectionError = error.localizedDescription
                 }
-                Log.transcription.warning(
-                    "Translation RT connection failed: \(error.localizedDescription)"
-                )
+                NSLog("[Transcription] Translation RT connection failed: %@", error.localizedDescription)
             }
         }
     }
 
     private func stopTranslationRealtimeSession(finalize: Bool) async -> (text: String, didReceiveFinalization: Bool) {
+        translationRealtimeConnectionTask?.cancel()
+        translationRealtimeConnectionTask = nil
         audioRecorder.onRealtimeAudioData = nil
 
         let accumulator = translationRealtimeAccumulator

--- a/Diduny/App/AppDelegate+TranslationRecording.swift
+++ b/Diduny/App/AppDelegate+TranslationRecording.swift
@@ -38,7 +38,7 @@ actor RealtimeTranslationAccumulator {
     }
 }
 
-// MARK: - Translation Recording (EN <-> UK)
+// MARK: - Translation Recording
 
 extension AppDelegate {
     @objc func toggleTranslationRecording() {
@@ -225,9 +225,9 @@ extension AppDelegate {
         }
 
         do {
-            // Configure realtime websocket BEFORE starting recorder.
-            // AudioRecorderService snapshots onRealtimeAudioData at start time.
-            await setupRealtimeTranslationIfNeeded()
+            // Set up realtime callback BEFORE starting recorder (AudioRecorderService
+            // snapshots onRealtimeAudioData at start time). WebSocket connects in background.
+            setupRealtimeTranslationIfNeeded()
 
             Log.app.info("startTranslationRecording: Starting audio recording")
             try await audioRecorder.startRecording(device: device)
@@ -346,49 +346,19 @@ extension AppDelegate {
             Log.app.info("stopTranslationRecording: Got audio data, size = \(audioData.count) bytes")
 
             let realtimeResult = await stopTranslationRealtimeSession(finalize: true)
-            let recordingDurationSeconds = recordingStartTime.map { stopTime.timeIntervalSince($0) } ?? 0
 
             let text: String
-            let useRealtimeWithoutFinalize = shouldUseRealtimeFallbackText(
-                realtimeResult.text,
-                didReceiveFinalization: realtimeResult.didReceiveFinalization,
-                recordingDurationSeconds: recordingDurationSeconds
-            )
-
-            if useRealtimeWithoutFinalize {
+            if !realtimeResult.text.isEmpty {
                 text = realtimeResult.text
-                if realtimeResult.didReceiveFinalization {
-                    Log.app.info("stopTranslationRecording: Using realtime translation (\(realtimeResult.text.count) chars)")
-                } else {
-                    Log.app.warning(
-                        "stopTranslationRecording: Finalize delayed, using realtime fallback text (\(realtimeResult.text.count) chars)"
-                    )
-                }
+                Log.app.info("stopTranslationRecording: Using realtime translation (\(text.count) chars)")
+            } else if SettingsStorage.shared.transcriptionProvider == .local {
+                // Local Whisper — no WebSocket, transcribe from audio
+                text = try await whisperTranscriptionService.translateAndTranscribe(audioData: audioData)
+                Log.app.info("stopTranslationRecording: Local Whisper translation (\(text.count) chars)")
+            } else if let connectionError = translationRealtimeConnectionError {
+                throw TranscriptionError.cloudConnectionFailed(connectionError)
             } else {
-                let service = activeTranscriptionService
-
-                if !realtimeResult.didReceiveFinalization {
-                    Log.app.warning("stopTranslationRecording: Realtime finalize was incomplete, forcing async translation fallback")
-                } else if realtimeResult.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Log.app.info("stopTranslationRecording: Realtime translation empty, using async fallback")
-                } else {
-                    Log.app.warning(
-                        "stopTranslationRecording: Realtime finalized text too short (\(realtimeResult.text.count) chars) for \(String(format: "%.2f", recordingDurationSeconds))s recording, using async fallback"
-                    )
-                }
-
-                do {
-                    text = try await service.translateAndTranscribe(audioData: audioData)
-                } catch {
-                    if !realtimeResult.text.isEmpty {
-                        Log.app.warning(
-                            "stopTranslationRecording: Async fallback failed, using partial realtime text (\(realtimeResult.text.count) chars)"
-                        )
-                        text = realtimeResult.text
-                    } else {
-                        throw error
-                    }
-                }
+                throw TranscriptionError.emptyTranscription
             }
             Log.app.info("stopTranslationRecording: Translation received (\(text.count) chars)")
 
@@ -489,9 +459,8 @@ extension AppDelegate {
 
     // MARK: - Realtime Translation (WebSocket)
 
-    private func setupRealtimeTranslationIfNeeded() async {
-        guard SettingsStorage.shared.transcriptionProvider == .cloud,
-              SettingsStorage.shared.translationRealtimeSocketEnabled else {
+    private func setupRealtimeTranslationIfNeeded() {
+        guard SettingsStorage.shared.transcriptionProvider == .cloud else {
             audioRecorder.onRealtimeAudioData = nil
             translationRealtimeSessionEnabled = false
             translationRealtimeAccumulator = nil
@@ -529,25 +498,35 @@ extension AppDelegate {
             Log.transcription.error("Translation RT error: \(error.localizedDescription)")
         }
 
-        do {
-            try await rtService.connect(
-                languageHints: [pair.languageA, pair.languageB],
-                strictLanguageHints: true,
-                audioConfig: .defaultPCM16kMono,
-                translationConfig: RealtimeTranslationConfig(
-                    mode: .twoWay(languageA: pair.languageA, languageB: pair.languageB)
-                ),
-            )
+        translationRealtimeConnectionError = nil
 
-            translationRealtimeSessionEnabled = true
-            Log.transcription.info("Translation RT connected (\(pair.languageA) <-> \(pair.languageB))")
-        } catch {
-            audioRecorder.onRealtimeAudioData = nil
-            translationRealtimeSessionEnabled = false
-            translationRealtimeAccumulator = nil
-            Log.transcription.warning(
-                "Translation RT unavailable (\(error.localizedDescription)); fallback to async translation will be used"
-            )
+        // Connect WebSocket in background — don't block recording start
+        Task {
+            do {
+                try await rtService.connect(
+                    languageHints: [pair.languageA, pair.languageB],
+                    strictLanguageHints: true,
+                    audioConfig: .defaultPCM16kMono,
+                    translationConfig: RealtimeTranslationConfig(
+                        mode: .twoWay(languageA: pair.languageA, languageB: pair.languageB)
+                    ),
+                )
+
+                await MainActor.run {
+                    self.translationRealtimeSessionEnabled = true
+                }
+                Log.transcription.info("Translation RT connected (\(pair.languageA) <-> \(pair.languageB))")
+            } catch {
+                await MainActor.run {
+                    self.audioRecorder.onRealtimeAudioData = nil
+                    self.translationRealtimeSessionEnabled = false
+                    self.translationRealtimeAccumulator = nil
+                    self.translationRealtimeConnectionError = error.localizedDescription
+                }
+                Log.transcription.warning(
+                    "Translation RT connection failed: \(error.localizedDescription)"
+                )
+            }
         }
     }
 
@@ -580,12 +559,11 @@ extension AppDelegate {
         return (text.trimmingCharacters(in: .whitespacesAndNewlines), didReceiveFinalization)
     }
 
-    private func translationLanguagePair(targetLanguage: String = "uk") -> (languageA: String, languageB: String) {
-        if targetLanguage == "en" {
-            let primary = SettingsStorage.shared.favoriteLanguages.first(where: { $0 != "en" }) ?? "uk"
-            return (primary, "en")
-        }
-        return ("en", targetLanguage)
+    private func translationLanguagePair() -> (languageA: String, languageB: String) {
+        return (
+            SettingsStorage.shared.translationLanguageA,
+            SettingsStorage.shared.translationLanguageB
+        )
     }
 
     // MARK: - Escape Cancel Handler
@@ -609,7 +587,7 @@ extension AppDelegate {
                 try? await Task.sleep(for: .seconds(1.6))
                 guard let self,
                       self.appState.translationRecordingState == .recording else { return }
-                NotchManager.shared.startRecording(mode: .translation(languagePair: "EN <-> UK"))
+                NotchManager.shared.startRecording(mode: .translation(languagePair: self.translationPairLabel))
             }
         }
 
@@ -626,46 +604,4 @@ extension AppDelegate {
         escapeService.activate()
     }
 
-    private func shouldUseRealtimeFallbackText(
-        _ text: String,
-        didReceiveFinalization: Bool,
-        recordingDurationSeconds: TimeInterval
-    ) -> Bool {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-
-        let wordCount = trimmed.split { $0.isWhitespace || $0.isNewline }.count
-        let charCount = trimmed.count
-        let hasSentenceEnding = trimmed.hasSuffix(".")
-            || trimmed.hasSuffix("!")
-            || trimmed.hasSuffix("?")
-            || trimmed.contains("\n")
-
-        if didReceiveFinalization {
-            // Same guard as voice mode: avoid accepting tiny finalized websocket fragments.
-            if recordingDurationSeconds <= 1.2 {
-                return true
-            }
-            if wordCount >= 2 {
-                return true
-            }
-            if charCount >= 12 {
-                return true
-            }
-            return false
-        }
-
-        // Slightly softer thresholds for translation output.
-        if hasSentenceEnding, wordCount >= 3 {
-            return true
-        }
-        if wordCount >= 6 {
-            return true
-        }
-        if charCount >= 36 {
-            return true
-        }
-
-        return false
-    }
 }

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -69,6 +69,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var translationRealtimeAccumulator: RealtimeTranslationAccumulator?
     var translationRealtimeSessionEnabled: Bool = false
     var translationRealtimeConnectionError: String?
+    var translationRealtimeConnectionTask: Task<Void, Never>?
 
     var activeTranscriptionService: TranscriptionServiceProtocol {
         switch SettingsStorage.shared.transcriptionProvider {

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -64,9 +64,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @available(macOS 13.0, *)
     var voiceRealtimeAccumulator: RealtimeVoiceAccumulator?
     var voiceRealtimeSessionEnabled: Bool = false
+    var voiceRealtimeConnectionError: String?
     @available(macOS 13.0, *)
     var translationRealtimeAccumulator: RealtimeTranslationAccumulator?
     var translationRealtimeSessionEnabled: Bool = false
+    var translationRealtimeConnectionError: String?
 
     var activeTranscriptionService: TranscriptionServiceProtocol {
         switch SettingsStorage.shared.transcriptionProvider {
@@ -164,12 +166,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        // Warn if cloud provider requires auth but user is not logged in
-        if SettingsStorage.shared.transcriptionProvider == .cloud,
-           !AuthService.shared.isLoggedIn
-        {
-            Log.app.warning("[Auth] Cloud provider selected but user is not logged in — open Settings to authenticate")
-            NotchManager.shared.showInfo(message: "Please log in via Settings to use cloud transcription", duration: 4.0)
+        // Enforce local provider if not logged in (cloud requires auth)
+        if !AuthService.shared.isLoggedIn {
+            if SettingsStorage.shared.transcriptionProvider == .cloud {
+                SettingsStorage.shared.transcriptionProvider = .local
+                Log.app.warning("[Auth] Not logged in — switched to local provider")
+            }
+            if SettingsStorage.shared.meetingRealtimeTranscriptionEnabled {
+                SettingsStorage.shared.meetingRealtimeTranscriptionEnabled = false
+                Log.app.warning("[Auth] Not logged in — disabled meeting cloud mode")
+            }
         }
     }
 
@@ -228,7 +234,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     }
                 case .translation, .meetingTranslation:
                     let service = activeTranscriptionService
-                    text = try await service.translateAndTranscribe(audioData: audioData, targetLanguage: "uk")
+                    text = try await service.translateAndTranscribe(audioData: audioData)
                 }
 
                 let copyBehavior: ClipboardCopyBehavior
@@ -325,7 +331,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
 
-            let translationMode: RecordingMode = .translation(languagePair: "EN <-> UK")
+            let translationMode: RecordingMode = .translation(languagePair: self.translationPairLabel)
             if self.appState.translationRecordingState == .recording {
                 NotchManager.shared.startRecording(mode: translationMode)
                 return
@@ -472,11 +478,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
+    var translationPairLabel: String {
+        let a = SettingsStorage.shared.translationLanguageA.uppercased()
+        let b = SettingsStorage.shared.translationLanguageB.uppercased()
+        return "\(a) <-> \(b)"
+    }
+
     func handleTranslationStateChange(_ state: RecordingState) {
         translationAutoResetTask?.cancel()
         handleStateChange(
             state,
-            mode: .translation(languagePair: "EN <-> UK"),
+            mode: .translation(languagePair: translationPairLabel),
             currentStateGetter: { self.appState.translationRecordingState },
             stateResetter: { self.appState.translationRecordingState = $0 },
             autoResetTaskSetter: { self.translationAutoResetTask = $0 },

--- a/Diduny/Core/Models/Errors.swift
+++ b/Diduny/Core/Models/Errors.swift
@@ -5,6 +5,7 @@ enum TranscriptionError: LocalizedError {
     case apiError(String)
     case invalidResponse
     case emptyTranscription
+    case cloudConnectionFailed(String)
     case invalidURL
     case usageLimitExceeded(usedHours: Double, limitHours: Double)
 
@@ -18,6 +19,8 @@ enum TranscriptionError: LocalizedError {
             "Invalid response from server"
         case .emptyTranscription:
             "No speech detected"
+        case let .cloudConnectionFailed(reason):
+            "Cloud connection failed: \(reason)"
         case .invalidURL:
             "Invalid API URL"
         case let .usageLimitExceeded(usedHours, limitHours):

--- a/Diduny/Core/Models/SupportedLanguage.swift
+++ b/Diduny/Core/Models/SupportedLanguage.swift
@@ -6,7 +6,7 @@ struct SupportedLanguage: Identifiable, Hashable {
 
     var id: String { code }
 
-    /// All languages supported by Soniox cloud transcription & translation (60 languages).
+    /// All languages supported by cloud transcription & translation (60 languages).
     static let cloudLanguages: [SupportedLanguage] = [
         SupportedLanguage(code: "af", name: "Afrikaans"),
         SupportedLanguage(code: "sq", name: "Albanian"),

--- a/Diduny/Core/Services/AuthService.swift
+++ b/Diduny/Core/Services/AuthService.swift
@@ -96,6 +96,7 @@ final class AuthService {
 
         // Switch to cloud processing now that the user is authenticated
         SettingsStorage.shared.transcriptionProvider = .cloud
+        SettingsStorage.shared.meetingRealtimeTranscriptionEnabled = true
 
         Log.app.info("[Auth] Logged in as \(email), switched to cloud processing")
     }
@@ -152,7 +153,12 @@ final class AuthService {
         }
 
         clearTokens()
-        Log.app.info("[Auth] Logged out")
+
+        // Switch to local providers since cloud requires auth
+        SettingsStorage.shared.transcriptionProvider = .local
+        SettingsStorage.shared.meetingRealtimeTranscriptionEnabled = false
+
+        Log.app.info("[Auth] Logged out, switched to local provider")
     }
 
     // MARK: - Token Access

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -106,11 +106,29 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             wsURLString += "\(separator)token=\(accessToken)"
         }
 
-        guard let url = URL(string: wsURLString) else {
-            throw RealtimeTranscriptionError.connectionFailed("Invalid WebSocket URL")
+        guard let url = URL(string: wsURLString),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "ws" || scheme == "wss" else {
+            throw RealtimeTranscriptionError.connectionFailed("Invalid WebSocket URL: \(wsURLString)")
         }
 
-        let task = session.webSocketTask(with: url)
+        // URLSession.webSocketTask(with:) can throw an ObjC NSException that Swift
+        // cannot catch with do/catch. Wrap in ObjC exception catcher to prevent crash.
+        var task: URLSessionWebSocketTask?
+        do {
+            try ObjCExceptionCatcher.catchException {
+                task = session.webSocketTask(with: url)
+            }
+        } catch {
+            throw RealtimeTranscriptionError.connectionFailed(
+                "WebSocket task creation failed: \(error.localizedDescription)"
+            )
+        }
+
+        guard let task else {
+            throw RealtimeTranscriptionError.connectionFailed("Failed to create WebSocket task")
+        }
+
         self.webSocketTask = task
         task.resume()
 

--- a/Diduny/Core/Services/CloudTranscriptionService.swift
+++ b/Diduny/Core/Services/CloudTranscriptionService.swift
@@ -61,28 +61,26 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         return text
     }
 
-    /// Transcribe and translate between English and Ukrainian (auto-detects language)
+    /// Transcribe and translate using the configured language pair from settings
     func translateAndTranscribe(audioData: Data) async throws -> String {
-        try await translateAndTranscribe(audioData: audioData, targetLanguage: "uk")
+        let langA = SettingsStorage.shared.translationLanguageA
+        let langB = SettingsStorage.shared.translationLanguageB
+        return try await translateAndTranscribe(audioData: audioData, languageA: langA, languageB: langB)
     }
 
-    /// Transcribe and translate to a specific target language
+    /// Transcribe and translate to a specific target language (legacy, pairs with stored Language A)
     func translateAndTranscribe(audioData: Data, targetLanguage: String) async throws -> String {
-        Log.transcription.info("translateAndTranscribe: BEGIN, audioData size = \(audioData.count) bytes, targetLanguage = \(targetLanguage)")
+        let langA = SettingsStorage.shared.translationLanguageA
+        return try await translateAndTranscribe(audioData: audioData, languageA: langA, languageB: targetLanguage)
+    }
+
+    private func translateAndTranscribe(audioData: Data, languageA: String, languageB: String) async throws -> String {
+        Log.transcription.info("translateAndTranscribe: BEGIN, audioData size = \(audioData.count) bytes, pair = \(languageA) <-> \(languageB)")
 
         try await ensureSpeechDetected(audioData, context: "translateAndTranscribe")
 
-        // Resolve language pair for two-way translation
-        let langA: String
-        let langB: String
-        if targetLanguage == "en" {
-            let primary = SettingsStorage.shared.favoriteLanguages.first(where: { $0 != "en" }) ?? "uk"
-            langA = primary
-            langB = "en"
-        } else {
-            langA = "en"
-            langB = targetLanguage
-        }
+        let langA = languageA
+        let langB = languageB
 
         let languageConfig = resolveLanguageConfig(forcedLanguageHints: [langA, langB])
         var config: [String: Any] = [

--- a/Diduny/Core/Storage/SettingsStorage.swift
+++ b/Diduny/Core/Storage/SettingsStorage.swift
@@ -48,6 +48,8 @@ final class SettingsStorage {
         case whisperLanguage
         case whisperPrompt
         case favoriteLanguages
+        case translationLanguageA
+        case translationLanguageB
         case translationRealtimeSocketEnabled
         case transcriptionRealtimeSocketEnabled
         case meetingRealtimeTranscriptionEnabled
@@ -398,6 +400,18 @@ final class SettingsStorage {
     var favoriteLanguages: [String] {
         get { defaults.stringArray(forKey: Key.favoriteLanguages.rawValue) ?? ["en", "uk"] }
         set { defaults.set(newValue, forKey: Key.favoriteLanguages.rawValue) }
+    }
+
+    // MARK: - Translation Language Pair
+
+    var translationLanguageA: String {
+        get { defaults.string(forKey: Key.translationLanguageA.rawValue) ?? "en" }
+        set { defaults.set(newValue, forKey: Key.translationLanguageA.rawValue) }
+    }
+
+    var translationLanguageB: String {
+        get { defaults.string(forKey: Key.translationLanguageB.rawValue) ?? "uk" }
+        set { defaults.set(newValue, forKey: Key.translationLanguageB.rawValue) }
     }
 
     private static func normalizedFillerWords(_ words: [String]) -> [String] {

--- a/Diduny/Core/Utilities/ObjCExceptionCatcher.h
+++ b/Diduny/Core/Utilities/ObjCExceptionCatcher.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCExceptionCatcher : NSObject
++ (BOOL)catchException:(void(NS_NOESCAPE ^)(void))tryBlock error:(__autoreleasing NSError **)error;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Diduny/Core/Utilities/ObjCExceptionCatcher.m
+++ b/Diduny/Core/Utilities/ObjCExceptionCatcher.m
@@ -1,0 +1,20 @@
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)catchException:(void(NS_NOESCAPE ^)(void))tryBlock error:(__autoreleasing NSError **)error {
+    @try {
+        tryBlock();
+        return YES;
+    }
+    @catch (NSException *exception) {
+        if (error) {
+            *error = [NSError errorWithDomain:exception.name code:0 userInfo:@{
+                NSLocalizedDescriptionKey: exception.reason ?: @"Unknown Objective-C exception"
+            }];
+        }
+        return NO;
+    }
+}
+
+@end

--- a/Diduny/Core/Whisper/WhisperBridge.h
+++ b/Diduny/Core/Whisper/WhisperBridge.h
@@ -2,5 +2,6 @@
 #define WhisperBridge_h
 
 #include "whisper.h"
+#import "../Utilities/ObjCExceptionCatcher.h"
 
 #endif /* WhisperBridge_h */

--- a/Diduny/Features/Settings/DictationSettingsView.swift
+++ b/Diduny/Features/Settings/DictationSettingsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct DictationSettingsView: View {
     @State private var transcriptionProvider: TranscriptionProvider = SettingsStorage.shared.transcriptionProvider
-    @State private var transcriptionRealtimeSocketEnabled: Bool = SettingsStorage.shared.transcriptionRealtimeSocketEnabled
     @State private var selectedModel: String = SettingsStorage.shared.selectedWhisperModel
     @State private var modelSort: ModelSort = .speed
     @State private var whisperLanguage: String = SettingsStorage.shared.whisperLanguage
@@ -38,16 +37,6 @@ struct DictationSettingsView: View {
                     SettingsStorage.shared.transcriptionProvider = newValue
                 }
 
-                if transcriptionProvider == .cloud {
-                    Toggle("Realtime dictation via WebSocket", isOn: $transcriptionRealtimeSocketEnabled)
-                        .onChange(of: transcriptionRealtimeSocketEnabled) { _, newValue in
-                            SettingsStorage.shared.transcriptionRealtimeSocketEnabled = newValue
-                        }
-
-                    Text("When enabled, dictation is streamed live via cloud socket. Socket mode can improve paragraph detection from pauses/endpoints. If unavailable, app falls back to async cloud transcription.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
             }
 
             if needsWhisper {
@@ -56,9 +45,6 @@ struct DictationSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .onAppear {
-            transcriptionRealtimeSocketEnabled = SettingsStorage.shared.transcriptionRealtimeSocketEnabled
-        }
     }
 
     // MARK: - Whisper Models

--- a/Diduny/Features/Settings/TranslationSettingsView.swift
+++ b/Diduny/Features/Settings/TranslationSettingsView.swift
@@ -2,17 +2,35 @@ import SwiftUI
 
 struct TranslationSettingsView: View {
     @State private var favoriteLanguageCodes: Set<String> = Set(SettingsStorage.shared.favoriteLanguages)
-    @State private var translationRealtimeSocketEnabled: Bool = SettingsStorage.shared.translationRealtimeSocketEnabled
+    @State private var translationLanguageA: String = SettingsStorage.shared.translationLanguageA
+    @State private var translationLanguageB: String = SettingsStorage.shared.translationLanguageB
+
+    private var translationPairLabel: String {
+        "\(translationLanguageA.uppercased()) <-> \(translationLanguageB.uppercased())"
+    }
 
     var body: some View {
         Form {
-            Section("Realtime Translation") {
-                Toggle("Realtime translation via WebSocket", isOn: $translationRealtimeSocketEnabled)
-                    .onChange(of: translationRealtimeSocketEnabled) { _, newValue in
-                        SettingsStorage.shared.translationRealtimeSocketEnabled = newValue
+            Section("Default Translation Pair") {
+                Picker("Language A", selection: $translationLanguageA) {
+                    ForEach(SupportedLanguage.cloudLanguages.filter { $0.code != translationLanguageB }) { lang in
+                        Text(lang.name).tag(lang.code)
                     }
+                }
+                .onChange(of: translationLanguageA) { _, newValue in
+                    SettingsStorage.shared.translationLanguageA = newValue
+                }
 
-                Text("When enabled, translation is streamed live via cloud socket. Socket mode can improve paragraph detection from pauses/endpoints. If unavailable, app falls back to async cloud translation.")
+                Picker("Language B", selection: $translationLanguageB) {
+                    ForEach(SupportedLanguage.cloudLanguages.filter { $0.code != translationLanguageA }) { lang in
+                        Text(lang.name).tag(lang.code)
+                    }
+                }
+                .onChange(of: translationLanguageB) { _, newValue in
+                    SettingsStorage.shared.translationLanguageB = newValue
+                }
+
+                Text("Translation pair: \(translationPairLabel)")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -35,15 +53,12 @@ struct TranslationSettingsView: View {
                     .toggleStyle(.checkbox)
                 }
 
-                Text("Selected languages are used as quick-translate buttons and as language hints for cloud transcription. Supports 60 languages via Soniox.")
+                Text("Selected languages are used as language hints for cloud transcription. Supports 60 languages.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
         }
         .formStyle(.grouped)
-        .onAppear {
-            translationRealtimeSocketEnabled = SettingsStorage.shared.translationRealtimeSocketEnabled
-        }
     }
 }
 

--- a/project.yml
+++ b/project.yml
@@ -26,7 +26,7 @@ configs:
 
 settings:
   base:
-    MARKETING_VERSION: "1.12.0"
+    MARKETING_VERSION: "1.12.1"
     CURRENT_PROJECT_VERSION: "1"
     DEVELOPMENT_TEAM: "8JL9TM5WLG"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary
- Store and cancel translation RT connection `Task` to prevent WebSocket resource leak (addresses CodeRabbit review from #7)
- Use absolute keychain path for `notarytool` in CI release workflow

## Test plan
- [x] Build verified locally (`xcodebuild` succeeds)
- [ ] CI release workflow passes with corrected keychain path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable default translation language pair settings in preferences

* **Improvements**
  * Enhanced error messages for transcription and translation failures
  * Improved reliability of realtime transcription and translation connections
  * Simplified settings interface by removing WebSocket configuration option

* **Chores**
  * Version updated to 1.12.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->