### PR TITLE
fix: restore instant real-time meeting transcription (v1.12.4)

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		03EBBAC2178925692C5B0F28 /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */; };
 		0B16463025082AB0F9EF90A5 /* LiveTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C08AEA7B3D9495385E0990 /* LiveTranscriptView.swift */; };
+		0CD34EAB840AD6CB69BF6ECB /* JobModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ADA0228DC80DA0ACD8CE17 /* JobModels.swift */; };
 		0FFD1A4567A90C61047FD763 /* SettingsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E893AF3E6C20B492D3CB7 /* SettingsStorage.swift */; };
 		107FDBF081DEEF30BD2A922D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0D8B455676B571AEC778E72 /* Assets.xcassets */; };
 		1CBA3DB7D76838DB69D9DDDE /* RecordingsLibraryWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDED8DC543F3EEDBCAC5A5D7 /* RecordingsLibraryWindowController.swift */; };
@@ -29,6 +30,7 @@
 		48D234DA0A725C503B5DEA75 /* HistoryPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED41A85ABE10582EF485F5D /* HistoryPaletteView.swift */; };
 		497E932204DB8D119B40EAA5 /* PushToTalkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE81820CACD577C91281C9 /* PushToTalkService.swift */; };
 		4A3450320A622E433A5E4907 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB584F0BDA9252D1D71CE50D /* Logger.swift */; };
+		4B43C41C32D07C52621117A2 /* AsyncTranscriptionJobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */; };
 		4E4C0DD6E977C6306BD0289C /* UpdaterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684A014D6E9B1A40935A7608 /* UpdaterManager.swift */; };
 		4EB7E17EB03BFF9E631E38A9 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430641841403AB68C61B536 /* KeychainManager.swift */; };
 		5007F0585DD384082AB30B8F /* AppDelegate+TranslationRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E272A8E12D4EEF5D724E91 /* AppDelegate+TranslationRecording.swift */; };
@@ -146,12 +148,14 @@
 		622FD84CF56FC17420114B9C /* NotchContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchContentView.swift; sourceTree = "<group>"; };
 		67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToTalkKey.swift; sourceTree = "<group>"; };
 		684A014D6E9B1A40935A7608 /* UpdaterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterManager.swift; sourceTree = "<group>"; };
+		6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTranscriptionJobService.swift; sourceTree = "<group>"; };
 		6BBD93A73F0292748E989CA5 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+FileTranscription.swift"; sourceTree = "<group>"; };
 		7074B6A737CE72D77BD9AE8F /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioCaptureService.swift; sourceTree = "<group>"; };
 		741C4E6B6495E48C5D14392E /* AudioCompressionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCompressionService.swift; sourceTree = "<group>"; };
 		741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingDetailView.swift; sourceTree = "<group>"; };
+		78ADA0228DC80DA0ACD8CE17 /* JobModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobModels.swift; sourceTree = "<group>"; };
 		792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLevelMonitor.swift; sourceTree = "<group>"; };
 		7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Hotkeys.swift"; sourceTree = "<group>"; };
 		865E86F8079EAE7A9BFB178E /* RecordingsLibraryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingsLibraryStorage.swift; sourceTree = "<group>"; };
@@ -277,6 +281,7 @@
 			children = (
 				118CE8BCA0160E31FD916B10 /* AudioDevice.swift */,
 				BECAEC93BAEBC7FB0CE79126 /* Errors.swift */,
+				78ADA0228DC80DA0ACD8CE17 /* JobModels.swift */,
 				BED4AC73DF15E8FB1B784BE2 /* LiveTranscriptStore.swift */,
 				3193B0160E38FA4135969F79 /* MeetingAudioSource.swift */,
 				09A53A5FD4196FA12DF76141 /* MeetingChapter.swift */,
@@ -304,6 +309,7 @@
 		4E9257208A1E961F03A1A487 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */,
 				741C4E6B6495E48C5D14392E /* AudioCompressionService.swift */,
 				8D1A1D461E4C3229A9A8A486 /* AudioDeviceManager.swift */,
 				39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */,
