### PR TITLE
refactor(release): stage app into dedicated dir for create-dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,6 @@ jobs:
             -exportPath "$EXPORT_DIR" \
             -exportOptionsPlist ExportOptions.plist
 
-          # create-dmg packages everything in $EXPORT_DIR — strip the
-          # xcodebuild export artifacts so only the .app ends up in the DMG.
-          rm -f "$EXPORT_DIR/DistributionSummary.plist" \
-                "$EXPORT_DIR/ExportOptions.plist" \
-                "$EXPORT_DIR/Packaging.log"
-
           echo "Architectures:"
           lipo -archs "$EXPORT_DIR/$APP_BUNDLE_NAME/Contents/MacOS/$APP_NAME"
 
@@ -163,6 +157,15 @@ jobs:
           brew install create-dmg
           VERSION=${GITHUB_REF_NAME#v}
 
+          # Stage ONLY the .app — never point create-dmg at $EXPORT_DIR
+          # itself, because xcodebuild also drops DistributionSummary.plist,
+          # ExportOptions.plist and Packaging.log there and create-dmg
+          # would package the lot.
+          STAGE_DIR="build/dmg-stage"
+          rm -rf "$STAGE_DIR"
+          mkdir -p "$STAGE_DIR"
+          cp -R "$EXPORT_DIR/$APP_BUNDLE_NAME" "$STAGE_DIR/"
+
           create-dmg \
             --volname "$DISPLAY_NAME" \
             --window-pos 200 120 \
@@ -171,7 +174,7 @@ jobs:
             --icon "$APP_BUNDLE_NAME" 175 190 \
             --app-drop-link 425 190 \
             "build/${DISPLAY_NAME}-${VERSION}.dmg" \
-            "$EXPORT_DIR/"
+            "$STAGE_DIR/"
 
           shasum -a 256 "build/${DISPLAY_NAME}-${VERSION}.dmg" | awk '{print $1}' > "build/${DISPLAY_NAME}-${VERSION}.sha256"
 


### PR DESCRIPTION
Replaces the previous `rm`-based cleanup of `build/export/` with a proper staging dir: copy only the `.app` into `build/dmg-stage/` and point create-dmg there. The DMG can no longer accidentally pick up xcodebuild export artifacts regardless of what's in `build/export/`.