### PR TITLE
Add label-driven automatic release pipeline

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,70 @@
+name: Prepare release
+
+# Runs when a PR is merged into main. Reads the PR's release label, computes
+# the next version from the latest tag, pushes an annotated tag, and kicks
+# off release.yml via workflow_dispatch.
+#
+# This is the ONLY automation step that writes a git ref — and it only ever
+# writes a tag, never a commit to main. release.yml is dispatched explicitly
+# (not via the tag push) because tags pushed with GITHUB_TOKEN do not trigger
+# other workflows; this keeps everything on GITHUB_TOKEN with no PAT needed.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump from PR label
+        id: bump
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if   echo "$LABELS" | grep -q '"release:major"'; then bump=major
+          elif echo "$LABELS" | grep -q '"release:minor"'; then bump=minor
+          elif echo "$LABELS" | grep -q '"release:patch"'; then bump=patch
+          else
+            echo "No release:patch|minor|major label (release:skip or none) — nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and dispatch release
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP: ${{ steps.bump.outputs.bump }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          TAG="$(scripts/next-version.sh "$BUMP")"
+          echo "Next release: $TAG (from release:$BUMP)"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists — aborting."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG" "$MERGE_SHA"
+          git push origin "$TAG"
+
+          gh workflow run release.yml --ref "$TAG"
+          echo "Pushed $TAG and dispatched release.yml"

--- a/.github/workflows/release-label-check.yml
+++ b/.github/workflows/release-label-check.yml
@@ -1,0 +1,51 @@
+name: Release label check
+
+# Every PR into main must declare its release intent via exactly one label:
+#   release:patch | release:minor | release:major | release:skip
+# This check fails if that's not the case, and comments the version that
+# will be released on merge. Make it a required status check in branch
+# protection so a PR can't merge without a deliberate release decision.
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require exactly one release label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          count=0
+          for l in release:major release:minor release:patch release:skip; do
+            if echo "$LABELS" | grep -q "\"$l\""; then count=$((count + 1)); fi
+          done
+          if [ "$count" -ne 1 ]; then
+            echo "::error::PR must have exactly one of: release:patch, release:minor, release:major, release:skip (found $count)"
+            exit 1
+          fi
+
+      - name: Comment next version
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:skip') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if   echo "$LABELS" | grep -q '"release:major"'; then bump=major
+          elif echo "$LABELS" | grep -q '"release:minor"'; then bump=minor
+          else bump=patch; fi
+          TAG="$(scripts/next-version.sh "$bump")"
+          gh pr comment "$PR" --edit-last --create-if-none \
+            --body "🔖 On merge this PR will release **$TAG** (\`release:$bump\`)."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
-  pull-requests: write
+
+concurrency:
+  # Prevent duplicate/overlapping release runs for the same ref.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   APP_NAME: Diduny
@@ -105,6 +110,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           BUILD_NUMBER=$(git rev-list --count HEAD)
+          # The git tag is the single source of truth for the version —
+          # project.yml's MARKETING_VERSION is just a placeholder.
+          MARKETING_VERSION="${GITHUB_REF_NAME#v}"
           xcodebuild archive \
             -project "$PROJECT_FILE" \
             -scheme "$SCHEME" \
@@ -116,7 +124,8 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            MARKETING_VERSION="$MARKETING_VERSION"
 
       - name: Export and verify app
         run: |
@@ -202,22 +211,28 @@ jobs:
               --generate-notes
           fi
 
-      - name: Update appcast.xml
+      - name: Publish appcast to gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           BUILD_NUMBER=$(git rev-list --count HEAD)
           DMG_PATH="build/${DISPLAY_NAME}-${VERSION}.dmg"
           DMG_SIZE=$(stat -f%z "$DMG_PATH")
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/${DISPLAY_NAME}-${VERSION}.dmg"
-
-          # Parse edSignature and length from sign_update output
+          DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${DISPLAY_NAME}-${VERSION}.dmg"
           ED_SIGNATURE=$(echo "$SPARKLE_SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
           ED_LENGTH=$(echo "$SPARKLE_SIGN_OUTPUT" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
 
-          # Insert new item into appcast.xml using Python (sed can't handle multiline)
+          # The Sparkle feed lives on the dedicated, unprotected gh-pages
+          # branch — never on main. A worktree isolates it from the tag checkout.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:gh-pages
+          git worktree add /tmp/ghpages gh-pages
+
           python3 -c "
           import datetime, pathlib, sys
-          appcast = pathlib.Path('docs/appcast.xml')
+          appcast = pathlib.Path('/tmp/ghpages/appcast.xml')
           content = appcast.read_text()
           marker = '<sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>'
           if marker in content:
@@ -240,40 +255,14 @@ jobs:
           appcast.write_text(content)
           "
 
-          echo "Updated appcast.xml with version ${VERSION}"
-          cat docs/appcast.xml
-
-      - name: Commit appcast.xml via PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          VERSION=${GITHUB_REF_NAME#v}
-          BRANCH_NAME="appcast-${GITHUB_REF_NAME}"
-
-          cp docs/appcast.xml /tmp/appcast.xml
-          git fetch origin main
-          git checkout -B "$BRANCH_NAME" origin/main
-          cp /tmp/appcast.xml docs/appcast.xml
-          git add docs/appcast.xml
-
-          if ! git diff --quiet --cached -- docs/appcast.xml; then
-            git commit -m "Update appcast.xml for ${GITHUB_REF_NAME}"
-            git push --force-with-lease origin "$BRANCH_NAME"
-
-            PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --base main --json number --jq '.[0].number')
-            if [ -z "$PR_NUMBER" ]; then
-              gh pr create \
-                --base main \
-                --head "$BRANCH_NAME" \
-                --title "Update appcast.xml for ${GITHUB_REF_NAME}" \
-                --body "Automated Sparkle appcast update for ${GITHUB_REF_NAME}."
-              PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --base main --json number --jq '.[0].number')
-            fi
-
-            gh pr merge "$PR_NUMBER" --squash --delete-branch
+          cd /tmp/ghpages
+          if git diff --quiet -- appcast.xml; then
+            echo "appcast.xml unchanged — nothing to publish"
+          else
+            git add appcast.xml
+            git commit -m "Update appcast for ${GITHUB_REF_NAME}"
+            git push origin gh-pages
+            echo "Published ${GITHUB_REF_NAME} to the Sparkle feed (gh-pages)"
           fi
 
       - name: Cleanup signing artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,30 @@ open Diduny.xcodeproj
 ./release.sh
 ```
 
+## Release process
+
+**NEVER push directly to `main`** — not commits, not tags. Everything goes through a PR.
+**NEVER create or push `v*` tags by hand** — CI does that.
+**NEVER hand-edit** `MARKETING_VERSION` in `project.yml` or the Sparkle `appcast.xml`.
+
+To ship a release:
+
+1. Open a PR into `main`.
+2. Add exactly one label: `release:patch` (bug fix / internal), `release:minor`
+   (new user-facing capability), `release:major` (breaking change), or
+   `release:skip` (no release for this PR).
+3. Merge the PR.
+
+CI does the rest: `prepare-release.yml` computes the next version from the
+latest tag, pushes tag `vX.Y.Z`, and dispatches `release.yml`, which builds,
+notarizes, signs, creates the GitHub Release, and updates the Sparkle
+`appcast.xml` on the **`gh-pages`** branch. The app version comes **from the
+git tag** — `project.yml`'s `MARKETING_VERSION` is only a placeholder.
+
+Workflows: `.github/workflows/release-label-check.yml` (PR gate),
+`prepare-release.yml` (tag on merge), `release.yml` (build + publish).
+Version math: `scripts/next-version.sh`.
+
 ## Required Permissions
 - Microphone (NSMicrophoneUsageDescription)
 - Screen Recording (for meeting audio capture via ScreenCaptureKit)

--- a/release.sh
+++ b/release.sh
@@ -61,6 +61,12 @@ ARCHIVE_PATH="${BUILD_DIR}/${APP_NAME}.xcarchive"
 EXPORT_PATH="${BUILD_DIR}/export"
 APP_PATH="${EXPORT_PATH}/${APP_NAME}.app"
 
+# The git tag is the single source of truth for the version (same as CI).
+# project.yml's MARKETING_VERSION is only a placeholder. Override with
+# RELEASE_VERSION=X.Y.Z for a local build that isn't on a tag.
+MARKETING_VERSION="${RELEASE_VERSION:-$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')}"
+MARKETING_VERSION="${MARKETING_VERSION:-0.0.0}"
+
 echo -e "${BLUE}"
 echo "╔═══════════════════════════════════════════════════════════╗"
 echo "║               ${DISPLAY_NAME} Release Builder                      ║"
@@ -96,7 +102,7 @@ xcodebuild -resolvePackageDependencies \
     -project "${PROJECT_FILE}" \
     -scheme "${SCHEME}"
 
-echo -e "${YELLOW}[3/7] Archiving universal app (arm64 + x86_64)...${NC}"
+echo -e "${YELLOW}[3/7] Archiving universal app (arm64 + x86_64), version ${MARKETING_VERSION}...${NC}"
 xcodebuild archive \
     -project "${PROJECT_FILE}" \
     -scheme "${SCHEME}" \
@@ -107,7 +113,8 @@ xcodebuild archive \
     ONLY_ACTIVE_ARCH=NO \
     CODE_SIGN_STYLE=Manual \
     CODE_SIGN_IDENTITY="Developer ID Application" \
-    DEVELOPMENT_TEAM="${TEAM_ID}"
+    DEVELOPMENT_TEAM="${TEAM_ID}" \
+    MARKETING_VERSION="${MARKETING_VERSION}"
 
 if [ ! -d "${ARCHIVE_PATH}" ]; then
     echo -e "${RED}Error: Archive failed${NC}"

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Compute the next release tag from the latest `v*` git tag.
+#
+# Usage: next-version.sh <patch|minor|major>
+# Prints: vX.Y.Z
+#
+# Pure tag math — the git tag is the single source of truth for the app
+# version. CI (prepare-release.yml) uses this on PR merge; humans can run
+# it locally to preview the next version. It writes nothing.
+set -euo pipefail
+
+bump="${1:?usage: next-version.sh <patch|minor|major>}"
+
+git fetch --tags --quiet 2>/dev/null || true
+
+latest="$(git tag -l 'v*' | sed 's/^v//' | sort -V | tail -1)"
+latest="${latest:-0.0.0}"
+
+IFS=. read -r major minor patch <<<"$latest"
+major="${major:-0}"; minor="${minor:-0}"; patch="${patch:-0}"
+
+case "$bump" in
+  major) major=$((major + 1)); minor=0; patch=0 ;;
+  minor) minor=$((minor + 1)); patch=0 ;;
+  patch) patch=$((patch + 1)) ;;
+  *) echo "unknown bump: $bump (expected patch|minor|major)" >&2; exit 1 ;;
+esac
+
+echo "v${major}.${minor}.${patch}"


### PR DESCRIPTION
## What

Brings Diduny onto the same label-driven release pipeline piloted on BrowserCat.

**New flow:** open PR → add one `release:*` label → merge → CI tags, builds, notarizes, signs, publishes the GitHub Release, and updates the Sparkle appcast on `gh-pages`.

## Why

v1.14.1's release CI failed on the appcast-commit step — the tag was on a feature branch so `git checkout main` aborted on the locally-modified appcast.xml. This removes that failure class:
- appcast publishes to the unprotected `gh-pages` branch → never touches `main`
- `concurrency` guard → no duplicate-run races
- version comes from the git tag → no manual bumping

## Files

- **new** `release-label-check.yml`, `prepare-release.yml`, `scripts/next-version.sh` (identical across all three apps)
- **changed** `release.yml`, `release.sh`, `CLAUDE.md`

## Prereqs already done

- `release:{patch,minor,major,skip}` labels created
- `gh-pages` branch seeded with current `appcast.xml`; Pages source switched to `gh-pages`

Verified end-to-end on BrowserCat (v1.7.3 released cleanly through the new pipeline). No PAT needed.