@@ -582,6 +588,7 @@
 				5007F0585DD384082AB30B8F /* AppDelegate+TranslationRecording.swift in Sources */,
 				A09E73F9CCF5D1023A1E3D2F /* AppDelegate.swift in Sources */,
 				9FD5B6627D4A5BE503A607FF /* AppState.swift in Sources */,
+				4B43C41C32D07C52621117A2 /* AsyncTranscriptionJobService.swift in Sources */,
 				A546AE88A1817EF822FFEAE1 /* AudioCompressionService.swift in Sources */,
 				C8F29AF8B551E388C4C6F2A0 /* AudioConverter.swift in Sources */,
 				D52AFEB3B25B529860D14116 /* AudioDevice.swift in Sources */,
@@ -605,6 +612,7 @@
 				48D234DA0A725C503B5DEA75 /* HistoryPaletteView.swift in Sources */,
 				B11EF2458AEAF401E1A03FD2 /* HistoryPaletteWindowController.swift in Sources */,
 				D6203B3BADF3AA7E40186F11 /* HotkeyService.swift in Sources */,
+				0CD34EAB840AD6CB69BF6ECB /* JobModels.swift in Sources */,
 				4EB7E17EB03BFF9E631E38A9 /* KeychainManager.swift in Sources */,
 				DDA86150D6B671266D004BEE /* LiveTranscriptStore.swift in Sources */,
 				0B16463025082AB0F9EF90A5 /* LiveTranscriptView.swift in Sources */,
