### PR TITLE
fix(onboarding): stop duplicate permission prompts (v1.14.3)

### DIFF
--- a/Diduny/Core/Storage/PermissionManager.swift
+++ b/Diduny/Core/Storage/PermissionManager.swift
@@ -149,16 +149,19 @@ final class PermissionManager {
         return granted
     }
 
-    /// Ensure screen recording permission - request if not determined, or prompt to open Settings if denied
+    /// Ensure screen recording permission - request if not determined, or open Settings if denied.
+    /// Do not show an extra NSAlert here: macOS already shows an "Open System Settings"
+    /// prompt for the first Screen Recording request.
     func ensureScreenRecordingPermission() async -> Bool {
         // First, try to get permission (this will trigger the dialog if not determined)
         let granted = await requestScreenRecordingPermission()
 
         if !granted {
-            // If not granted, show alert to open System Settings
-            NSLog("[Diduny] Screen recording permission denied, prompting user to open Settings")
+            // If not granted, open System Settings directly. A custom alert here
+            // duplicates the native TCC prompt and stacks two permission popups.
+            NSLog("[Diduny] Screen recording permission not granted, opening System Settings")
             await MainActor.run {
-                showPermissionAlert(for: .screenRecording)
+                openSystemSettingsForPermission(.screenRecording)
             }
         }
 

--- a/Diduny/Features/Onboarding/OnboardingContainerView.swift
+++ b/Diduny/Features/Onboarding/OnboardingContainerView.swift
@@ -288,6 +288,7 @@ private struct OnboardingMainButton: View {
                 .background(disabled ? OnboardingStyle.brandBlue.opacity(0.45)
                                      : OnboardingStyle.brandBlueDark)
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
         .disabled(disabled)
@@ -341,6 +342,7 @@ private struct PermissionActionButton: View {
                 .background(disabled ? OnboardingStyle.brandBlue.opacity(0.45)
                                      : OnboardingStyle.brandBlueDark)
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
         .disabled(disabled)
@@ -364,6 +366,7 @@ private struct PermissionOutlineButton: View {
                         .stroke(OnboardingStyle.brandBlueDark.opacity(0.65), lineWidth: 1.5)
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
     }
@@ -584,12 +587,34 @@ struct SetupComputerStepView: View {
     private func requestMicrophonePermission() {
         guard !isRequestingMicrophone else { return }
         isRequestingMicrophone = true
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            DispatchQueue.main.async {
-                self.isRequestingMicrophone = false
-                self.microphoneGranted = granted
-                bringOnboardingWindowToFront()
+
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            isRequestingMicrophone = false
+            microphoneGranted = true
+
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                DispatchQueue.main.async {
+                    self.isRequestingMicrophone = false
+                    self.microphoneGranted = granted
+                    if granted {
+                        bringOnboardingWindowToFront()
+                    } else {
+                        openSystemSettings(anchor: "Privacy_Microphone")
+                    }
+                }
             }
+
+        case .denied, .restricted:
+            isRequestingMicrophone = false
+            microphoneGranted = false
+            openSystemSettings(anchor: "Privacy_Microphone")
+
+        @unknown default:
+            isRequestingMicrophone = false
+            microphoneGranted = false
+            openSystemSettings(anchor: "Privacy_Microphone")
         }
     }
 
@@ -603,11 +628,14 @@ struct SetupComputerStepView: View {
         // Do NOT pull the onboarding window back to the front here: the system
         // Accessibility prompt is non-modal and would end up hidden behind
         // onboarding (and the user re-clicking "Allow" feels like a double
-        // prompt). Leave it visible; the poll timer picks up the grant once
-        // the user enables Diduny in System Settings.
+        // prompt). If macOS no longer shows the prompt, open the exact Privacy
+        // pane so the Allow click still gives the user a visible next step.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.isRequestingAccessibility = false
             self.refreshPermissionStatus()
+            if !self.accessibilityGranted {
+                openSystemSettings(anchor: "Privacy_Accessibility")
+            }
         }
     }
 }
@@ -735,17 +763,17 @@ struct ScreenRecordingStepView: View {
         isRequesting = true
 
         Task {
-            // ensureScreenRecordingPermission falls back to System Settings if
-            // the status is already `denied` (SCShareableContent only shows the
-            // macOS prompt for `undetermined` status).
-            _ = await PermissionManager.shared.ensureScreenRecordingPermission()
+            // Request only the native macOS TCC prompt here. Do not call
+            // ensureScreenRecordingPermission(), because its fallback alert
+            // duplicates the system "Open System Settings" prompt.
+            _ = await PermissionManager.shared.requestScreenRecordingPermission()
             // The boolean returned above is unreliable inside the running
             // process due to SCShareableContent's cached state. The passive
             // refresh path is the source of truth — it polls TCC directly.
             await MainActor.run {
                 isRequesting = false
-                bringOnboardingWindowToFront()
             }
+            await refreshStatus()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Microphone permission now branches on `authorizationStatus`: opens the **Privacy → Microphone** pane on denied/restricted instead of waiting silently.
- Accessibility permission: if grant is still missing after the native prompt, deep-link to **Privacy → Accessibility**.
- Screen recording: removed the duplicate NSAlert in `ensureScreenRecordingPermission`; we now call `requestScreenRecordingPermission` directly. The macOS TCC prompt is enough — stacking a custom alert on top was the "feels triggered twice" bug.
- Buttons: added `contentShape` so the entire pill is hit-testable (not just label glyphs).

## Test plan
- [ ] Reset TCC: `tccutil reset Microphone ua.com.rmarinsky.diduny && tccutil reset Accessibility ua.com.rmarinsky.diduny && tccutil reset ScreenCapture ua.com.rmarinsky.diduny`
- [ ] Launch onboarding → microphone card → tap Allow → grant in prompt → auto-advance.
- [ ] Tap Deny on microphone prompt → System Settings opens to Privacy → Microphone.
- [ ] Accessibility card → Allow → check that no double prompt appears.
- [ ] Screen Recording card → only one system prompt, no extra Diduny alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate system prompts when requesting screen recording permission during setup
  * Improved microphone permission request flow with better state handling
  * Enhanced accessibility permission dialog to display correctly when access is needed
  * Increased clickable area size for onboarding action buttons for better usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rmarinsky/Diduny/pull/37)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->