### PR TITLE
fix(release): strip export artifacts before DMG packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,12 @@ jobs:
             -exportPath "$EXPORT_DIR" \
             -exportOptionsPlist ExportOptions.plist
 
+          # create-dmg packages everything in $EXPORT_DIR — strip the
+          # xcodebuild export artifacts so only the .app ends up in the DMG.
+          rm -f "$EXPORT_DIR/DistributionSummary.plist" \
+                "$EXPORT_DIR/ExportOptions.plist" \
+                "$EXPORT_DIR/Packaging.log"
+
           echo "Architectures:"
           lipo -archs "$EXPORT_DIR/$APP_BUNDLE_NAME/Contents/MacOS/$APP_NAME"
 


### PR DESCRIPTION
v1.14.1 DMG contained `DistributionSummary.plist`, `ExportOptions.plist` and `Packaging.log` next to `Diduny.app`. `create-dmg` packages everything in the export dir; BrowserCat's `release.yml` strips these first, Diduny's didn't.

After merge, this will auto-release v1.14.2 with a clean DMG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to automatically remove temporary and configuration files generated during the app export process, resulting in cleaner release artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rmarinsky/Diduny/pull/34)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->