### PR TITLE
fix: update Sparkle to 2.9.0 and make appcast push non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
           DMG_PATH="build/${DISPLAY_NAME}-${VERSION}.dmg"
 
           # Download Sparkle tools
-          SPARKLE_VERSION="2.6.4"
+          SPARKLE_VERSION="2.9.0"
           curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" -o sparkle.tar.xz
           mkdir -p sparkle_tools
           tar -xf sparkle.tar.xz -C sparkle_tools
@@ -224,6 +224,7 @@ jobs:
           cat docs/appcast.xml
 
       - name: Commit and push appcast.xml
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Update Sparkle `sign_update` tool from 2.6.4 to 2.9.0
- Add `continue-on-error: true` to appcast push step so the GitHub release still gets created even if branch protection blocks the push

After merging, you still need to allow `github-actions[bot]` to bypass branch protection for the appcast push to actually work. But now the release won't fail because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)