### PR TITLE
Cut v1.14.2 with clean DMG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - **Language:** Swift / SwiftUI
 - **App Type:** Menu bar app (LSUIElement = YES, no dock icon)
 - **Transcription:** Proxy-only (all cloud API calls routed through proxy)
+- **Distribution:** notarized DMG via GitHub Releases + Sparkle auto-update (see Release process)
 
 ## Key Architecture
 


### PR DESCRIPTION
v1.14.1 DMG contained xcodebuild export artifacts (`DistributionSummary.plist`, `ExportOptions.plist`, `Packaging.log`) next to `Diduny.app`. PR #35 fixed the CI to stage only the .app for create-dmg. This PR is a tiny doc tweak labeled `release:patch` to trigger v1.14.2 through the new pipeline.