@@ -736,7 +744,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.12.3;
+				MARKETING_VERSION = 1.12.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -822,7 +830,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.12.3;
+				MARKETING_VERSION = 1.12.4;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -888,7 +896,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.12.3;
+				MARKETING_VERSION = 1.12.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -395,12 +395,44 @@ extension AppDelegate {
                 text = realtimeText
                 Log.app.info("Using real-time transcript (\(realtimeText.count) chars)")
             } else if cloudModeEnabled {
-                Log.app.info("No real-time transcript, falling back to async API...")
+                Log.app.info("No real-time transcript, falling back to async jobs API...")
                 let audioData = try await loadAudioData(from: compressedURL)
                 Log.app.info("Meeting recording size = \(audioData.count) bytes")
 
-                text = try await transcriptionService.transcribeMeeting(audioData: audioData)
-                Log.app.info("Async meeting transcription received (\(text?.count ?? 0) chars)")
+                let asyncJobService = AsyncTranscriptionJobService()
+                let hints = SettingsStorage.shared.favoriteLanguages
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                var config: [String: Any] = [
+                    "mode": "transcribe",
+                    "enable_speaker_diarization": true
+                ]
+                if !hints.isEmpty {
+                    config["language_hints"] = hints
+                }
+
+                text = try await asyncJobService.transcribeMeetingWithRetry(
+                    audioData: audioData,
+                    config: config
+                ) { status in
+                    Task { @MainActor in
+                        switch status {
+                        case .queued:
+                            NotchManager.shared.showInfo(message: "Queued...", duration: 30)
+                        case .uploading:
+                            NotchManager.shared.showInfo(message: "Uploading...", duration: 30)
+                        case .processing:
+                            // Processing can take tens of minutes for large files —
+                            // use persistent processing state instead of auto-dismissing info
+                            NotchManager.shared.startProcessing(mode: .meeting)
+                        case .finalizing:
+                            NotchManager.shared.showInfo(message: "Finishing up...", duration: 30)
+                        default:
+                            break
+                        }
+                    }
+                }
+                Log.app.info("Async jobs transcription received (\(text?.count ?? 0) chars)")
             } else {
                 text = nil
                 Log.app.info("Saving meeting recording without automatic transcription")

--- a/Diduny/Core/Models/JobModels.swift
+++ b/Diduny/Core/Models/JobModels.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// MARK: - Async Jobs API Models
+
+struct JobSubmission: Decodable {
+    let jobId: String
+    let status: String
+    let createdAt: String
+}
+
+struct JobStatusResponse: Decodable {
+    let jobId: String
+    let status: String
+    let progress: Int?
+    let createdAt: String
+    let updatedAt: String
+    let result: JobTranscriptionResult?
+    let error: String?
+}
+
+struct JobTranscriptionResult: Decodable {
+    let text: String
+}
+
+struct JobResult {
+    let text: String
+}
+
+enum JobStatus: String {
+    case queued, uploading, processing, finalizing, completed, error
+}

--- a/Diduny/Core/Services/AsyncTranscriptionJobService.swift
+++ b/Diduny/Core/Services/AsyncTranscriptionJobService.swift
@@ -1,0 +1,216 @@
+import Foundation
+import os
+
+final class AsyncTranscriptionJobService {
+    private var proxyBase: String {
+        SettingsStorage.shared.proxyBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+
+    private let maxRetries = 3
+
+    // MARK: - Submit Job
+
+    func submitJob(audioData: Data, config: [String: Any]) async throws -> JobSubmission {
+        guard let url = URL(string: "\(proxyBase)/api/v1/jobs") else {
+            throw TranscriptionError.invalidURL
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        await AuthService.shared.authenticatedRequest(&request)
+
+        let configData = try JSONSerialization.data(withJSONObject: config)
+        let configString = String(data: configData, encoding: .utf8) ?? "{}"
+
+        var body = Data()
+        body.append(Data("--\(boundary)\r\n".utf8))
+        body.append(Data("Content-Disposition: form-data; name=\"audio\"; filename=\"meeting.flac\"\r\n".utf8))
+        body.append(Data("Content-Type: audio/flac\r\n\r\n".utf8))
+        body.append(audioData)
+        body.append(Data("\r\n".utf8))
+        body.append(Data("--\(boundary)\r\n".utf8))
+        body.append(Data("Content-Disposition: form-data; name=\"config\"\r\n".utf8))
+        body.append(Data("Content-Type: text/plain\r\n\r\n".utf8))
+        body.append(Data(configString.utf8))
+        body.append(Data("\r\n--\(boundary)--\r\n".utf8))
+
+        request.httpBody = body
+
+        Log.transcription.info("submitJob: uploading \(audioData.count) bytes")
+
+        var (data, response) = try await URLSession.shared.data(for: request)
+        guard var httpResponse = response as? HTTPURLResponse else {
+            throw TranscriptionError.invalidResponse
+        }
+
+        // 401 retry
+        if httpResponse.statusCode == 401 {
+            Log.transcription.info("submitJob: 401 — refreshing token and retrying")
+            try await AuthService.shared.refreshTokens()
+            await AuthService.shared.authenticatedRequest(&request)
+            (data, response) = try await URLSession.shared.data(for: request)
+            guard let retryResponse = response as? HTTPURLResponse else {
+                throw TranscriptionError.invalidResponse
+            }
+            httpResponse = retryResponse
+        }
+
+        // 402: usage limit
+        if httpResponse.statusCode == 402 {
+            Log.transcription.warning("submitJob: 402 — usage limit exceeded")
+            Task { await UsageService.shared.refresh() }
+            if let body = try? JSONDecoder().decode(UsageLimitErrorResponse.self, from: data) {
+                throw TranscriptionError.usageLimitExceeded(
+                    usedHours: body.usedHours, limitHours: body.limitHours
+                )
+            }
+            throw TranscriptionError.usageLimitExceeded(usedHours: 0, limitHours: 0)
+        }
+
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            Log.transcription.error("submitJob: failed (\(httpResponse.statusCode)): \(errorBody)")
+            throw TranscriptionError.apiError("Job submission failed (\(httpResponse.statusCode)): \(errorBody)")
+        }
+
+        let submission = try JSONDecoder().decode(JobSubmission.self, from: data)
+        Log.transcription.info("submitJob: jobId=\(submission.jobId), status=\(submission.status)")
+        return submission
+    }
+
+    // MARK: - Stream Job Result (SSE)
+
+    func streamJobResult(jobId: String, onUpdate: @escaping (JobStatus) -> Void) async throws -> JobResult {
+        guard let url = URL(string: "\(proxyBase)/api/v1/jobs/\(jobId)/events") else {
+            throw TranscriptionError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        await AuthService.shared.authenticatedRequest(&request)
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw TranscriptionError.apiError("SSE connection failed")
+        }
+
+        var currentEvent = ""
+        var currentData = ""
+
+        for try await line in bytes.lines {
+            if line.hasPrefix("event: ") {
+                currentEvent = String(line.dropFirst(7))
+            } else if line.hasPrefix("data: ") {
+                currentData = String(line.dropFirst(6))
+            } else if line.isEmpty && !currentEvent.isEmpty {
+                switch currentEvent {
+                case "status":
+                    if let status = JobStatus(rawValue: currentData.trimmingCharacters(in: .whitespaces)) {
+                        Log.transcription.info("SSE status: \(status.rawValue)")
+                        onUpdate(status)
+                    } else if let parsed = parseStatusFromJSON(currentData) {
+                        Log.transcription.info("SSE status: \(parsed.rawValue)")
+                        onUpdate(parsed)
+                    }
+                case "completed":
+                    return try parseCompletedResult(currentData)
+                case "error":
+                    let message = parseErrorMessage(currentData)
+                    throw TranscriptionError.apiError(message)
+                default:
+                    break
+                }
+                currentEvent = ""
+                currentData = ""
+            }
+            // Lines starting with ":" are SSE comments (keep-alive), ignore them
+        }
+
+        throw TranscriptionError.apiError("SSE stream ended without result")
+    }
+
+    // MARK: - Poll Job Status (fallback)
+
+    func getJobStatus(jobId: String) async throws -> JobStatusResponse {
+        guard let url = URL(string: "\(proxyBase)/api/v1/jobs/\(jobId)") else {
+            throw TranscriptionError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        await AuthService.shared.authenticatedRequest(&request)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, (200 ... 299).contains(httpResponse.statusCode) else {
+            throw TranscriptionError.apiError("Failed to get job status")
+        }
+
+        return try JSONDecoder().decode(JobStatusResponse.self, from: data)
+    }
+
+    // MARK: - Retry-aware transcription
+
+    func transcribeMeetingWithRetry(
+        audioData: Data,
+        config: [String: Any],
+        onUpdate: @escaping (JobStatus) -> Void
+    ) async throws -> String {
+        let submission = try await submitJob(audioData: audioData, config: config)
+
+        var retries = 0
+
+        while retries < self.maxRetries {
+            do {
+                let result = try await streamJobResult(jobId: submission.jobId, onUpdate: onUpdate)
+                return result.text
+            } catch {
+                retries += 1
+                Log.transcription.warning("SSE stream failed (attempt \(retries)/\(self.maxRetries)): \(error)")
+
+                // Check if job finished while disconnected
+                let status = try await getJobStatus(jobId: submission.jobId)
+                if status.status == "completed", let result = status.result {
+                    return result.text
+                }
+                if status.status == "error" {
+                    throw TranscriptionError.apiError(status.error ?? "Transcription failed")
+                }
+
+                // Still in progress — backoff and retry SSE
+                try await Task.sleep(nanoseconds: UInt64(retries) * 2_000_000_000)
+            }
+        }
+
+        throw TranscriptionError.apiError("Failed to get transcription result after \(self.self.maxRetries) retries")
+    }
+
+    // MARK: - SSE Parsing Helpers
+
+    private func parseStatusFromJSON(_ data: String) -> JobStatus? {
+        guard let jsonData = data.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let statusString = dict["status"] as? String
+        else { return nil }
+        return JobStatus(rawValue: statusString)
+    }
+
+    private func parseCompletedResult(_ data: String) throws -> JobResult {
+        guard let jsonData = data.data(using: .utf8) else {
+            throw TranscriptionError.invalidResponse
+        }
+        let result = try JSONDecoder().decode(JobTranscriptionResult.self, from: jsonData)
+        return JobResult(text: result.text)
+    }
+
+    private func parseErrorMessage(_ data: String) -> String {
+        if let jsonData = data.data(using: .utf8),
+           let dict = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+           let message = dict["error"] as? String
+        {
+            return message
+        }
+        return data.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Diduny/Core/Services/CloudTranscriptionService.swift
+++ b/Diduny/Core/Services/CloudTranscriptionService.swift
@@ -115,6 +115,9 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
             throw TranscriptionError.invalidURL
         }
 
+        // Optimize audio before upload: downsample to 16kHz mono + FLAC compress
+        let optimizedData = await optimizeAudioForUpload(audioData)
+
         let boundary = UUID().uuidString
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -125,8 +128,8 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         let configData = try JSONSerialization.data(withJSONObject: config)
         let configString = String(data: configData, encoding: .utf8) ?? "{}"
 
-        let (filename, contentType) = detectAudioFormat(audioData)
-        Log.transcription.info("proxyTranscribe: audio format=\(contentType), config=\(configString)")
+        let (filename, contentType) = detectAudioFormat(optimizedData)
+        Log.transcription.info("proxyTranscribe: audio format=\(contentType), original=\(audioData.count) bytes, optimized=\(optimizedData.count) bytes, config=\(configString)")
 
         // Build multipart body: audio + config
         var body = Data()
@@ -134,7 +137,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         body.append(Data("--\(boundary)\r\n".utf8))
         body.append(Data("Content-Disposition: form-data; name=\"audio\"; filename=\"\(filename)\"\r\n".utf8))
         body.append(Data("Content-Type: \(contentType)\r\n\r\n".utf8))
-        body.append(audioData)
+        body.append(optimizedData)
         body.append(Data("\r\n".utf8))
         // Config part
         body.append(Data("--\(boundary)\r\n".utf8))
@@ -176,6 +179,83 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         }
 
         return try JSONDecoder().decode(ProxyTranscribeResponse.self, from: data)
+    }
+
+    // MARK: - Audio Optimization for Upload
+
+    /// Downsample WAV to 16kHz mono 16-bit, then FLAC compress.
+    /// Soniox processes 16kHz mono — sending higher quality wastes upload time and processing time.
+    /// 48kHz stereo 32-bit (38MB/min) → 16kHz mono 16-bit WAV (1.9MB/min) → FLAC (~1MB/min)
+    private func optimizeAudioForUpload(_ audioData: Data) async -> Data {
+        let startTime = ContinuousClock.now
+
+        // Step 1: Downsample to 16kHz mono 16-bit WAV using afconvert
+        let downsampledData = await downsampleToSoniox(audioData)
+
+        // Step 2: FLAC compress the downsampled WAV
+        let compressedData = await AudioCompressionService.compressToFLAC(audioData: downsampledData)
+
+        let elapsed = ContinuousClock.now - startTime
+        let ratio = audioData.count > 0 ? Double(compressedData.count) / Double(audioData.count) * 100 : 100
+        Log.transcription.info(
+            "Audio optimized: \(audioData.count) → \(compressedData.count) bytes (\(String(format: "%.1f%%", ratio))) in \(elapsed)"
+        )
+
+        return compressedData
+    }
+
+    /// Downsample audio to 16kHz mono 16-bit PCM WAV using macOS afconvert.
+    private func downsampleToSoniox(_ audioData: Data) async -> Data {
+        let tempDir = FileManager.default.temporaryDirectory
+        let inputURL = tempDir.appendingPathComponent(UUID().uuidString + ".wav")
+        let outputURL = tempDir.appendingPathComponent(UUID().uuidString + "_16k.wav")
+
+        defer {
+            try? FileManager.default.removeItem(at: inputURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        do {
+            try audioData.write(to: inputURL)
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/afconvert")
+            process.arguments = [
+                "-f", "WAVE",           // output format: WAV
+                "-d", "LEI16",          // data format: little-endian 16-bit integer
+                "-c", "1",              // mono
+                "-r", "16000",          // 16kHz sample rate
+                inputURL.path,
+                outputURL.path
+            ]
+
+            let errorPipe = Pipe()
+            process.standardError = errorPipe
+
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                process.terminationHandler = { proc in
+                    if proc.terminationStatus == 0 {
+                        continuation.resume()
+                    } else {
+                        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                        let msg = String(data: errorData, encoding: .utf8) ?? "exit \(proc.terminationStatus)"
+                        continuation.resume(throwing: NSError(domain: "afconvert", code: Int(proc.terminationStatus), userInfo: [NSLocalizedDescriptionKey: msg]))
+                    }
+                }
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            let downsampledData = try Data(contentsOf: outputURL)
+            Log.transcription.info("Downsampled: \(audioData.count) → \(downsampledData.count) bytes (16kHz mono s16le)")
+            return downsampledData
+        } catch {
+            Log.transcription.warning("Downsample failed, using original: \(error.localizedDescription)")
+            return audioData
+        }
     }
 
     // MARK: - Speech Pre-check

--- a/Diduny/Core/Services/RecordingQueueService.swift
+++ b/Diduny/Core/Services/RecordingQueueService.swift
@@ -7,6 +7,7 @@ final class RecordingQueueService {
 
     enum QueueAction {
         case transcribe
+        case transcribeDiarize
         case translate
     }
 
@@ -104,7 +105,7 @@ final class RecordingQueueService {
                 override
             } else {
                 switch action {
-                case .transcribe:
+                case .transcribe, .transcribeDiarize:
                     SettingsStorage.shared.effectiveTranscriptionProvider
                 case .translate:
                     SettingsStorage.shared.effectiveTranslationProvider
@@ -120,10 +121,10 @@ final class RecordingQueueService {
             let status: Recording.ProcessingStatus
             switch action {
             case .transcribe:
-                if provider == .cloud,
-                   recording.type == .meeting,
-                   let cloudService = service as? CloudTranscriptionService
-                {
+                text = try await service.transcribe(audioData: audioData)
+                status = .transcribed
+            case .transcribeDiarize:
+                if let cloudService = service as? CloudTranscriptionService {
                     text = try await cloudService.transcribeMeeting(audioData: audioData)
                 } else {
                     text = try await service.transcribe(audioData: audioData)

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -417,7 +417,8 @@ final class SystemAudioCaptureService: NSObject {
         guard audioFile != nil else { return }
 
         if captureMicrophone {
-            // Mix overlapping frames synchronously
+            // Mix overlapping frames synchronously and write to file only.
+            // Real-time emit already happened in handleSystemAudio().
             let mixCount = min(systemBuffer.count, micBuffer.count)
             if mixCount > 0 {
                 var mixed = [Float](repeating: 0, count: mixCount)
@@ -426,22 +427,17 @@ final class SystemAudioCaptureService: NSObject {
                 }
                 systemBuffer.removeFirst(mixCount)
                 micBuffer.removeFirst(mixCount)
-                emitRealtimeData(mixed)
                 writeSamples(mixed)
             }
-            // Flush remaining single-source samples
             if !systemBuffer.isEmpty {
-                emitRealtimeData(systemBuffer)
                 writeSamples(systemBuffer)
                 systemBuffer.removeAll()
             }
             if !micBuffer.isEmpty {
-                emitRealtimeData(micBuffer)
                 writeSamples(micBuffer)
                 micBuffer.removeAll()
             }
         } else if !systemBuffer.isEmpty {
-            emitRealtimeData(systemBuffer)
             writeSamples(systemBuffer)
             systemBuffer.removeAll()
         }
@@ -504,17 +500,20 @@ extension SystemAudioCaptureService: SCStreamOutput {
             checkSilence(source: .system)
         }
 
-        let appliedSystemGain: Float = captureMicrophone ? systemGain : 1.0
-        let gained = samples.map { max(-1, min(1, $0 * appliedSystemGain)) }
+        // Emit system audio for real-time transcription IMMEDIATELY, before mixing.
+        // This restores v1.12.0 behavior where real-time streaming was never blocked
+        // by mixer synchronization. The mixed audio is only needed for the WAV file.
+        emitRealtimeData(samples)
 
         if captureMicrophone {
+            let appliedSystemGain = systemGain
+            let gained = samples.map { max(-1, min(1, $0 * appliedSystemGain)) }
             systemBuffer.append(contentsOf: gained)
             drainMixedSamples()
             flushStaleBuffer()
         } else {
-            emitRealtimeData(gained)
             fileWriteQueue.async { [weak self] in
-                self?.writeSamples(gained)
+                self?.writeSamples(samples)
             }
         }
     }
@@ -556,7 +555,8 @@ extension SystemAudioCaptureService: SCStreamOutput {
         systemBuffer.removeFirst(mixCount)
         micBuffer.removeFirst(mixCount)
 
-        emitRealtimeData(mixed)
+        // Real-time emit happens in handleSystemAudio() before mixing.
+        // Mixer output is only written to the WAV file.
         fileWriteQueue.async { [weak self] in
             self?.writeSamples(mixed)
         }
@@ -574,7 +574,8 @@ extension SystemAudioCaptureService: SCStreamOutput {
         guard buffer.count > flushThresholdFrames else { return }
         let stale = Array(buffer)
         buffer.removeAll()
-        emitRealtimeData(stale)
+        // Real-time emit happens in handleSystemAudio() before mixing.
+        // Stale buffer flush only writes to the WAV file.
         fileWriteQueue.async { [weak self] in
             self?.writeSamples(stale)
         }

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -164,7 +164,7 @@ struct RecordingDetailView: View {
                 Button("Transcribe + Diarize") {
                     queueService.enqueue(
                         [recording.id],
-                        action: .transcribe,
+                        action: .transcribeDiarize,
                         providerOverride: .cloud
                     )
                 }

--- a/project.yml
+++ b/project.yml
@@ -26,7 +26,7 @@ configs:
 
 settings:
   base:
-    MARKETING_VERSION: "1.12.3"
+    MARKETING_VERSION: "1.12.4"
     CURRENT_PROJECT_VERSION: "1"
     DEVELOPMENT_TEAM: "8JL9TM5WLG"
     CODE_SIGN_STYLE: Automatic


### PR DESCRIPTION
## Summary

- **Fix critical real-time latency regression** introduced in v1.12.1 (ae96b48): system audio is now emitted for WebSocket transcription immediately, before mixer synchronization — restoring v1.12.0 instant behavior
- **Add async jobs API client** (`AsyncTranscriptionJobService`) for large meeting fallback transcription via `diduny-jobs` service with SSE streaming
- **Audio upload optimization**: downsample to 16kHz mono + FLAC compress before sync transcription uploads
- **Explicit Transcribe+Diarize action** in Recordings Library (previously all meeting recordings silently used diarization)
- **Bump version to 1.12.4**

## Root Cause

v1.12.1 replaced the separate `AudioMixerService` with inline mixing in `SystemAudioCaptureService`. This accidentally tied real-time WebSocket emission to the mixer output — system audio waited in `systemBuffer` for mic data (`drainMixedSamples`) or 800-frame threshold (`flushStaleBuffer`, 50ms at 16kHz). With Bluetooth devices delivering mic data at irregular intervals, this created 50-100ms+ variable latency.

## Fix

Emit system audio via `emitRealtimeData()` in `handleSystemAudio()` **before** entering the mixer path. Mixer output (system+mic mixed) is only written to the WAV file. This matches v1.12.0's architecture where real-time streaming and file mixing were independent paths.

## Test plan

- [ ] Start meeting recording with System+Microphone mode and AirPods — verify real-time transcript appears with no visible delay
- [ ] Start meeting recording with System Only mode — verify real-time transcript works as before
- [ ] Stop meeting with real-time transcript — verify text is copied and WAV file contains mixed audio
- [ ] Stop meeting without real-time transcript — verify async jobs fallback triggers (if jobs service deployed)
- [ ] Open Recordings Library → click "Transcribe + Diarize" on a meeting recording → verify diarized transcript
- [ ] Open Recordings Library → click "Transcribe" on a voice recording → verify plain transcript (no diarization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous job-based transcription with real-time status notifications (queued, uploading, processing, finalizing)

* **Improvements**
  * Enhanced audio preprocessing and optimization for transcription quality
  * Refined meeting transcription workflow with speaker diarization support

* **Chores**
  * Version bump to 1.12.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->