### PR TITLE
fix: restore release archive language metadata build

### DIFF
--- a/Diduny/Core/Models/Recording.swift
+++ b/Diduny/Core/Models/Recording.swift
@@ -32,6 +32,7 @@ struct Recording: Identifiable, Codable, Equatable {
     var processedAt: Date?
     var chapters: [MeetingChapter]?
     let sourceDevice: RecordingDeviceInfo?
+    var translationTargetLanguageCode: String? = nil
     /// Marks a recording that originated from a recovery path rather than a normal
     /// stop; intended to drive the "Recovered" badge in the library and the
     /// detail-view notice. Once set it is preserved (never cleared), including

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -39,7 +39,8 @@ final class RecordingsLibraryStorage {
         type: Recording.RecordingType,
         duration: TimeInterval,
         transcriptionText: String? = nil,
-        sourceDevice: RecordingDeviceInfo? = nil
+        sourceDevice: RecordingDeviceInfo? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard shouldSaveRecording(type: type) else { return }
 
@@ -70,7 +71,8 @@ final class RecordingsLibraryStorage {
             status: status,
             transcriptionText: transcriptionText,
             processedAt: transcriptionText != nil ? Date() : nil,
-            sourceDevice: sourceDevice
+            sourceDevice: sourceDevice,
+            translationTargetLanguageCode: translationTargetLanguageCode
         )
 
         recordings.insert(recording, at: 0)
@@ -87,7 +89,8 @@ final class RecordingsLibraryStorage {
         type: Recording.RecordingType,
         duration: TimeInterval,
         transcriptionText: String? = nil,
-        sourceDevice: RecordingDeviceInfo? = nil
+        sourceDevice: RecordingDeviceInfo? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard shouldSaveRecording(type: type) else { return }
 
@@ -127,7 +130,8 @@ final class RecordingsLibraryStorage {
             status: status,
             transcriptionText: transcriptionText,
             processedAt: transcriptionText != nil ? Date() : nil,
-            sourceDevice: sourceDevice
+            sourceDevice: sourceDevice,
+            translationTargetLanguageCode: translationTargetLanguageCode
         )
 
         recordings.insert(recording, at: 0)
@@ -180,12 +184,16 @@ final class RecordingsLibraryStorage {
         id: UUID,
         status: Recording.ProcessingStatus,
         text: String? = nil,
-        error: String? = nil
+        error: String? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
         recordings[index].status = status
         recordings[index].transcriptionText = text ?? recordings[index].transcriptionText
         recordings[index].errorMessage = error
+        if let translationTargetLanguageCode {
+            recordings[index].translationTargetLanguageCode = translationTargetLanguageCode
+        }
         if status == .transcribed || status == .translated {
             recordings[index].processedAt = Date()
         }

--- a/Diduny/Features/Notch/NotchManager.swift
+++ b/Diduny/Features/Notch/NotchManager.swift
@@ -14,7 +14,7 @@ enum NotchState: Equatable {
 
 enum RecordingMode: Equatable {
     case voice
-    case translation(languagePair: String = "EN <-> UK")
+    case translation(targetLanguage: String = "EN <-> UK")
     case meeting
     case meetingTranslation
     case fileTranscription


### PR DESCRIPTION
## Summary

- Add the missing `Recording.translationTargetLanguageCode` metadata field used by the Audio & Dictation language flow.
- Thread `translationTargetLanguageCode` through recording save/update APIs.
- Align `RecordingMode.translation` associated-value label with the merged call sites.

## Why

The v1.15.0 release workflow created the tag but failed during `xcodebuild archive` because part of the language-flow API remained unstaged locally and was not included in PR #40.

## Validation

- `./scripts/generate_project.sh`
- `xcodebuild -project Diduny.xcodeproj -scheme Diduny -configuration Release -destination 'generic/platform=macOS' CODE_SIGNING_ALLOWED=NO build`

## Release

- `release:patch`
- Expected next tag: `v1.15.1`
