### PR TITLE
fix(library): preserve translationTargetLanguageCode on file replacement

### DIFF
--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -337,6 +337,7 @@ final class RecordingsLibraryStorage {
                 processedAt: recording.processedAt,
                 chapters: recording.chapters,
                 sourceDevice: recording.sourceDevice,
+                translationTargetLanguageCode: recording.translationTargetLanguageCode,
                 recoverySource: recording.recoverySource
             )
             saveMetadata()


### PR DESCRIPTION
## Bug
`RecordingsLibraryStorage.replaceStoredAudioFile` rebuilds a `Recording` through the memberwise initializer when an audio file is compressed (FLAC) or renamed — but it omitted the `translationTargetLanguageCode` field, so it silently reset to `nil`. Translation recordings lost their target-language metadata after storage optimization. Present in production (v1.15.2).

## Fix
Carry `translationTargetLanguageCode: recording.translationTargetLanguageCode` through the re-init, alongside the other preserved fields.

## Verification
`Diduny DEV` app target: **BUILD SUCCEEDED**.

> Note: I could not run `DidunyTests` against this `main` base — the test target currently **fails to compile** on `main` (`SettingsStorageProviderTests.swift` references `TextTranslationViewModel.swapLanguagesAndText` / `sourceLanguageCode`, which don't exist on `main`'s view model — they're on the `redesign/diduny` branch). That's a pre-existing inconsistency unrelated to this one-line change. Flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)