### PR TITLE
fix(crash): run Text Input Source APIs on the main thread (macOS 26 SIGTRAP)

### DIFF
--- a/Diduny/Core/Models/SupportedLanguage.swift
+++ b/Diduny/Core/Models/SupportedLanguage.swift
@@ -215,17 +215,24 @@ struct KeyboardLanguageDetector {
     }
 
     static func detectedLanguages() -> [DetectedLanguage] {
-        selectableInputSources().flatMap { source -> [DetectedLanguage] in
-            let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
-            let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
-            let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
-            return languageCodes(
-                inputSourceLanguages: languages,
-                inputSourceID: id,
-                localizedName: name
-            ).map { DetectedLanguage(code: $0, sourceName: name, sourceID: id) }
+        // Text Input Source APIs (TISCreateInputSourceList) must run on the main
+        // thread. On macOS 26 they assert the dispatch queue and hard-crash when
+        // called off-main, which happens because this is reached from background
+        // transcription Tasks. Hop to main so every caller is safe regardless of
+        // the thread it runs on.
+        runOnMainThread {
+            selectableInputSources().flatMap { source -> [DetectedLanguage] in
+                let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
+                let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
+                let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
+                return languageCodes(
+                    inputSourceLanguages: languages,
+                    inputSourceID: id,
+                    localizedName: name
+                ).map { DetectedLanguage(code: $0, sourceName: name, sourceID: id) }
+            }
+            .deduplicatedByCode()
         }
-        .deduplicatedByCode()
     }
 
     static func detectedLanguageCodes() -> [String] {
@@ -233,11 +240,23 @@ struct KeyboardLanguageDetector {
     }
 
     static func currentLanguageCode() -> String? {
-        let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
-        let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
-        let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
-        let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
-        return languageCodes(inputSourceLanguages: languages, inputSourceID: id, localizedName: name).first
+        // See note in detectedLanguages(): TIS APIs are main-thread only.
+        runOnMainThread {
+            let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+            let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
+            let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
+            let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
+            return languageCodes(inputSourceLanguages: languages, inputSourceID: id, localizedName: name).first
+        }
+    }
+
+    /// Runs `work` on the main thread, blocking the caller until it completes.
+    /// Executes inline when already on the main thread to avoid a deadlock.
+    private static func runOnMainThread<T>(_ work: () -> T) -> T {
+        if Thread.isMainThread {
+            return work()
+        }
+        return DispatchQueue.main.sync(execute: work)
     }
 
     static func languageCodes(


### PR DESCRIPTION
## The crash
Users on **macOS 26** crash with `EXC_BREAKPOINT` (SIGTRAP) on the **second consecutive dictation**. Reproduced via tap-to-speak: record nothing for ~2s, release, wait for processing, start again → crash.

```
Thread N Crashed:: com.apple.root.user-initiated-qos.cooperative   ← Swift async pool, not main
  dispatch_assert_queue + 108
  islGetInputSourceListWithAdditions
  TSMGetInputSourceCountWithFilteredAdditions
  TISCreateInputSourceList
  ...
  completeTaskWithClosure                                           ← inside an async Task
```

## Root cause
`TISCreateInputSourceList` / `TISCopyCurrentKeyboardInputSource` (Carbon Text Input Source APIs) **assert the main dispatch queue on macOS 26** and hard-crash when called off-main. `KeyboardLanguageDetector` is reached from **background transcription Tasks** — `CloudTranscriptionService.resolveLanguageConfig` → `SettingsStorage.speechLanguageHints` → `KeyboardLanguageDetector.detectedLanguages()` → `TISCreateInputSourceList`. Older macOS tolerated the off-main call; macOS 26 does not.

## Fix
Route every TIS access through a single main-thread hop centralized in `KeyboardLanguageDetector` (runs inline when already on main to avoid deadlock). This covers all ~7 off-main call sites (transcribe, recording queue, file, meeting, translation-pair resolution) in one place. One file changed.

## Verification
- `BUILD SUCCEEDED` (Diduny DEV, Debug) built off this `main` base
- `DidunyTests`: 53/53 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of keyboard language detection on macOS by ensuring proper thread handling for system APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->