### PR TITLE
[codex] Ship shortcuts redesign and recording fixes

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		497E932204DB8D119B40EAA5 /* PushToTalkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE81820CACD577C91281C9 /* PushToTalkService.swift */; };
 		4A3450320A622E433A5E4907 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB584F0BDA9252D1D71CE50D /* Logger.swift */; };
 		4B43C41C32D07C52621117A2 /* AsyncTranscriptionJobService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */; };
+		4D10D5466C7B83FF47A47945 /* TypingSpeedMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FF2EDE31E6D84069F1D5D0 /* TypingSpeedMeasurement.swift */; };
 		4E4C0DD6E977C6306BD0289C /* UpdaterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684A014D6E9B1A40935A7608 /* UpdaterManager.swift */; };
 		4E980E04C373EE5FBF3D2DC6 /* SettingsStorageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06685A0367DD0430BCEE035 /* SettingsStorageProviderTests.swift */; };
 		4EB7E17EB03BFF9E631E38A9 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2430641841403AB68C61B536 /* KeychainManager.swift */; };
@@ -99,9 +100,9 @@
 		CBD76325F1DE55DA51EDD348 /* DeviceLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */; };
 		CC8A0AB7ADA44B998EC3E45D /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26809CA162E096F4EA668768 /* ServiceProtocols.swift */; };
 		CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */; };
+		D0BDBD33AD9969711AEF33E1 /* TypingTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803A2E19B668337A8516CC31 /* TypingTestView.swift */; };
 		D52AFEB3B25B529860D14116 /* AudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118CE8BCA0160E31FD916B10 /* AudioDevice.swift */; };
 		D6203B3BADF3AA7E40186F11 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0491E26240E167BDB5DCACEE /* HotkeyService.swift */; };
-		D04D8395563E428F839BE368 /* TypingTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA1CD5086FD4EA0922A5A3E /* TypingTestView.swift */; };
 		D88F0858310A14339ADE4178 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4ECCACC4D64216B39204947 /* Metal.framework */; };
 		D9A94E2B88149920B8BA2B9E /* TranscriptCleanupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */; };
 		DB3964EFB7C60E392C41A920 /* MenuBarIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B43D2844894F848F20BFDEB /* MenuBarIconView.swift */; };
@@ -123,11 +124,10 @@
 		EBD6CE2EED71E6F9BC63E53E /* MenuBarContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C864D23789DFC70C7FE0D3 /* MenuBarContentView.swift */; };
 		F1802FC4C604B7FB3AA13B96 /* RemoteConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4852162851F73B8352C95E25 /* RemoteConfigService.swift */; };
 		F293480FBFF36536227A5878 /* TranscriptionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5B2157378ABF82C5B80572 /* TranscriptionProvider.swift */; };
-		95C9CE064CC2410EB46F0BCF /* TypingSpeedMeasurementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779A91E28C54DE8A7CC5F78 /* TypingSpeedMeasurementTests.swift */; };
-		B4AA58AA307C410FA6755D56 /* TypingSpeedMeasurement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEB516FDE22E4469AF6568A1 /* TypingSpeedMeasurement.swift */; };
 		F64CD3B70A52B315B4110B8C /* CloudRealtimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D5E66F362C783C621055C /* CloudRealtimeService.swift */; };
 		F6597F7A3262A493D769B85B /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECAEC93BAEBC7FB0CE79126 /* Errors.swift */; };
 		F9204E8BCBCCA977B096A3D2 /* AudioPlaybackControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88AE153FCAA14A227A7E16 /* AudioPlaybackControlView.swift */; };
+		FFBC1497C42CFFB50037E3EA /* TypingSpeedMeasurementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -155,7 +155,6 @@
 		1967633DAD0607B3B2756CC8 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		1999FC4728C79F46A514A1E4 /* AppDelegate+MeetingTranslationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingTranslationRecording.swift"; sourceTree = "<group>"; };
 		1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
-		1EA1CD5086FD4EA0922A5A3E /* TypingTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingTestView.swift; sourceTree = "<group>"; };
 		22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		22ECCCBC345EE579CFE2AD5F /* InProgressRecordingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressRecordingStoreTests.swift; sourceTree = "<group>"; };
 		22F3DF3DBD7AB2A6B8F1B8D1 /* SupabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseService.swift; sourceTree = "<group>"; };
@@ -180,7 +179,6 @@
 		44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingModelMigrationTests.swift; sourceTree = "<group>"; };
 		459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		459DCE179DA235DE6208C013 /* SupportedLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedLanguage.swift; sourceTree = "<group>"; };
-		4779A91E28C54DE8A7CC5F78 /* TypingSpeedMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSpeedMeasurementTests.swift; sourceTree = "<group>"; };
 		4852162851F73B8352C95E25 /* RemoteConfigService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigService.swift; sourceTree = "<group>"; };
 		4C5A21F6255692712508A475 /* Diduny.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Diduny.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CAB5C5B84DF4B8F5E37A9FF /* AudioDictationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDictationSettingsView.swift; sourceTree = "<group>"; };
@@ -199,6 +197,7 @@
 		65DFFB871345DD916879CEBD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToTalkKey.swift; sourceTree = "<group>"; };
 		684A014D6E9B1A40935A7608 /* UpdaterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterManager.swift; sourceTree = "<group>"; };
+		69FF2EDE31E6D84069F1D5D0 /* TypingSpeedMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSpeedMeasurement.swift; sourceTree = "<group>"; };
 		6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTranscriptionJobService.swift; sourceTree = "<group>"; };
 		6BBD93A73F0292748E989CA5 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+FileTranscription.swift"; sourceTree = "<group>"; };
@@ -211,6 +210,7 @@
 		78ADA0228DC80DA0ACD8CE17 /* JobModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobModels.swift; sourceTree = "<group>"; };
 		792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLevelMonitor.swift; sourceTree = "<group>"; };
 		7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Hotkeys.swift"; sourceTree = "<group>"; };
+		803A2E19B668337A8516CC31 /* TypingTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingTestView.swift; sourceTree = "<group>"; };
 		865E86F8079EAE7A9BFB178E /* RecordingsLibraryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingsLibraryStorage.swift; sourceTree = "<group>"; };
 		893211B2A0981542B494E03B /* MeetingChunkStitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingChunkStitcher.swift; sourceTree = "<group>"; };
 		8A2A0045FAC17572590BE16F /* EscapeCancelService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeCancelService.swift; sourceTree = "<group>"; };
@@ -224,7 +224,6 @@
 		A5A6F95E2FA37D325086B2BC /* OnboardingComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingComponents.swift; sourceTree = "<group>"; };
 		A71FCAF64D600F8EFA8B20A2 /* WhisperModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperModelManager.swift; sourceTree = "<group>"; };
 		A90DC34399C728FB2BD9C292 /* AuthServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthServiceTests.swift; sourceTree = "<group>"; };
-		AEB516FDE22E4469AF6568A1 /* TypingSpeedMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSpeedMeasurement.swift; sourceTree = "<group>"; };
 		AB584F0BDA9252D1D71CE50D /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		AE085119ABE74DF13D5DE78E /* DictationOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationOverlayController.swift; sourceTree = "<group>"; };
 		AF8E52BB2FE2DF4133F56731 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
@@ -246,6 +245,7 @@
 		C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepFlushCoordinatorTests.swift; sourceTree = "<group>"; };
 		D1B0622318D71BD3A1EEA701 /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
 		D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStateTests.swift; sourceTree = "<group>"; };
+		D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSpeedMeasurementTests.swift; sourceTree = "<group>"; };
 		DB47383A0059A74CA8DEA1AB /* MainWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowView.swift; sourceTree = "<group>"; };
 		DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptCleanupServiceTests.swift; sourceTree = "<group>"; };
 		E06685A0367DD0430BCEE035 /* SettingsStorageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStorageProviderTests.swift; sourceTree = "<group>"; };
@@ -361,8 +361,8 @@
 				6ECD47EAFC19CDD9D6561326 /* RecordingFeedbackSurface.swift */,
 				58445C3A1AF119838326EC9F /* RemoteConfig.swift */,
 				459DCE179DA235DE6208C013 /* SupportedLanguage.swift */,
-				AEB516FDE22E4469AF6568A1 /* TypingSpeedMeasurement.swift */,
 				FF5B2157378ABF82C5B80572 /* TranscriptionProvider.swift */,
+				69FF2EDE31E6D84069F1D5D0 /* TypingSpeedMeasurement.swift */,
 				F06909181E0B9AD3B70E57E3 /* WhisperError.swift */,
 				B14415E4A90B0A80E5B44F3B /* WhisperModelUnloadPolicy.swift */,
 			);
@@ -462,7 +462,7 @@
 				8F1DB771BE47D76906F11C84 /* Settings */,
 				80BA8191113D56E490C4FF8A /* TextTranslation */,
 				26025DF9FC1F88D47FBD32E3 /* Transcription */,
-				4E0310B9A877483691A41E90 /* TypingTest */,
+				BD2D4F0969973C703C44CC27 /* TypingTest */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -474,14 +474,6 @@
 				583D24D80FE19BB49505E371 /* TextTranslationWindowController.swift */,
 			);
 			path = TextTranslation;
-			sourceTree = "<group>";
-		};
-		4E0310B9A877483691A41E90 /* TypingTest */ = {
-			isa = PBXGroup;
-			children = (
-				1EA1CD5086FD4EA0922A5A3E /* TypingTestView.swift */,
-			);
-			path = TypingTest;
 			sourceTree = "<group>";
 		};
 		86A4C8BEC7F50A0F4206230C /* Utilities */ = {
@@ -576,6 +568,14 @@
 			);
 			sourceTree = "<group>";
 		};
+		BD2D4F0969973C703C44CC27 /* TypingTest */ = {
+			isa = PBXGroup;
+			children = (
+				803A2E19B668337A8516CC31 /* TypingTestView.swift */,
+			);
+			path = TypingTest;
+			sourceTree = "<group>";
+		};
 		CB6A45DDD91116CF743B7691 /* HistoryPalette */ = {
 			isa = PBXGroup;
 			children = (
@@ -601,7 +601,7 @@
 				E06685A0367DD0430BCEE035 /* SettingsStorageProviderTests.swift */,
 				C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */,
 				DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */,
-				4779A91E28C54DE8A7CC5F78 /* TypingSpeedMeasurementTests.swift */,
+				D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */,
 			);
 			path = DidunyTests;
 			sourceTree = "<group>";
@@ -836,10 +836,10 @@
 				247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */,
 				2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */,
 				BB39149383C71119B82FE3AD /* TranscriptCleanupService.swift in Sources */,
-				B4AA58AA307C410FA6755D56 /* TypingSpeedMeasurement.swift in Sources */,
-				D04D8395563E428F839BE368 /* TypingTestView.swift in Sources */,
 				F293480FBFF36536227A5878 /* TranscriptionProvider.swift in Sources */,
 				50CD068CB639D75D27C09787 /* TranscriptionWindowController.swift in Sources */,
+				4D10D5466C7B83FF47A47945 /* TypingSpeedMeasurement.swift in Sources */,
+				D0BDBD33AD9969711AEF33E1 /* TypingTestView.swift in Sources */,
 				4E4C0DD6E977C6306BD0289C /* UpdaterManager.swift in Sources */,
 				6714EFD87502A88E18B6F7EE /* UsageService.swift in Sources */,
 				62EBB796CFA5A63DB61BA0B6 /* WhisperContext.swift in Sources */,
@@ -867,7 +867,7 @@
 				4E980E04C373EE5FBF3D2DC6 /* SettingsStorageProviderTests.swift in Sources */,
 				CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */,
 				D9A94E2B88149920B8BA2B9E /* TranscriptCleanupServiceTests.swift in Sources */,
-				95C9CE064CC2410EB46F0BCF /* TypingSpeedMeasurementTests.swift in Sources */,
+				FFBC1497C42CFFB50037E3EA /* TypingSpeedMeasurementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Diduny/App/AppDelegate+Hotkeys.swift
+++ b/Diduny/App/AppDelegate+Hotkeys.swift
@@ -14,6 +14,14 @@ extension AppDelegate {
             self?.toggleTranslationRecording()
         }
 
+        hotkeyService.registerMeetingHotkey { [weak self] in
+            self?.toggleMeetingRecording()
+        }
+
+        hotkeyService.registerMeetingTranslationHotkey { [weak self] in
+            self?.toggleMeetingTranslationRecording()
+        }
+
         hotkeyService.registerHistoryPaletteHotkey {
             HistoryPaletteWindowController.shared.toggle()
         }

--- a/Diduny/Core/Models/LiveTranscriptStore.swift
+++ b/Diduny/Core/Models/LiveTranscriptStore.swift
@@ -13,13 +13,8 @@ final class LiveTranscriptStore {
     var connectionStatus: RealtimeConnectionStatus = .disconnected
     private var forceNewSegmentForNextFinalToken = false
 
-    var wordCount: Int {
-        let finalWords = segments.reduce(0) { count, segment in
-            count + segment.text.split(separator: " ").count
-        }
-        let provisionalWords = provisionalText.split(separator: " ").count
-        return finalWords + provisionalWords
-    }
+    private(set) var wordCount: Int = 0
+    private var _provisionalWordCount: Int = 0
 
     var finalTranscriptText: String {
         var result = ""
@@ -44,17 +39,24 @@ final class LiveTranscriptStore {
             appendFinalToken(token)
         }
 
-        // Update provisional text
+        // Update provisional text and word count
         if !nonFinalTokens.isEmpty {
-            provisionalText = nonFinalTokens.map(\.text).joined()
+            let newText = nonFinalTokens.map(\.text).joined()
+            let newCount = newText.split(separator: " ").filter { !$0.isEmpty }.count
+            wordCount += newCount - _provisionalWordCount
+            _provisionalWordCount = newCount
+            provisionalText = newText
             provisionalSpeaker = nonFinalTokens.first?.speaker
         } else if !finalTokens.isEmpty {
+            wordCount -= _provisionalWordCount
+            _provisionalWordCount = 0
             provisionalText = ""
             provisionalSpeaker = nil
         }
     }
 
     private func appendFinalToken(_ token: RealtimeToken) {
+        wordCount += token.text.split(separator: " ").filter { !$0.isEmpty }.count
         if forceNewSegmentForNextFinalToken {
             forceNewSegmentForNextFinalToken = false
             let segment = TranscriptSegment(
@@ -93,6 +95,8 @@ final class LiveTranscriptStore {
         segments = []
         provisionalText = ""
         provisionalSpeaker = nil
+        wordCount = 0
+        _provisionalWordCount = 0
         isActive = false
         connectionStatus = .disconnected
         forceNewSegmentForNextFinalToken = false

--- a/Diduny/Core/Models/RealtimeTranscription.swift
+++ b/Diduny/Core/Models/RealtimeTranscription.swift
@@ -164,7 +164,7 @@ struct RealtimeAudioConfig: Equatable {
 struct RealtimeTranslationConfig: Equatable {
     enum Mode: Equatable {
         case twoWay(languageA: String, languageB: String)
-        case oneWay(sourceLanguage: String, targetLanguage: String)
+        case oneWay(targetLanguage: String)
     }
 
     let mode: Mode

--- a/Diduny/Core/Services/AsyncTranscriptionJobService.swift
+++ b/Diduny/Core/Services/AsyncTranscriptionJobService.swift
@@ -9,6 +9,7 @@ final class AsyncTranscriptionJobService {
     private let maxJobWaitSeconds: TimeInterval = 7200
     private let maxAudioBytesForSpeechPrecheck = 25 * 1024 * 1024
     private let longRunningSessionBodyThresholdBytes = 10 * 1024 * 1024
+    private let statusPollRetryCount = 3
     private let strictSpeechPrecheck = false
 
     private lazy var longRunningSession: URLSession = {
@@ -143,7 +144,8 @@ final class AsyncTranscriptionJobService {
         let request = URLRequest(url: url)
         let (data, httpResponse) = try await performDataRequest(request)
         guard (200 ... 299).contains(httpResponse.statusCode) else {
-            throw TranscriptionError.apiError("Failed to get job status")
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw TranscriptionError.apiError("Failed to get job status (\(httpResponse.statusCode)): \(errorBody)")
         }
 
         return try JSONDecoder().decode(JobStatusResponse.self, from: data)
@@ -183,15 +185,16 @@ final class AsyncTranscriptionJobService {
                 Log.transcription.warning("SSE stream failed (attempt \(sseFailures)): \(error)")
 
                 // Check if job finished while disconnected
-                let status = try await getJobStatus(jobId: submission.jobId)
-                if status.status == "completed", let result = status.result {
-                    return result.outputText(preferSpeakerDiarization: preferSpeakerDiarization)
-                }
-                if status.status == "error" {
-                    throw TranscriptionError.apiError(status.error ?? "Transcription failed")
-                }
-                if let parsed = JobStatus(rawValue: status.status) {
-                    onUpdate(parsed)
+                if let status = try await getJobStatusAfterDisconnect(jobId: submission.jobId, sseAttempt: sseFailures) {
+                    if status.status == "completed", let result = status.result {
+                        return result.outputText(preferSpeakerDiarization: preferSpeakerDiarization)
+                    }
+                    if status.status == "error" {
+                        throw TranscriptionError.apiError(status.error ?? "Transcription failed")
+                    }
+                    if let parsed = JobStatus(rawValue: status.status) {
+                        onUpdate(parsed)
+                    }
                 }
 
                 // Still in progress. SSE is best-effort; keep polling/retrying until
@@ -203,6 +206,38 @@ final class AsyncTranscriptionJobService {
         }
 
         throw TranscriptionError.apiError("Timed out waiting for transcription result")
+    }
+
+    private func getJobStatusAfterDisconnect(jobId: String, sseAttempt: Int) async throws -> JobStatusResponse? {
+        var lastError: Error?
+
+        for attempt in 1 ... statusPollRetryCount {
+            try Task.checkCancellation()
+
+            do {
+                return try await getJobStatus(jobId: jobId)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                lastError = error
+                Log.transcription.warning(
+                    "Job status poll failed after SSE disconnect (sseAttempt=\(sseAttempt), pollAttempt=\(attempt)): \(error.localizedDescription)"
+                )
+
+                if attempt < statusPollRetryCount {
+                    let delaySeconds = min(Double(attempt), 3)
+                    try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+                }
+            }
+        }
+
+        if let lastError {
+            Log.transcription.warning(
+                "Job status temporarily unavailable after \(self.statusPollRetryCount) attempts; keeping async job alive: \(lastError.localizedDescription)"
+            )
+        }
+
+        return nil
     }
 
     // MARK: - Upload Preparation

--- a/Diduny/Core/Services/AudioRecorderService.swift
+++ b/Diduny/Core/Services/AudioRecorderService.swift
@@ -26,6 +26,8 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
     private var configurationObserver: NSObjectProtocol?
     private var realtimeAudioStreamer: RealtimeAudioStreamer?
     private var activeRecordingFormat: AVAudioFormat?
+    private nonisolated let _audioLevelBox = OSAllocatedUnfairLock<Float>(initialState: 0)
+    private var audioLevelTimer: DispatchSourceTimer?
     private(set) var currentRecordingDeviceInfo: RecordingDeviceInfo?
 
     /// Timeout for audio hardware operations (in seconds)
@@ -252,6 +254,7 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
         }
 
         isRecording = true
+        startAudioLevelPolling()
         let updatedRecordingState = self.isRecording
         Log.audio.info("startRecording: END, isRecording=\(updatedRecordingState)")
     }
@@ -283,7 +286,7 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
         audioFile = nil
 
         isRecording = false
-        audioLevel = 0
+        stopAudioLevelPolling()
         onDeviceLost = nil
         activeRecordingFormat = nil
 
@@ -327,7 +330,7 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
 
         realtimeAudioStreamer = nil
         isRecording = false
-        audioLevel = 0
+        stopAudioLevelPolling()
         currentRecordingDeviceInfo = nil
         onDeviceLost = nil
     }
@@ -376,7 +379,7 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
         activeRecordingFormat = nil
         currentRecordingDeviceInfo = nil
         isRecording = false
-        audioLevel = 0
+        stopAudioLevelPolling()
         onDeviceLost = nil
 
         if removeFile, let url = recordingURL {
@@ -416,26 +419,40 @@ final class AudioRecorderService: ObservableObject, AudioRecorderProtocol {
 
     private nonisolated func updateAudioLevelFromBuffer(_ buffer: AVAudioPCMBuffer) {
         guard let channelData = buffer.floatChannelData?[0] else { return }
-
         let frameLength = Int(buffer.frameLength)
         guard frameLength > 0 else { return }
 
-        // Calculate RMS (Root Mean Square) for audio level
         var sum: Float = 0
         for i in 0 ..< frameLength {
             let sample = channelData[i]
             sum += sample * sample
         }
         let rms = sqrt(sum / Float(frameLength))
-
-        // Convert to dB and normalize
         let db = 20 * log10(max(rms, 0.0001))
         let minDb: Float = -60
         let normalizedLevel = max(0, min(1, (db - minDb) / -minDb))
 
-        Task { @MainActor [weak self] in
-            self?.audioLevel = normalizedLevel
+        _audioLevelBox.withLock { $0 = normalizedLevel }
+    }
+
+    private func startAudioLevelPolling() {
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: 1.0 / 25.0)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            let latest = self._audioLevelBox.withLock { $0 }
+            if abs(latest - self.audioLevel) > 0.01 {
+                self.audioLevel = latest
+            }
         }
+        timer.resume()
+        audioLevelTimer = timer
+    }
+
+    private func stopAudioLevelPolling() {
+        audioLevelTimer?.cancel()
+        audioLevelTimer = nil
+        audioLevel = 0
     }
 
     // MARK: - Timeout Helper

--- a/Diduny/Core/Services/ClipboardService.swift
+++ b/Diduny/Core/Services/ClipboardService.swift
@@ -77,7 +77,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         // Keep only a short focus handoff delay. NSPasteboard writes above are synchronous.
         try await Task.sleep(nanoseconds: Self.pasteReadinessDelayNanoseconds)
 
-        try postCommandShortcut(keyCode: CGKeyCode(9), error: .pasteEventFailed)
+        try await postCommandShortcut(keyCode: CGKeyCode(9), error: .pasteEventFailed)
 
         Log.app.info("Paste event sent successfully to frontmost app")
     }
@@ -93,7 +93,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         }
 
         let initialChangeCount = pasteboard.changeCount
-        try postCommandShortcut(keyCode: CGKeyCode(8), error: .copyEventFailed)
+        try await postCommandShortcut(keyCode: CGKeyCode(8), error: .copyEventFailed)
 
         let timeout = Date().addingTimeInterval(0.8)
         while Date() < timeout {
@@ -114,7 +114,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         pasteboard.string(forType: .string)
     }
 
-    private func postCommandShortcut(keyCode: CGKeyCode, error: ClipboardError) throws {
+    private func postCommandShortcut(keyCode: CGKeyCode, error: ClipboardError) async throws {
         guard let source = CGEventSource(stateID: .hidSystemState) else {
             Log.app.error("Failed to create event source")
             throw error
@@ -125,16 +125,21 @@ final class ClipboardService: ClipboardServiceProtocol {
             throw error
         }
         keyDown.flags = .maskCommand
-        keyDown.post(tap: .cgAnnotatedSessionEventTap)
 
-        // Keep a tiny delay between key down/up so target apps can process shortcuts reliably.
-        usleep(Self.shortcutKeyHoldMicroseconds)
-
+        // Build the key-up up front and post it via defer so it always fires —
+        // even if the hold-interval sleep below is cancelled (e.g. the user
+        // re-triggers recording mid-paste). Otherwise the virtual ⌘ stays
+        // "held" in the target app until the next real key event.
         guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else {
             Log.app.error("Failed to create keyUp event")
             throw error
         }
         keyUp.flags = .maskCommand
-        keyUp.post(tap: .cgAnnotatedSessionEventTap)
+
+        keyDown.post(tap: .cgAnnotatedSessionEventTap)
+        defer { keyUp.post(tap: .cgAnnotatedSessionEventTap) }
+
+        // Suspend rather than park the thread for the key-hold interval.
+        try await Task.sleep(for: .milliseconds(12))
     }
 }

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -614,6 +614,8 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         if !languageHints.isEmpty {
             config["language_hints"] = languageHints
+            // Contract (see SettingsStorageProviderTests): any hints present are
+            // treated as strict, regardless of `strictLanguageHints`.
             config["language_hints_strict"] = strictLanguageHints || !languageHints.isEmpty
         }
 

--- a/Diduny/Core/Services/CloudTranscriptionService.swift
+++ b/Diduny/Core/Services/CloudTranscriptionService.swift
@@ -404,6 +404,9 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
     static func applyLanguageConfig(_ languageConfig: CloudLanguageConfig, to config: inout [String: Any]) {
         guard !languageConfig.hints.isEmpty else { return }
         config["language_hints"] = languageConfig.hints
+        // Contract (see SettingsStorageProviderTests): whenever any hints are
+        // present they are treated as strict, regardless of the config's own
+        // `strict` flag. Keep the disjunction.
         config["language_hints_strict"] = languageConfig.strict || !languageConfig.hints.isEmpty
     }
 

--- a/Diduny/Core/Services/DeviceLevelMonitor.swift
+++ b/Diduny/Core/Services/DeviceLevelMonitor.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import CoreAudio
+import os
 
 @MainActor
 @Observable
@@ -7,6 +8,8 @@ final class DeviceLevelMonitor {
     var audioLevel: Float = 0
 
     private var engine: AVAudioEngine?
+    private nonisolated let _audioLevelBox = OSAllocatedUnfairLock<Float>(initialState: 0)
+    private var pollingTimer: DispatchSourceTimer?
 
     func startMonitoring(deviceID: AudioDeviceID) {
         stopMonitoring()
@@ -50,24 +53,41 @@ final class DeviceLevelMonitor {
             let minDb: Float = -60
             let level = max(0, min(1, (db - minDb) / -minDb))
 
-            Task { @MainActor in
-                self?.audioLevel = level
-            }
+            self?._audioLevelBox.withLock { $0 = level }
         }
 
         do {
             try engine.start()
         } catch {
             self.engine = nil
+            return
         }
+
+        startPollingTimer()
     }
 
     func stopMonitoring() {
+        pollingTimer?.cancel()
+        pollingTimer = nil
         if let engine {
             engine.inputNode.removeTap(onBus: 0)
             engine.stop()
         }
         engine = nil
         audioLevel = 0
+    }
+
+    private func startPollingTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: 1.0 / 25.0)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            let latest = self._audioLevelBox.withLock { $0 }
+            if abs(latest - self.audioLevel) > 0.01 {
+                self.audioLevel = latest
+            }
+        }
+        timer.resume()
+        pollingTimer = timer
     }
 }

--- a/Diduny/Core/Services/EscapeCancelService.swift
+++ b/Diduny/Core/Services/EscapeCancelService.swift
@@ -21,6 +21,8 @@ final class EscapeCancelService: ObservableObject {
     /// Called on intermediate Escape presses so UI can explain how many are left.
     var onProgressEscape: ((Int, Int) -> Void)?
 
+    private let tinkSound = NSSound(named: .init("Tink"))
+
     private init() {}
 
     /// Activate shortcut monitoring (call when recording starts)
@@ -31,6 +33,7 @@ final class EscapeCancelService: ObservableObject {
 
         // Monitor keyDown events globally.
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == 53, !event.isARepeat else { return }
             Task { @MainActor in
                 self?.handleKeyDown(event)
             }
@@ -38,6 +41,7 @@ final class EscapeCancelService: ObservableObject {
 
         // Also monitor locally when app is active
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard event.keyCode == 53, !event.isARepeat else { return event }
             Task { @MainActor in
                 self?.handleKeyDown(event)
             }
@@ -94,7 +98,7 @@ final class EscapeCancelService: ObservableObject {
             onCancel?()
         } else {
             Log.app.debug("Escape press \(self.consecutivePressCount)/\(requiredPressCount) - waiting for confirmation")
-            NSSound(named: NSSound.Name("Tink"))?.play()
+            tinkSound?.play()
             onProgressEscape?(self.consecutivePressCount, requiredPressCount)
             timeoutTask?.cancel()
             timeoutTask = Task { [weak self] in

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Accelerate
 import CoreAudio
 import CoreMedia
 import Foundation
@@ -30,6 +31,9 @@ final class SystemAudioCaptureService: NSObject {
     /// Serial queue for mixer buffer access — both SCStream callbacks and AVAudioEngine tap dispatch here.
     private let mixerQueue = DispatchQueue(label: "ua.com.rmarinsky.diduny.mixer")
     private let streamOutputQueue = DispatchQueue(label: "ua.com.rmarinsky.diduny.scstream.output")
+    /// Serial queue serializing all lifecycle-state reads/writes (isCapturing, stream, counters).
+    /// SCStream delegate prologues hop here before touching any lifecycle field.
+    private let controlQueue = DispatchQueue(label: "ua.com.rmarinsky.diduny.capture.control")
     private let maxSystemRecoveryAttempts = 3
     private let maxMicrophoneRecoveryAttempts = 3
     private let initialRecoveryDelay: TimeInterval = 0.75
@@ -91,6 +95,8 @@ final class SystemAudioCaptureService: NSObject {
 
     private var systemBuffer: [Float] = []
     private var micBuffer: [Float] = []
+    /// Preallocated scratch buffer for mixing — grows as needed, never shrinks.
+    private var mixScratchBuffer: [Float] = []
     /// Maximum single-source frames before flushing without counterpart.
     /// This bounds live-transcription latency when one source temporarily leads
     /// the other, while still giving the mixer a chance to align overlapping audio.
@@ -743,9 +749,13 @@ final class SystemAudioCaptureService: NSObject {
 
 extension SystemAudioCaptureService: SCStreamDelegate {
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        guard let activeStream = self.stream, activeStream === stream, isCapturing, !isStoppingCapture else { return }
-        Log.audio.error("Stream stopped with error: \(error)")
-        scheduleSystemRecovery(after: error)
+        controlQueue.async { [weak self] in
+            guard let self else { return }
+            guard let activeStream = self.stream, activeStream === stream,
+                  self.isCapturing, !self.isStoppingCapture else { return }
+            Log.audio.error("Stream stopped with error: \(error)")
+            self.scheduleSystemRecovery(after: error)
+        }
     }
 }
 
@@ -753,21 +763,36 @@ extension SystemAudioCaptureService: SCStreamDelegate {
 
 extension SystemAudioCaptureService: SCStreamOutput {
     func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
-        guard let activeStream = self.stream, activeStream === stream, isCapturing, !isStoppingCapture else { return }
-        delegateCallCount += 1
-        if delegateCallCount <= 5 {
-            NSLog("[AudioCapture] delegate called #%d, type=%d (.screen=0, .audio=1)", delegateCallCount, type.rawValue)
+        // Audio samples must be extracted on the delivery queue before CMSampleBuffer is reclaimed.
+        let audioSamples: [Float]?
+        if type == .audio {
+            let extracted = extractFloatSamples(from: sampleBuffer)
+            guard let extracted, !extracted.isEmpty else { return }
+            audioSamples = extracted
+        } else {
+            audioSamples = nil
         }
-        guard type == .audio else { return }
 
-        let samples = extractFloatSamples(from: sampleBuffer)
-        guard let samples, !samples.isEmpty else { return }
+        controlQueue.async { [weak self] in
+            guard let self else { return }
+            guard let activeStream = self.stream, activeStream === stream,
+                  self.isCapturing, !self.isStoppingCapture else { return }
 
-        sampleCount += 1
+            self.delegateCallCount += 1
+            if self.delegateCallCount <= 5 {
+                NSLog("[AudioCapture] delegate called #%d, type=%d (.screen=0, .audio=1)",
+                      self.delegateCallCount, type.rawValue)
+            }
 
-        // Dispatch system audio to mixer queue
-        mixerQueue.async { [weak self] in
-            self?.handleSystemAudio(samples)
+            guard let samples = audioSamples else { return }
+            self.sampleCount += 1
+            if self.sampleCount <= 3 {
+                NSLog("[AudioCapture] system audio sample #%d, %d frames", self.sampleCount, samples.count)
+            }
+
+            self.mixerQueue.async { [weak self] in
+                self?.handleSystemAudio(samples)
+            }
         }
     }
 
@@ -792,9 +817,15 @@ extension SystemAudioCaptureService: SCStreamOutput {
         }
 
         if captureMicrophone {
-            let appliedSystemGain = systemGain
-            let gained = samples.map { max(-1, min(1, $0 * appliedSystemGain)) }
-            systemBuffer.append(contentsOf: gained)
+            let offset = systemBuffer.count
+            systemBuffer.append(contentsOf: samples)
+            var gain = systemGain
+            var lo: Float = -1.0, hi: Float = 1.0
+            systemBuffer.withUnsafeMutableBufferPointer { ptr in
+                let base = ptr.baseAddress!.advanced(by: offset)
+                vDSP_vsmul(base, 1, &gain, base, 1, vDSP_Length(samples.count))
+                vDSP_vclip(base, 1, &lo, &hi, base, 1, vDSP_Length(samples.count))
+            }
             drainMixedSamples()
             flushStaleBuffer()
         } else {
@@ -823,8 +854,15 @@ extension SystemAudioCaptureService: SCStreamOutput {
             checkSilence(source: .microphone)
         }
 
-        let gained = samples.map { max(-1, min(1, $0 * micGain)) }
-        micBuffer.append(contentsOf: gained)
+        let offset = micBuffer.count
+        micBuffer.append(contentsOf: samples)
+        var gain = micGain
+        var lo: Float = -1.0, hi: Float = 1.0
+        micBuffer.withUnsafeMutableBufferPointer { ptr in
+            let base = ptr.baseAddress!.advanced(by: offset)
+            vDSP_vsmul(base, 1, &gain, base, 1, vDSP_Length(samples.count))
+            vDSP_vclip(base, 1, &lo, &hi, base, 1, vDSP_Length(samples.count))
+        }
         drainMixedSamples()
         flushStaleBuffer()
     }
@@ -835,10 +873,19 @@ extension SystemAudioCaptureService: SCStreamOutput {
         let mixCount = min(systemBuffer.count, micBuffer.count)
         guard mixCount > 0 else { return }
 
-        var mixed = [Float](repeating: 0, count: mixCount)
-        for i in 0 ..< mixCount {
-            mixed[i] = max(-1.0, min(1.0, systemBuffer[i] + micBuffer[i]))
+        if mixScratchBuffer.count < mixCount {
+            mixScratchBuffer = [Float](repeating: 0, count: mixCount)
         }
+        var lo: Float = -1.0, hi: Float = 1.0
+        systemBuffer.withUnsafeBufferPointer { sysPtr in
+            micBuffer.withUnsafeBufferPointer { micPtr in
+                mixScratchBuffer.withUnsafeMutableBufferPointer { mixPtr in
+                    vDSP_vadd(sysPtr.baseAddress!, 1, micPtr.baseAddress!, 1, mixPtr.baseAddress!, 1, vDSP_Length(mixCount))
+                    vDSP_vclip(mixPtr.baseAddress!, 1, &lo, &hi, mixPtr.baseAddress!, 1, vDSP_Length(mixCount))
+                }
+            }
+        }
+        let mixed = Array(mixScratchBuffer.prefix(mixCount))
         systemBuffer.removeFirst(mixCount)
         micBuffer.removeFirst(mixCount)
 
@@ -1024,14 +1071,6 @@ extension SystemAudioCaptureService: SCStreamOutput {
         }
         guard frameCount > 0 else { return nil }
 
-        let currentSampleCount = sampleCount
-        if currentSampleCount <= 3 {
-            Log.audio
-                .info(
-                    "Audio sample \(currentSampleCount): frames=\(frameCount), sampleRate=\(asbd.pointee.mSampleRate), ch=\(channelCount), bits=\(bitsPerChannel), float=\(isFloat)"
-                )
-        }
-
         let rawPointer = UnsafeRawPointer(ptr)
 
         func sample(at offset: Int) -> Float {
@@ -1076,11 +1115,9 @@ extension SystemAudioCaptureService: SCStreamOutput {
 
     private func rms(_ samples: [Float]) -> Float {
         guard !samples.isEmpty else { return 0 }
-        var sum: Float = 0
-        for sample in samples {
-            sum += sample * sample
-        }
-        return sqrt(sum / Float(samples.count))
+        var result: Float = 0
+        vDSP_rmsqv(samples, 1, &result, vDSP_Length(samples.count))
+        return result
     }
 
     private func checkSilence(source: SilenceSource) {

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -26,9 +26,9 @@ final class RecordingsLibraryStorage {
         try? fm.createDirectory(at: appDir, withIntermediateDirectories: true)
         metadataURL = appDir.appendingPathComponent("recordings_metadata.json")
 
-        loadMetadata()
-        pruneOrphaned()
-        pruneExpiredRecordings()
+        Task { @MainActor [weak self] in
+            await self?.loadAndPruneAsync()
+        }
     }
 
     // MARK: - Save (from Data — voice/translation)
@@ -250,43 +250,57 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Persistence
 
-    private func loadMetadata() {
-        guard let data = try? Data(contentsOf: metadataURL) else { return }
-        do {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            recordings = try decoder.decode([Recording].self, from: data)
-        } catch {
-            Log.app.error("Failed to load recordings metadata: \(error.localizedDescription)")
+    private func loadAndPruneAsync() async {
+        let url = metadataURL
+        let recDir = recordingsDir
+        let result = await Task.detached(priority: .utility) { () -> [Recording]? in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                var loaded = try decoder.decode([Recording].self, from: data)
+                // Prune orphans with a single directory scan instead of per-file fileExists
+                if let contents = try? FileManager.default.contentsOfDirectory(
+                    at: recDir, includingPropertiesForKeys: nil
+                ) {
+                    let names = Set(contents.map(\.lastPathComponent))
+                    loaded.removeAll { !names.contains($0.audioFileName) }
+                }
+                return loaded
+            } catch {
+                Log.app.error("Failed to load recordings metadata: \(error.localizedDescription)")
+                return nil
+            }
+        }.value
+        if let result {
+            if recordings.isEmpty {
+                recordings = result
+            } else {
+                // A save landed while we were loading from disk. Don't clobber the
+                // freshly inserted in-memory entries — merge the disk snapshot in,
+                // keeping in-memory (newer) records on id conflicts.
+                let existingIDs = Set(recordings.map(\.id))
+                recordings.append(contentsOf: result.filter { !existingIDs.contains($0.id) })
+            }
+            pruneExpiredRecordings()
         }
     }
 
     private func saveMetadata() {
-        do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(recordings)
-            try data.write(to: metadataURL)
-        } catch {
-            Log.app.error("Failed to save recordings metadata: \(error.localizedDescription)")
+        let snapshot = recordings
+        let url = metadataURL
+        Task.detached(priority: .utility) {
+            do {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(snapshot)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                Log.app.error("Failed to save recordings metadata: \(error.localizedDescription)")
+            }
         }
     }
 
-    private func pruneOrphaned() {
-        let before = recordings.count
-        let recordingsDir = self.recordingsDir
-        let fileManager = self.fileManager
-        recordings.removeAll { recording in
-            let fileURL = recordingsDir.appendingPathComponent(recording.audioFileName)
-            return !fileManager.fileExists(atPath: fileURL.path)
-        }
-        if recordings.count != before {
-            let prunedCount = before - recordings.count
-            Log.app.info("Pruned \(prunedCount) orphaned recording entries")
-            saveMetadata()
-        }
-    }
 
     private func shouldSaveRecording(type: Recording.RecordingType) -> Bool {
         let policy = SettingsStorage.shared.historyRetentionPolicy(for: type)

--- a/Diduny/Features/DictationOverlay/LiveDictationOverlayView.swift
+++ b/Diduny/Features/DictationOverlay/LiveDictationOverlayView.swift
@@ -7,45 +7,40 @@ struct LiveDictationOverlayView: View {
     private static let transcriptBottomID = "transcript-bottom"
 
     var body: some View {
-        TimelineView(.periodic(from: store.startedAt, by: 1)) { timeline in
-            HStack(spacing: 12) {
-                statusIcon
+        HStack(spacing: 12) {
+            OverlayStatusIcon(store: store, statusColor: statusColor, iconName: iconName)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 8) {
-                        Text(store.title)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(store.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
 
-                        Text(store.statusText)
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(statusColor)
-                            .lineLimit(1)
+                    Text(store.statusText)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(statusColor)
+                        .lineLimit(1)
 
-                        Spacer(minLength: 8)
+                    Spacer(minLength: 8)
 
-                        Text(elapsedText(at: timeline.date))
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-
-                    transcriptView
+                    ElapsedTimeLabel(startedAt: store.startedAt)
                 }
 
-                controls
+                transcriptView
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
-            .frame(width: 560, height: 96)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.08))
-            }
-            .shadow(color: .black.opacity(0.18), radius: 20, y: 8)
+
+            controls
         }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(width: 560, height: 96)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.08))
+        }
+        .shadow(color: .black.opacity(0.18), radius: 20, y: 8)
     }
 
     private var displayText: String {
@@ -89,24 +84,6 @@ struct LiveDictationOverlayView: View {
                 proxy.scrollTo(Self.transcriptBottomID, anchor: .bottom)
             }
         }
-    }
-
-    private var statusIcon: some View {
-        ZStack {
-            Circle()
-                .fill(statusColor.opacity(0.14))
-                .frame(width: 38, height: 38)
-
-            if store.phase == .recording {
-                LiveAudioMeter(level: store.audioLevel, color: statusColor)
-                    .frame(width: 26, height: 18)
-            } else {
-                Image(systemName: iconName)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(statusColor)
-            }
-        }
-        .frame(width: 38, height: 38)
     }
 
     private var controls: some View {
@@ -161,12 +138,49 @@ struct LiveDictationOverlayView: View {
             store.mode.icon
         }
     }
+}
+
+// Isolated leaf so only this small view re-evaluates when audioLevel changes (~25/sec).
+private struct OverlayStatusIcon: View {
+    let store: LiveDictationOverlayStore
+    let statusColor: Color
+    let iconName: String
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(statusColor.opacity(0.14))
+                .frame(width: 38, height: 38)
+
+            if store.phase == .recording {
+                LiveAudioMeter(level: store.audioLevel, color: statusColor)
+                    .frame(width: 26, height: 18)
+            } else {
+                Image(systemName: iconName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(statusColor)
+            }
+        }
+        .frame(width: 38, height: 38)
+    }
+}
+
+// Isolated leaf so only this view re-evaluates every second.
+private struct ElapsedTimeLabel: View {
+    let startedAt: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: startedAt, by: 1)) { timeline in
+            Text(elapsedText(at: timeline.date))
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
 
     private func elapsedText(at date: Date) -> String {
-        let elapsed = max(0, Int(date.timeIntervalSince(store.startedAt)))
-        let minutes = elapsed / 60
-        let seconds = elapsed % 60
-        return String(format: "%d:%02d", minutes, seconds)
+        let elapsed = max(0, Int(date.timeIntervalSince(startedAt)))
+        return String(format: "%d:%02d", elapsed / 60, elapsed % 60)
     }
 }
 

--- a/Diduny/Features/MenuBar/MenuBarIconView.swift
+++ b/Diduny/Features/MenuBar/MenuBarIconView.swift
@@ -4,11 +4,16 @@ struct MenuBarIconView: View {
     @Environment(AppState.self) var appState
 
     var body: some View {
-        Image(systemName: iconName)
-            .font(.system(size: 14, weight: .regular))
+        if let iconName = statusIconName {
+            Image(systemName: iconName)
+                .font(.system(size: 14, weight: .regular))
+        } else {
+            Image("MenuBarIcon")
+                .renderingMode(.original)
+        }
     }
 
-    private var iconName: String {
+    private var statusIconName: String? {
         // Meeting translation takes priority
         if appState.meetingTranslationRecordingState == .recording { return "globe" }
         if appState.meetingTranslationRecordingState == .processing { return "waveform" }
@@ -34,7 +39,7 @@ struct MenuBarIconView: View {
             } else if appState.meetingTranslationRecordingState == .error || appState.meetingRecordingState == .error {
                 return "xmark"
             }
-            return "mic"
+            return nil
         case .recording: return "waveform.badge.mic"
         case .processing: return "waveform"
         case .success: return "checkmark"

--- a/Diduny/Features/Notch/NotchContentView.swift
+++ b/Diduny/Features/Notch/NotchContentView.swift
@@ -11,7 +11,7 @@ struct NotchCompactLeadingView: View {
             case let .recording(mode):
                 HStack(spacing: 6) {
                     RecordingCompactView(mode: mode)
-                    AudioLevelView(level: manager.audioLevel)
+                    NotchAudioMeterView(manager: manager)
                 }
 
             case let .processing(mode):
@@ -137,6 +137,15 @@ private struct PulsingDotView: View {
                     isPulsing = true
                 }
             }
+    }
+}
+
+// Isolated leaf so only this view re-evaluates when audioLevel changes (~25/sec).
+private struct NotchAudioMeterView: View {
+    var manager: NotchManager
+
+    var body: some View {
+        AudioLevelView(level: manager.audioLevel)
     }
 }
 

--- a/Diduny/Features/Notch/NotchManager.swift
+++ b/Diduny/Features/Notch/NotchManager.swift
@@ -22,7 +22,7 @@ enum RecordingMode: Equatable {
     var label: String {
         switch self {
         case .voice: "Recording..."
-        case let .translation(pair): "Recording (\(pair))..."
+        case let .translation(targetLanguage): "Recording -> \(targetLanguage)..."
         case .meeting: "Meeting Recording..."
         case .meetingTranslation: "Meeting Translation..."
         case .fileTranscription: "Transcribing File..."

--- a/Diduny/Features/Settings/ShortcutsSettingsView.swift
+++ b/Diduny/Features/Settings/ShortcutsSettingsView.swift
@@ -16,210 +16,311 @@ struct ShortcutsSettingsView: View {
         SettingsStorage.shared.translationPushToTalkHoldStartDelaySeconds
     @State private var recordingHotkeyPressCount = SettingsStorage.shared.recordingHotkeyPressCount
     @State private var translationHotkeyPressCount = SettingsStorage.shared.translationHotkeyPressCount
+    @State private var meetingHotkeyPressCount = SettingsStorage.shared.meetingHotkeyPressCount
+    @State private var meetingTranslationHotkeyPressCount = SettingsStorage.shared.meetingTranslationHotkeyPressCount
     @State private var translateSelectedTextHotkeyPressCount = SettingsStorage.shared.translateSelectedTextHotkeyPressCount
     @State private var escapeCancelEnabled = SettingsStorage.shared.escapeCancelEnabled
     @State private var escapeCancelPressCount = SettingsStorage.shared.escapeCancelPressCount
     @State private var escapeCancelSaveAudio = SettingsStorage.shared.escapeCancelSaveAudio
+    @State private var shortcutDisplayRefresh = 0
 
     private let hotkeyPressCountOptions = [1, 2, 3]
     private let toggleTapCountOptions = [2, 3]
     private let escapePressCountOptions = [2, 3]
 
     var body: some View {
-        Form {
-            Section("Action Hotkeys") {
-                hotkeyRow(
-                    title: "Dictation:",
-                    shortcut: .toggleRecording,
-                    pressCount: $recordingHotkeyPressCount,
-                    store: { SettingsStorage.shared.recordingHotkeyPressCount = $0 }
-                )
+        ZStack(alignment: .topLeading) {
+            ShortcutStyle.windowBackground
+                .ignoresSafeArea()
 
-                hotkeyRow(
-                    title: "Translation:",
-                    shortcut: .toggleTranslation,
-                    pressCount: $translationHotkeyPressCount,
-                    store: { SettingsStorage.shared.translationHotkeyPressCount = $0 }
-                )
+            VStack(alignment: .leading, spacing: 0) {
+                header
 
-                hotkeyRow(
-                    title: "Translate Selected Text:",
-                    shortcut: .translateSelectedText,
-                    pressCount: $translateSelectedTextHotkeyPressCount,
-                    store: { SettingsStorage.shared.translateSelectedTextHotkeyPressCount = $0 }
-                )
+                Spacer()
+                    .frame(height: 10)
 
-                betaHotkeyRow(title: "Meeting:", shortcutLabel: "Beta")
-                betaHotkeyRow(title: "Meeting Translation:", shortcutLabel: "Beta")
+                sectionTitle("ACTION HOTKEYS")
+
+                Spacer()
+                    .frame(height: 10)
+
+                actionHotkeysCard
+
+                Spacer()
+                    .frame(height: 10)
+
+                sectionTitle("MODIFIER KEY RECORDING")
+
+                Spacer()
+                    .frame(height: 10)
+
+                modifierKeyRecordingCard
+
+                Spacer()
+                    .frame(height: 10)
+
+                sectionTitle("CANCEL RECORDING")
+
+                Spacer()
+                    .frame(height: 10)
+
+                cancelRecordingCard
             }
-
-            Section("Modifier Key Recording") {
-                modifierKeyRow(
-                    title: "Dictation:",
-                    key: $pushToTalkKey,
-                    holdEnabled: $pushToTalkHoldEnabled,
-                    toggleEnabled: $pushToTalkToggleEnabled,
-                    tapCount: $pushToTalkTapCount,
-                    holdStartDelay: $pushToTalkHoldStartDelay,
-                    keyStore: {
-                        SettingsStorage.shared.pushToTalkKey = $0
-                        NotificationCenter.default.post(name: .pushToTalkKeyChanged, object: $0)
-                    },
-                    holdEnabledStore: {
-                        SettingsStorage.shared.pushToTalkHoldEnabled = $0
-                        NotificationCenter.default.post(name: .pushToTalkModeChanged, object: nil)
-                    },
-                    toggleEnabledStore: {
-                        SettingsStorage.shared.pushToTalkToggleEnabled = $0
-                        NotificationCenter.default.post(name: .pushToTalkModeChanged, object: nil)
-                    },
-                    tapCountStore: {
-                        SettingsStorage.shared.pushToTalkToggleTapCount = $0
-                        NotificationCenter.default.post(name: .pushToTalkTapCountChanged, object: $0)
-                    },
-                    holdStartDelayStore: {
-                        SettingsStorage.shared.pushToTalkHoldStartDelaySeconds = $0
-                        NotificationCenter.default.post(name: .pushToTalkHoldStartDelayChanged, object: $0)
-                    }
-                )
-
-                modifierKeyRow(
-                    title: "Translation:",
-                    key: $translationPushToTalkKey,
-                    holdEnabled: $translationPushToTalkHoldEnabled,
-                    toggleEnabled: $translationPushToTalkToggleEnabled,
-                    tapCount: $translationPushToTalkTapCount,
-                    holdStartDelay: $translationPushToTalkHoldStartDelay,
-                    keyStore: {
-                        SettingsStorage.shared.translationPushToTalkKey = $0
-                        NotificationCenter.default.post(name: .translationPushToTalkKeyChanged, object: $0)
-                    },
-                    holdEnabledStore: {
-                        SettingsStorage.shared.translationPushToTalkHoldEnabled = $0
-                        NotificationCenter.default.post(name: .translationPushToTalkModeChanged, object: nil)
-                    },
-                    toggleEnabledStore: {
-                        SettingsStorage.shared.translationPushToTalkToggleEnabled = $0
-                        NotificationCenter.default.post(name: .translationPushToTalkModeChanged, object: nil)
-                    },
-                    tapCountStore: {
-                        SettingsStorage.shared.translationPushToTalkToggleTapCount = $0
-                        NotificationCenter.default.post(name: .translationPushToTalkTapCountChanged, object: $0)
-                    },
-                    holdStartDelayStore: {
-                        SettingsStorage.shared.translationPushToTalkHoldStartDelaySeconds = $0
-                        NotificationCenter.default.post(name: .translationPushToTalkHoldStartDelayChanged, object: $0)
-                    }
-                )
-            }
-
-            Section("Cancel Recording") {
-                HStack(alignment: .center) {
-                    Text("Shortcut:")
-                        .frame(width: 160, alignment: .leading)
-
-                    Picker("Cancel Shortcut", selection: $escapeCancelEnabled) {
-                        Text("None").tag(false)
-                        Text("Esc").tag(true)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 160)
-
-                    Spacer(minLength: 12)
-
-                    pressCountPicker(
-                        title: "Cancel after",
-                        selection: $escapeCancelPressCount,
-                        options: escapePressCountOptions
-                    )
-                    .disabled(!escapeCancelEnabled)
-                    .opacity(escapeCancelEnabled ? 1.0 : 0.45)
-                }
-                .onChange(of: escapeCancelEnabled) { _, newValue in
-                    SettingsStorage.shared.escapeCancelEnabled = newValue
-                    if !newValue {
-                        EscapeCancelService.shared.deactivate()
-                    }
-                }
-                .onChange(of: escapeCancelPressCount) { _, newValue in
-                    SettingsStorage.shared.escapeCancelPressCount = newValue
-                }
-
-                Toggle("Save audio when cancelled", isOn: $escapeCancelSaveAudio)
-                    .disabled(!escapeCancelEnabled)
-                    .opacity(escapeCancelEnabled ? 1.0 : 0.45)
-                    .onChange(of: escapeCancelSaveAudio) { _, newValue in
-                        SettingsStorage.shared.escapeCancelSaveAudio = newValue
-                    }
-
-                Text(
-                    escapeCancelEnabled
-                        ? "Press Esc \(escapeCancelPressCount)x during recording to cancel."
-                        : "Disable Escape cancellation completely."
-                )
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
+            .frame(width: ShortcutLayout.contentWidth, alignment: .topLeading)
+            .padding(.leading, ShortcutLayout.contentLeading)
+            .padding(.top, ShortcutLayout.contentTop)
         }
-        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
-    // MARK: - Rows
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Text("Shortcuts")
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(ShortcutStyle.primaryText)
 
-    @ViewBuilder
-    private func hotkeyRow(
+            Spacer()
+
+            Text("Editable")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(ShortcutStyle.accent)
+                .padding(.horizontal, 10)
+                .frame(height: 24)
+                .background(ShortcutStyle.accentSoft, in: Capsule())
+                .overlay {
+                    Capsule()
+                        .stroke(ShortcutStyle.accentBorder, lineWidth: 1)
+                }
+        }
+        .frame(width: ShortcutLayout.contentWidth, height: 30)
+    }
+
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(ShortcutStyle.tertiaryText)
+            .frame(width: ShortcutLayout.contentWidth, height: 13, alignment: .leading)
+    }
+
+    // MARK: - Action Hotkeys
+
+    private var actionHotkeysCard: some View {
+        settingsCard {
+            actionHeader
+            divider
+
+            actionHotkeyRow(
+                title: "Dictation",
+                shortcut: .toggleRecording,
+                pressCount: $recordingHotkeyPressCount,
+                store: { SettingsStorage.shared.recordingHotkeyPressCount = $0 }
+            )
+            divider
+
+            actionHotkeyRow(
+                title: "Translation",
+                shortcut: .toggleTranslation,
+                pressCount: $translationHotkeyPressCount,
+                store: { SettingsStorage.shared.translationHotkeyPressCount = $0 }
+            )
+            divider
+
+            actionHotkeyRow(
+                title: "Translate Selected Text",
+                shortcut: .translateSelectedText,
+                pressCount: $translateSelectedTextHotkeyPressCount,
+                store: { SettingsStorage.shared.translateSelectedTextHotkeyPressCount = $0 }
+            )
+            divider
+
+            actionHotkeyRow(
+                title: "Meeting",
+                shortcut: .toggleMeetingRecording,
+                pressCount: $meetingHotkeyPressCount,
+                store: { SettingsStorage.shared.meetingHotkeyPressCount = $0 }
+            )
+            divider
+
+            actionHotkeyRow(
+                title: "Meeting Translation",
+                shortcut: .toggleMeetingTranslation,
+                pressCount: $meetingTranslationHotkeyPressCount,
+                store: { SettingsStorage.shared.meetingTranslationHotkeyPressCount = $0 }
+            )
+        }
+    }
+
+    private var actionHeader: some View {
+        HStack(spacing: 0) {
+            headerCell("Action", width: ShortcutLayout.actionTitleColumn)
+            headerCell("Shortcut", width: ShortcutLayout.actionShortcutColumn)
+            headerCell("Trigger after", width: ShortcutLayout.actionTriggerColumn)
+            Spacer(minLength: 0)
+        }
+        .frame(height: 30)
+    }
+
+    private func actionHotkeyRow(
         title: String,
         shortcut: KeyboardShortcuts.Name,
         pressCount: Binding<Int>,
         store: @escaping (Int) -> Void
     ) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center) {
-                Text(title)
-                    .frame(width: 160, alignment: .leading)
-                KeyboardShortcuts.Recorder(for: shortcut)
-                Spacer(minLength: 12)
-                pressCountPicker(
-                    title: "Trigger after",
-                    selection: pressCount,
-                    options: hotkeyPressCountOptions
-                )
-            }
+        HStack(spacing: 0) {
+            rowTitle(title, width: ShortcutLayout.actionTitleColumn)
 
-            Text("Trigger this shortcut after \(pressCount.wrappedValue)x press\(pressCount.wrappedValue == 1 ? "" : "es").")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .padding(.leading, 160)
+            shortcutRecorderField(for: shortcut)
+                .frame(width: ShortcutLayout.actionShortcutColumn, alignment: .leading)
+
+            countSegmentedPicker(
+                selection: pressCount,
+                options: hotkeyPressCountOptions,
+                width: ShortcutLayout.actionTriggerWidth
+            )
+            .frame(width: ShortcutLayout.actionTriggerColumn, alignment: .leading)
+
+            Spacer(minLength: 0)
         }
+        .frame(height: 48)
         .onChange(of: pressCount.wrappedValue) { _, newValue in
             store(newValue)
         }
     }
 
-    @ViewBuilder
-    private func betaHotkeyRow(title: String, shortcutLabel: String) -> some View {
-        HStack(alignment: .center) {
-            Text(title)
-                .frame(width: 160, alignment: .leading)
+    private func shortcutRecorderField(for shortcut: KeyboardShortcuts.Name) -> some View {
+        let tokens = shortcutTokens(for: shortcut, refresh: shortcutDisplayRefresh)
 
-            Text(shortcutLabel)
-                .font(.caption.weight(.semibold))
-                .foregroundColor(.secondary)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 3)
-                .background(Color(.quaternaryLabelColor).opacity(0.14), in: Capsule())
+        return ZStack(alignment: .leading) {
+            HStack(spacing: 6) {
+                if tokens.isEmpty {
+                    Text("record shortcut")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(ShortcutStyle.secondaryText)
+                } else {
+                    ForEach(Array(tokens.enumerated()), id: \.offset) { _, token in
+                        keycap(token)
+                    }
+                }
 
-            Spacer()
+                Spacer(minLength: 8)
 
-            Text("Available in Recordings while Meetings is in beta.")
-                .font(.caption)
-                .foregroundColor(.secondary)
+                Text("edit")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(ShortcutStyle.accent)
+            }
+            .padding(.horizontal, 10)
+            .frame(width: ShortcutLayout.shortcutInputWidth, height: 32)
+            .background(ShortcutStyle.inputBackground, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(ShortcutStyle.inputBorder, lineWidth: 1)
+            }
+
+            KeyboardShortcuts.Recorder(for: shortcut) { _ in
+                shortcutDisplayRefresh += 1
+            }
+                .frame(width: ShortcutLayout.shortcutInputWidth, height: 32)
+                .opacity(0.01)
         }
-        .opacity(0.65)
+        .frame(width: ShortcutLayout.shortcutInputWidth, height: 32, alignment: .leading)
     }
 
-    @ViewBuilder
+    private func shortcutTokens(for shortcut: KeyboardShortcuts.Name, refresh: Int) -> [String] {
+        _ = refresh
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: shortcut) else { return [] }
+        return Array(String(describing: shortcut)).map(String.init)
+    }
+
+    private func keycap(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: 12, weight: .medium, design: .monospaced))
+            .foregroundStyle(ShortcutStyle.primaryText)
+            .frame(minWidth: 24, minHeight: 22)
+            .background(ShortcutStyle.keycapBackground, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(ShortcutStyle.keycapBorder, lineWidth: 1)
+            }
+    }
+
+    // MARK: - Modifier Key Recording
+
+    private var modifierKeyRecordingCard: some View {
+        settingsCard {
+            modifierHeader
+            divider
+
+            modifierKeyRow(
+                title: "Dictation",
+                key: $pushToTalkKey,
+                holdEnabled: $pushToTalkHoldEnabled,
+                toggleEnabled: $pushToTalkToggleEnabled,
+                tapCount: $pushToTalkTapCount,
+                holdStartDelay: $pushToTalkHoldStartDelay,
+                keyStore: {
+                    SettingsStorage.shared.pushToTalkKey = $0
+                    NotificationCenter.default.post(name: .pushToTalkKeyChanged, object: $0)
+                },
+                holdEnabledStore: {
+                    SettingsStorage.shared.pushToTalkHoldEnabled = $0
+                    NotificationCenter.default.post(name: .pushToTalkModeChanged, object: nil)
+                },
+                toggleEnabledStore: {
+                    SettingsStorage.shared.pushToTalkToggleEnabled = $0
+                    NotificationCenter.default.post(name: .pushToTalkModeChanged, object: nil)
+                },
+                tapCountStore: {
+                    SettingsStorage.shared.pushToTalkToggleTapCount = $0
+                    NotificationCenter.default.post(name: .pushToTalkTapCountChanged, object: $0)
+                },
+                holdStartDelayStore: {
+                    SettingsStorage.shared.pushToTalkHoldStartDelaySeconds = $0
+                    NotificationCenter.default.post(name: .pushToTalkHoldStartDelayChanged, object: $0)
+                }
+            )
+            divider
+
+            modifierKeyRow(
+                title: "Translation",
+                key: $translationPushToTalkKey,
+                holdEnabled: $translationPushToTalkHoldEnabled,
+                toggleEnabled: $translationPushToTalkToggleEnabled,
+                tapCount: $translationPushToTalkTapCount,
+                holdStartDelay: $translationPushToTalkHoldStartDelay,
+                keyStore: {
+                    SettingsStorage.shared.translationPushToTalkKey = $0
+                    NotificationCenter.default.post(name: .translationPushToTalkKeyChanged, object: $0)
+                },
+                holdEnabledStore: {
+                    SettingsStorage.shared.translationPushToTalkHoldEnabled = $0
+                    NotificationCenter.default.post(name: .translationPushToTalkModeChanged, object: nil)
+                },
+                toggleEnabledStore: {
+                    SettingsStorage.shared.translationPushToTalkToggleEnabled = $0
+                    NotificationCenter.default.post(name: .translationPushToTalkModeChanged, object: nil)
+                },
+                tapCountStore: {
+                    SettingsStorage.shared.translationPushToTalkToggleTapCount = $0
+                    NotificationCenter.default.post(name: .translationPushToTalkTapCountChanged, object: $0)
+                },
+                holdStartDelayStore: {
+                    SettingsStorage.shared.translationPushToTalkHoldStartDelaySeconds = $0
+                    NotificationCenter.default.post(name: .translationPushToTalkHoldStartDelayChanged, object: $0)
+                }
+            )
+        }
+    }
+
+    private var modifierHeader: some View {
+        HStack(spacing: 0) {
+            headerCell("Action", width: ShortcutLayout.modifierTitleColumn)
+            headerCell("Modifier key", width: ShortcutLayout.modifierKeyColumn)
+            headerCell("Tap trigger", width: ShortcutLayout.modifierTapColumn)
+            headerCell("Hold key + delay", width: ShortcutLayout.modifierHoldColumn)
+        }
+        .frame(height: 30)
+    }
+
     private func modifierKeyRow(
         title: String,
         key: Binding<PushToTalkKey>,
@@ -233,63 +334,27 @@ struct ShortcutsSettingsView: View {
         tapCountStore: @escaping (Int) -> Void,
         holdStartDelayStore: @escaping (TimeInterval) -> Void
     ) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center) {
-                Text(title)
-                    .frame(width: 160, alignment: .leading)
+        HStack(spacing: 0) {
+            rowTitle(title, width: ShortcutLayout.modifierTitleColumn)
 
-                Picker(title, selection: key) {
-                    ForEach(PushToTalkKey.allCases) { option in
-                        Text(option.pickerLabel).tag(option)
-                    }
-                }
-                .labelsHidden()
+            modifierKeyMenu(selection: key)
+                .frame(width: ShortcutLayout.modifierKeyColumn, alignment: .leading)
 
-                Spacer(minLength: 12)
-            }
+            tapTriggerPicker(
+                toggleEnabled: toggleEnabled,
+                tapCount: tapCount,
+                isDisabled: key.wrappedValue == .none
+            )
+            .frame(width: ShortcutLayout.modifierTapColumn, alignment: .leading)
 
-            HStack(alignment: .center, spacing: 12) {
-                Spacer()
-                    .frame(width: 160)
-
-                Toggle("Hold to talk", isOn: holdEnabled)
-                    .disabled(key.wrappedValue == .none)
-
-                holdDelaySlider(
-                    title: "Start after",
-                    selection: holdStartDelay
-                )
-                .disabled(key.wrappedValue == .none || !holdEnabled.wrappedValue)
-                .opacity(key.wrappedValue == .none || !holdEnabled.wrappedValue ? 0.45 : 1.0)
-            }
-
-            HStack(alignment: .center, spacing: 12) {
-                Spacer()
-                    .frame(width: 160)
-
-                Toggle("Toggle mode", isOn: toggleEnabled)
-                    .disabled(key.wrappedValue == .none)
-
-                pressCountPicker(
-                    title: "Toggle after",
-                    selection: tapCount,
-                    options: toggleTapCountOptions
-                )
-                .disabled(key.wrappedValue == .none || !toggleEnabled.wrappedValue)
-                .opacity(key.wrappedValue == .none || !toggleEnabled.wrappedValue ? 0.45 : 1.0)
-            }
-
-            Text(modifierSummary(
+            holdTriggerCard(
                 key: key.wrappedValue,
-                holdEnabled: holdEnabled.wrappedValue,
-                toggleEnabled: toggleEnabled.wrappedValue,
-                tapCount: tapCount.wrappedValue,
-                holdStartDelay: holdStartDelay.wrappedValue
-            ))
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .padding(.leading, 160)
+                isEnabled: holdEnabled,
+                holdStartDelay: holdStartDelay
+            )
+            .frame(width: ShortcutLayout.modifierHoldColumn, alignment: .leading)
         }
+        .frame(height: 77)
         .onChange(of: key.wrappedValue) { _, newValue in
             keyStore(newValue)
         }
@@ -307,66 +372,446 @@ struct ShortcutsSettingsView: View {
         }
     }
 
-    private func pressCountPicker(title: String, selection: Binding<Int>, options: [Int]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.caption)
-                .foregroundColor(.secondary)
-
-            Picker(title, selection: selection) {
-                ForEach(options, id: \.self) { count in
-                    Text("\(count)x").tag(count)
+    private func modifierKeyMenu(selection: Binding<PushToTalkKey>) -> some View {
+        Menu {
+            ForEach(PushToTalkKey.allCases) { option in
+                Button(option.pickerLabel) {
+                    selection.wrappedValue = option
                 }
             }
-            .labelsHidden()
-            .pickerStyle(.segmented)
-        }
-        .frame(width: 150, alignment: .leading)
-    }
-
-    private func holdDelaySlider(title: String, selection: Binding<TimeInterval>) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.caption)
-                .foregroundColor(.secondary)
-
+        } label: {
             HStack(spacing: 8) {
-                Slider(value: selection, in: 0.5...2.0, step: 0.1)
-                    .accessibilityLabel("Start recording after hold duration")
-                    .accessibilityValue(formattedHoldDelay(selection.wrappedValue))
+                Text(selection.wrappedValue.displayName)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(ShortcutStyle.primaryText)
+                    .lineLimit(1)
 
-                Text(formattedHoldDelay(selection.wrappedValue))
-                    .monospacedDigit()
-                    .frame(width: 42, alignment: .leading)
+                Spacer(minLength: 4)
+
+                Text("⌄")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(ShortcutStyle.secondaryText)
+            }
+            .padding(.horizontal, 10)
+            .frame(width: 136, height: 30)
+            .background(ShortcutStyle.inputBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(ShortcutStyle.inputBorder, lineWidth: 1)
             }
         }
-        .frame(width: 190, alignment: .leading)
+        .buttonStyle(.plain)
+    }
+
+    private func tapTriggerPicker(
+        toggleEnabled: Binding<Bool>,
+        tapCount: Binding<Int>,
+        isDisabled: Bool
+    ) -> some View {
+        countSegmentedPicker(
+            selection: tapTriggerSelection(toggleEnabled: toggleEnabled, tapCount: tapCount),
+            options: [0, 2, 3],
+            width: 154,
+            label: { $0 == 0 ? "Off" : "\($0)x" }
+        )
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.45 : 1.0)
+    }
+
+    private func tapTriggerSelection(toggleEnabled: Binding<Bool>, tapCount: Binding<Int>) -> Binding<Int> {
+        Binding<Int>(
+            get: {
+                guard toggleEnabled.wrappedValue else { return 0 }
+                return toggleTapCountOptions.contains(tapCount.wrappedValue) ? tapCount.wrappedValue : 3
+            },
+            set: { newValue in
+                guard newValue != 0 else {
+                    toggleEnabled.wrappedValue = false
+                    return
+                }
+
+                tapCount.wrappedValue = newValue
+                toggleEnabled.wrappedValue = true
+            }
+        )
+    }
+
+    private func holdTriggerCard(
+        key: PushToTalkKey,
+        isEnabled: Binding<Bool>,
+        holdStartDelay: Binding<TimeInterval>
+    ) -> some View {
+        let isAvailable = key != .none
+        let isActive = isAvailable && isEnabled.wrappedValue
+
+        return VStack(alignment: .leading, spacing: 7) {
+            Button {
+                guard isAvailable else { return }
+                isEnabled.wrappedValue.toggle()
+            } label: {
+                HStack(spacing: 8) {
+                    checkmarkBadge(isActive: isActive)
+
+                    Text(holdTriggerTitle(key: key))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(ShortcutStyle.primaryText)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 6)
+
+                    Text(isActive ? formattedHoldDelay(holdStartDelay.wrappedValue) : "—")
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(isActive ? ShortcutStyle.accentSoftText : ShortcutStyle.secondaryText)
+                }
+                .frame(width: 198, height: 20)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isAvailable)
+            .accessibilityLabel(holdTriggerAccessibilityLabel(key: key, isActive: isActive))
+
+            holdDelaySlider(selection: holdStartDelay, isEnabled: isActive)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .frame(width: 218, height: 64, alignment: .topLeading)
+        .background(
+            holdTriggerBackground(isActive: isActive),
+            in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(holdTriggerBorder(isActive: isActive), lineWidth: 1)
+        }
+        .opacity(isAvailable ? 1.0 : 0.45)
+    }
+
+    private func checkmarkBadge(isActive: Bool) -> some View {
+        ZStack {
+            Circle()
+                .fill(isActive ? ShortcutStyle.accent : .clear)
+                .overlay {
+                    Circle()
+                        .stroke(isActive ? ShortcutStyle.accent : ShortcutStyle.secondaryText.opacity(0.45), lineWidth: 1)
+                }
+
+            if isActive {
+                Text("✓")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .offset(y: -0.5)
+            }
+        }
+        .frame(width: 18, height: 18)
+    }
+
+    private func holdDelaySlider(selection: Binding<TimeInterval>, isEnabled: Bool) -> some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let progress = holdDelayProgress(selection.wrappedValue)
+            let progressWidth = max(8, width * progress)
+            let knobSize: CGFloat = 16
+            let knobOffsetX = min(max(progressWidth - knobSize / 2, 0), width - knobSize)
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(ShortcutStyle.sliderTrack)
+                    .frame(height: 4)
+
+                Capsule()
+                    .fill(isEnabled ? ShortcutStyle.accent : ShortcutStyle.secondaryText.opacity(0.3))
+                    .frame(width: progressWidth, height: 4)
+
+                Circle()
+                    .fill(isEnabled ? ShortcutStyle.accent : ShortcutStyle.secondaryText.opacity(0.5))
+                    .frame(width: knobSize, height: knobSize)
+                    .overlay {
+                        Circle()
+                            .stroke(Color.white.opacity(0.5), lineWidth: 1)
+                    }
+                    .offset(x: knobOffsetX)
+            }
+            .frame(width: width, height: 18, alignment: .center)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        guard isEnabled else { return }
+                        selection.wrappedValue = holdDelayValue(at: value.location.x, width: width)
+                    }
+            )
+        }
+        .frame(width: 198, height: 18)
+    }
+
+    private func holdDelayProgress(_ value: TimeInterval) -> CGFloat {
+        CGFloat((min(max(value, 0.5), 2.0) - 0.5) / 1.5)
+    }
+
+    private func holdDelayValue(at x: CGFloat, width: CGFloat) -> TimeInterval {
+        guard width > 0 else { return 0.5 }
+        let progress = min(max(x / width, 0), 1)
+        let rawValue = 0.5 + TimeInterval(progress) * 1.5
+        return (rawValue * 10).rounded() / 10
+    }
+
+    // MARK: - Cancel Recording
+
+    private var cancelRecordingCard: some View {
+        settingsCard {
+            HStack(spacing: 0) {
+                rowTitle("Cancel Recording", width: ShortcutLayout.cancelTitleColumn)
+
+                booleanSegmentedPicker(
+                    selection: $escapeCancelEnabled,
+                    falseLabel: "None",
+                    trueLabel: "Esc",
+                    width: 150
+                )
+                .frame(width: ShortcutLayout.cancelKeyColumn, alignment: .leading)
+
+                countSegmentedPicker(
+                    selection: $escapeCancelPressCount,
+                    options: escapePressCountOptions,
+                    width: 104
+                )
+                .disabled(!escapeCancelEnabled)
+                .opacity(escapeCancelEnabled ? 1.0 : 0.45)
+                .frame(width: ShortcutLayout.cancelTriggerColumn, alignment: .leading)
+
+                saveAudioControl
+                    .frame(width: ShortcutLayout.cancelSaveAudioColumn, alignment: .leading)
+
+                Spacer(minLength: 0)
+            }
+            .frame(height: 50)
+        }
+        .onChange(of: escapeCancelEnabled) { _, newValue in
+            SettingsStorage.shared.escapeCancelEnabled = newValue
+            if !newValue {
+                EscapeCancelService.shared.deactivate()
+            }
+        }
+        .onChange(of: escapeCancelPressCount) { _, newValue in
+            SettingsStorage.shared.escapeCancelPressCount = newValue
+        }
+        .onChange(of: escapeCancelSaveAudio) { _, newValue in
+            SettingsStorage.shared.escapeCancelSaveAudio = newValue
+        }
+    }
+
+    private var saveAudioControl: some View {
+        Button {
+            guard escapeCancelEnabled else { return }
+            escapeCancelSaveAudio.toggle()
+        } label: {
+            HStack(spacing: 8) {
+                ZStack(alignment: escapeCancelSaveAudio ? .trailing : .leading) {
+                    Capsule()
+                        .fill(escapeCancelSaveAudio ? ShortcutStyle.accent : ShortcutStyle.segmentBackground)
+                        .frame(width: 34, height: 20)
+
+                    Circle()
+                        .fill(.white)
+                        .frame(width: 14, height: 14)
+                        .padding(.horizontal, 3)
+                }
+                .frame(width: 34, height: 20)
+
+                Text("Save audio")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(ShortcutStyle.secondaryText)
+            }
+            .frame(height: 28)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!escapeCancelEnabled)
+        .opacity(escapeCancelEnabled ? 1.0 : 0.45)
+    }
+
+    // MARK: - Shared Controls
+
+    private func settingsCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) {
+            content()
+        }
+        .frame(width: ShortcutLayout.contentWidth)
+        .background(ShortcutStyle.cardBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(ShortcutStyle.separator, lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(ShortcutStyle.separator)
+            .frame(width: ShortcutLayout.contentWidth, height: 1)
+    }
+
+    private func headerCell(_ title: String, width: CGFloat) -> some View {
+        Text(title)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(ShortcutStyle.tertiaryText)
+            .frame(width: width, height: 30, alignment: .leading)
+            .padding(.leading, 14)
+    }
+
+    private func rowTitle(_ title: String, width: CGFloat) -> some View {
+        Text(title)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(ShortcutStyle.primaryText)
+            .lineLimit(1)
+            .frame(width: width, alignment: .leading)
+            .padding(.leading, 14)
+    }
+
+    private func countSegmentedPicker(
+        selection: Binding<Int>,
+        options: [Int],
+        width: CGFloat,
+        label: @escaping (Int) -> String = { "\($0)x" }
+    ) -> some View {
+        HStack(spacing: 0) {
+            ForEach(options, id: \.self) { option in
+                segmentButton(
+                    title: label(option),
+                    isSelected: selection.wrappedValue == option,
+                    width: width / CGFloat(options.count)
+                ) {
+                    selection.wrappedValue = option
+                }
+            }
+        }
+        .padding(2)
+        .frame(width: width, height: 28)
+        .background(ShortcutStyle.segmentBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(ShortcutStyle.inputBorder, lineWidth: 1)
+        }
+    }
+
+    private func booleanSegmentedPicker(
+        selection: Binding<Bool>,
+        falseLabel: String,
+        trueLabel: String,
+        width: CGFloat
+    ) -> some View {
+        HStack(spacing: 0) {
+            segmentButton(title: falseLabel, isSelected: !selection.wrappedValue, width: width / 2) {
+                selection.wrappedValue = false
+            }
+
+            segmentButton(title: trueLabel, isSelected: selection.wrappedValue, width: width / 2) {
+                selection.wrappedValue = true
+            }
+        }
+        .padding(2)
+        .frame(width: width, height: 28)
+        .background(ShortcutStyle.segmentBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(ShortcutStyle.inputBorder, lineWidth: 1)
+        }
+    }
+
+    private func segmentButton(
+        title: String,
+        isSelected: Bool,
+        width: CGFloat,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isSelected ? Color.white : ShortcutStyle.secondaryText)
+                .frame(width: width - 4, height: 24)
+                .background(
+                    isSelected ? ShortcutStyle.accent : Color.clear,
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     private func formattedHoldDelay(_ value: TimeInterval) -> String {
         String(format: "%.1f s", value)
     }
 
-    private func modifierSummary(
-        key: PushToTalkKey,
-        holdEnabled: Bool,
-        toggleEnabled: Bool,
-        tapCount: Int,
-        holdStartDelay: TimeInterval
-    ) -> String {
-        guard key != .none else {
-            return "Choose a modifier key to enable hold-to-talk or multi-tap toggle."
-        }
-        switch (holdEnabled, toggleEnabled) {
-        case (true, true):
-            return "Hold starts after \(formattedHoldDelay(holdStartDelay)); \(tapCount)x quick presses toggles hands-free recording."
-        case (true, false):
-            return "Hold starts after \(formattedHoldDelay(holdStartDelay)). Shorter presses are ignored."
-        case (false, true):
-            return "\(tapCount)x quick presses toggles recording. Single presses are ignored."
-        case (false, false):
-            return "Modifier key is selected but inactive until at least one mode is enabled."
-        }
+    private func holdTriggerTitle(key: PushToTalkKey) -> String {
+        guard key != .none else { return "Choose modifier key" }
+        return "Hold \(key.displayName)"
+    }
+
+    private func holdTriggerAccessibilityLabel(key: PushToTalkKey, isActive: Bool) -> String {
+        guard key != .none else { return "Choose a modifier key before enabling hold trigger" }
+        return isActive ? "Disable hold trigger for \(key.displayName)" : "Enable hold trigger for \(key.displayName)"
+    }
+
+    private func holdTriggerBackground(isActive: Bool) -> Color {
+        isActive ? ShortcutStyle.holdActiveBackground : ShortcutStyle.inputBackground
+    }
+
+    private func holdTriggerBorder(isActive: Bool) -> Color {
+        isActive ? ShortcutStyle.accent.opacity(0.72) : ShortcutStyle.inputBorder
+    }
+}
+
+private enum ShortcutLayout {
+    static let contentWidth: CGFloat = 715
+    static let contentLeading: CGFloat = 22
+    static let contentTop: CGFloat = 6
+
+    static let actionTitleColumn: CGFloat = 216
+    static let actionShortcutColumn: CGFloat = 236
+    static let actionTriggerColumn: CGFloat = 150
+    static let actionTriggerWidth: CGFloat = 150
+    static let shortcutInputWidth: CGFloat = 224
+
+    static let modifierTitleColumn: CGFloat = 162
+    static let modifierKeyColumn: CGFloat = 146
+    static let modifierTapColumn: CGFloat = 164
+    static let modifierHoldColumn: CGFloat = 243
+
+    static let cancelTitleColumn: CGFloat = 216
+    static let cancelKeyColumn: CGFloat = 162
+    static let cancelTriggerColumn: CGFloat = 116
+    static let cancelSaveAudioColumn: CGFloat = 160
+}
+
+private enum ShortcutStyle {
+    static let windowBackground = Color(hex: 0x1C1C1E)
+    static let cardBackground = Color(hex: 0x2C2C2E)
+    static let inputBackground = Color(hex: 0x242428)
+    static let segmentBackground = Color(hex: 0x242428)
+    static let keycapBackground = Color(hex: 0x3A3A40).opacity(0.55)
+    static let holdActiveBackground = Color(hex: 0x2B2028)
+    static let sliderTrack = Color(hex: 0x4A3945)
+
+    static let primaryText = Color(hex: 0xF5F5F7)
+    static let secondaryText = Color(hex: 0x98989D)
+    static let tertiaryText = Color(hex: 0x636366)
+    static let accent = Color(hex: 0xFF5C7E)
+    static let accentSoft = Color(hex: 0x3A2129)
+    static let accentSoftText = Color(hex: 0xFFD2DE)
+    static let accentBorder = Color(hex: 0xFF5C7E).opacity(0.25)
+    static let separator = Color.white.opacity(0.08)
+    static let inputBorder = Color(hex: 0x393940)
+    static let keycapBorder = Color.white.opacity(0.1)
+}
+
+private extension Color {
+    init(hex: UInt, opacity: Double = 1) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: opacity
+        )
     }
 }
 
@@ -384,5 +829,5 @@ extension Notification.Name {
 
 #Preview {
     ShortcutsSettingsView()
-        .frame(width: 640, height: 520)
+        .frame(width: 759, height: 666)
 }

--- a/Diduny/Features/TextTranslation/TextTranslationView.swift
+++ b/Diduny/Features/TextTranslation/TextTranslationView.swift
@@ -37,25 +37,27 @@ private struct TranslationResponse: Decodable {
 final class TextTranslationViewModel: ObservableObject {
     @Published var sourceText: String
     @Published var translatedText: String = ""
+    @Published var sourceLanguageCode: String
     @Published var targetLanguageCode: String
     @Published var detectedLanguageName: String = ""
+    @Published var detectedLanguageCode: String?
     @Published var isTranslating: Bool = false
     @Published var errorMessage: String?
     @Published var showCopiedConfirmation: Bool = false
 
     private var translationTask: Task<Void, Never>?
+    private var copiedConfirmationTask: Task<Void, Never>?
 
     deinit {
         translationTask?.cancel()
+        copiedConfirmationTask?.cancel()
     }
 
     init(sourceText: String) {
         self.sourceText = sourceText
-
-        // Detect source language and resolve target
-        let detectedCode = Self.detectLanguageCode(for: sourceText)
-        detectedLanguageName = Self.languageDisplayName(for: detectedCode)
-        targetLanguageCode = Self.resolveTargetLanguage(sourceCode: detectedCode)
+        sourceLanguageCode = SettingsStorage.shared.textTranslationSourceLanguage
+        targetLanguageCode = SettingsStorage.shared.textTranslationTargetLanguage
+        updateDetectedLanguage()
     }
 
     func translate() {
@@ -72,6 +74,7 @@ final class TextTranslationViewModel: ObservableObject {
             do {
                 let result = try await Self.requestTranslation(
                     sourceText: self.sourceText,
+                    sourceLanguage: self.sourceLanguageCode,
                     targetLanguage: self.targetLanguageCode
                 )
                 guard !Task.isCancelled else { return }
@@ -79,15 +82,7 @@ final class TextTranslationViewModel: ObservableObject {
                 self.isTranslating = false
 
                 // Auto-copy to clipboard
-                ClipboardService.shared.copy(text: result)
-                self.showCopiedConfirmation = true
-
-                // Hide confirmation after a delay
-                Task {
-                    try? await Task.sleep(for: .seconds(2))
-                    guard !Task.isCancelled else { return }
-                    self.showCopiedConfirmation = false
-                }
+                self.copyTranslation()
             } catch is CancellationError {
                 self.isTranslating = false
             } catch {
@@ -99,7 +94,55 @@ final class TextTranslationViewModel: ObservableObject {
 
     func updateDetectedLanguage() {
         let detectedCode = Self.detectLanguageCode(for: sourceText)
+        detectedLanguageCode = SettingsStorage.normalizedLanguageCode(detectedCode)
         detectedLanguageName = Self.languageDisplayName(for: detectedCode)
+    }
+
+    func persistSourceLanguage() {
+        SettingsStorage.shared.textTranslationSourceLanguage = sourceLanguageCode
+    }
+
+    func persistTargetLanguage() {
+        SettingsStorage.shared.textTranslationTargetLanguage = targetLanguageCode
+    }
+
+    func copyTranslation() {
+        guard !translatedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        ClipboardService.shared.copy(text: translatedText)
+        showCopiedConfirmation = true
+        copiedConfirmationTask?.cancel()
+        copiedConfirmationTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            self?.showCopiedConfirmation = false
+        }
+    }
+
+    var canSwapLanguagesAndText: Bool {
+        effectiveSourceLanguageCode != nil
+            && !translatedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func swapLanguagesAndText() {
+        guard let sourceTarget = effectiveSourceLanguageCode else { return }
+
+        let previousSourceText = sourceText
+        sourceText = translatedText
+        translatedText = previousSourceText
+
+        let previousTarget = targetLanguageCode
+        sourceLanguageCode = previousTarget
+        targetLanguageCode = sourceTarget
+        persistSourceLanguage()
+        persistTargetLanguage()
+        updateDetectedLanguage()
+    }
+
+    private var effectiveSourceLanguageCode: String? {
+        if sourceLanguageCode == "auto" {
+            return detectedLanguageCode
+        }
+        return SettingsStorage.normalizedLanguageCode(sourceLanguageCode)
     }
 
     // MARK: - Language Detection
@@ -117,22 +160,13 @@ final class TextTranslationViewModel: ObservableObject {
             ?? code.uppercased()
     }
 
-    private static func resolveTargetLanguage(sourceCode: String?) -> String {
-        let favoriteLanguages = SettingsStorage.shared.favoriteLanguages.filter { !$0.isEmpty }
-
-        switch sourceCode {
-        case "uk":
-            return favoriteLanguages.first(where: { $0 != "uk" }) ?? "en"
-        case "en":
-            return favoriteLanguages.first(where: { $0 != "en" }) ?? "uk"
-        default:
-            return favoriteLanguages.first ?? "uk"
-        }
-    }
-
     // MARK: - Translation API
 
-    private static func requestTranslation(sourceText: String, targetLanguage: String) async throws -> String {
+    private static func requestTranslation(
+        sourceText: String,
+        sourceLanguage: String,
+        targetLanguage: String
+    ) async throws -> String {
         let settings = SettingsStorage.shared
         let proxyBase = settings.proxyBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let translateURL = "\(proxyBase)/api/v1/translations"
@@ -144,7 +178,7 @@ final class TextTranslationViewModel: ObservableObject {
         components.queryItems = [
             URLQueryItem(name: "q", value: sourceText),
             URLQueryItem(name: "tl", value: targetLanguage),
-            URLQueryItem(name: "sl", value: "auto"),
+            URLQueryItem(name: "sl", value: normalizedSourceLanguage(sourceLanguage)),
         ]
 
         guard let url = components.url else {
@@ -181,6 +215,10 @@ final class TextTranslationViewModel: ObservableObject {
         return translatedText
     }
 
+    private static func normalizedSourceLanguage(_ code: String) -> String {
+        if code == "auto" { return "auto" }
+        return SettingsStorage.normalizedLanguageCode(code) ?? "auto"
+    }
 }
 
 // MARK: - View
@@ -190,14 +228,16 @@ struct TextTranslationView: View {
     var onClose: () -> Void
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 14) {
+            languageControls
+
             // Source text
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Text("Source")
                         .font(.headline)
 
-                    if !viewModel.detectedLanguageName.isEmpty {
+                    if viewModel.sourceLanguageCode == "auto", !viewModel.detectedLanguageName.isEmpty {
                         Text(viewModel.detectedLanguageName)
                             .font(.caption)
                             .foregroundColor(Color("BrandAccentDeep"))
@@ -221,32 +261,6 @@ struct TextTranslationView: View {
                     }
             }
 
-            // Target language + Translate button
-            HStack(spacing: 12) {
-                Picker("To:", selection: $viewModel.targetLanguageCode) {
-                    ForEach(SupportedLanguage.allLanguages) { language in
-                        Text(language.name).tag(language.code)
-                    }
-                }
-                .frame(maxWidth: 200)
-
-                Spacer()
-
-                if viewModel.isTranslating {
-                    ProgressView()
-                        .controlSize(.small)
-                }
-
-                Button(action: viewModel.translate) {
-                    Text("Translate")
-                        .frame(minWidth: 80)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color("BrandAccentDeep"))
-                .keyboardShortcut(.return, modifiers: .command)
-                .disabled(viewModel.isTranslating || viewModel.sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-
             // Translation result
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
@@ -261,9 +275,16 @@ struct TextTranslationView: View {
                             .foregroundColor(.secondary)
                             .transition(.opacity)
                     }
+
+                    Button {
+                        viewModel.copyTranslation()
+                    } label: {
+                        Label("Copy", systemImage: "doc.on.doc")
+                    }
+                    .disabled(viewModel.translatedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
 
-                TextEditor(text: .constant(viewModel.translatedText))
+                TextEditor(text: $viewModel.translatedText)
                     .font(.body)
                     .frame(minHeight: 80, maxHeight: 120)
                     .scrollContentBackground(.hidden)
@@ -279,7 +300,70 @@ struct TextTranslationView: View {
             }
         }
         .padding(20)
-        .frame(width: 480, height: 400)
+        .frame(width: 540, height: 450)
         .animation(.easeInOut(duration: 0.2), value: viewModel.showCopiedConfirmation)
+    }
+
+    private var languageControls: some View {
+        HStack(spacing: 10) {
+            Picker("From:", selection: $viewModel.sourceLanguageCode) {
+                Text("Auto").tag("auto")
+                ForEach(SupportedLanguage.cloudLanguages) { language in
+                    Text(language.name).tag(language.code)
+                }
+            }
+            .frame(maxWidth: 190)
+            .onChange(of: viewModel.sourceLanguageCode) { _, _ in
+                viewModel.persistSourceLanguage()
+            }
+
+            Button {
+                viewModel.swapLanguagesAndText()
+            } label: {
+                Image(systemName: "arrow.left.arrow.right")
+                    .frame(width: 18, height: 18)
+            }
+            .buttonStyle(.bordered)
+            .help("Swap languages and text")
+            .disabled(!viewModel.canSwapLanguagesAndText)
+
+            Picker("To:", selection: $viewModel.targetLanguageCode) {
+                ForEach(targetLanguages) { language in
+                    Text(language.name).tag(language.code)
+                }
+            }
+            .frame(maxWidth: 190)
+            .onChange(of: viewModel.targetLanguageCode) { _, _ in
+                viewModel.persistTargetLanguage()
+            }
+
+            Spacer(minLength: 0)
+
+            if viewModel.isTranslating {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Button(action: viewModel.translate) {
+                Text("Translate")
+                    .frame(minWidth: 80)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color("BrandAccentDeep"))
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(viewModel.isTranslating || viewModel.sourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private var targetLanguages: [SupportedLanguage] {
+        var languages = SettingsStorage.shared.translationTargetLanguages.compactMap {
+            SupportedLanguage.language(for: $0)
+        }
+        if !languages.contains(where: { $0.code == viewModel.targetLanguageCode }),
+           let selected = SupportedLanguage.language(for: viewModel.targetLanguageCode)
+        {
+            languages.insert(selected, at: 0)
+        }
+        return languages.isEmpty ? SupportedLanguage.cloudLanguages : languages
     }
 }

--- a/Diduny/Features/Transcription/LiveTranscriptView.swift
+++ b/Diduny/Features/Transcription/LiveTranscriptView.swift
@@ -3,9 +3,6 @@ import SwiftUI
 struct LiveTranscriptView: View {
     let store: LiveTranscriptStore
 
-    @State private var recordingDuration: TimeInterval = 0
-    @State private var timer: Timer?
-
     private let speakerColors: [Color] = [
         Color("BrandAccentDeep"), .green, .orange, .brown, .pink, .teal, .cyan, .mint
     ]
@@ -19,8 +16,6 @@ struct LiveTranscriptView: View {
             footerBar
         }
         .frame(minWidth: 500, idealWidth: 500, minHeight: 500)
-        .onAppear { seedDurationFromRecordingStart(); startTimer() }
-        .onDisappear { stopTimer() }
     }
 
     // MARK: - Header
@@ -46,9 +41,7 @@ struct LiveTranscriptView: View {
             Spacer()
 
             if store.isActive {
-                Text(formatDuration(recordingDuration))
-                    .font(.system(.body, design: .monospaced))
-                    .foregroundStyle(.secondary)
+                LiveTranscriptElapsedView(startedAt: store.createdAt)
             }
 
             connectionIndicator
@@ -214,33 +207,6 @@ struct LiveTranscriptView: View {
         return speakerColors[abs(index) % speakerColors.count]
     }
 
-    private func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = (Int(duration) % 3600) / 60
-        let seconds = Int(duration) % 60
-        if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-        }
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
-
-    private func seedDurationFromRecordingStart() {
-        recordingDuration = max(0, Date().timeIntervalSince(store.createdAt))
-    }
-
-    private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-            Task { @MainActor in
-                recordingDuration += 1
-            }
-        }
-    }
-
-    private func stopTimer() {
-        timer?.invalidate()
-        timer = nil
-    }
-
     private func saveTranscript() {
         let text = store.finalTranscriptText
         guard !text.isEmpty else { return }
@@ -252,5 +218,29 @@ struct LiveTranscriptView: View {
         if panel.runModal() == .OK, let url = panel.url {
             try? text.write(to: url, atomically: true, encoding: .utf8)
         }
+    }
+}
+
+// Isolated leaf so only this view re-evaluates every second; the parent body is not re-invoked.
+private struct LiveTranscriptElapsedView: View {
+    let startedAt: Date
+
+    var body: some View {
+        TimelineView(.periodic(from: startedAt, by: 1)) { context in
+            Text(formatDuration(context.date.timeIntervalSince(startedAt)))
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let total = Int(max(0, duration))
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%02d:%02d", minutes, seconds)
     }
 }

--- a/DidunyTests/CloudTranscriptionServiceE2ETests.swift
+++ b/DidunyTests/CloudTranscriptionServiceE2ETests.swift
@@ -343,8 +343,9 @@ final class CloudTranscriptionServiceE2ETests: XCTestCase {
         let targetLanguage = env["DIDUNY_E2E_TARGET_LANGUAGE"] ?? "en"
 
         SettingsStorage.shared.proxyBaseURL = proxyBaseURL
-        SettingsStorage.shared.translationLanguageA = sourceLanguage
-        SettingsStorage.shared.translationLanguageB = targetLanguage
+        SettingsStorage.shared.favoriteLanguages = [sourceLanguage]
+        SettingsStorage.shared.translationTargetLanguages = [targetLanguage]
+        SettingsStorage.shared.voiceTranslationTargetLanguage = targetLanguage
 
         let audioData = try Data(contentsOf: URL(fileURLWithPath: audioPath))
         let text = try await CloudTranscriptionService()

--- a/DidunyTests/RecordingModelMigrationTests.swift
+++ b/DidunyTests/RecordingModelMigrationTests.swift
@@ -4,6 +4,7 @@ import XCTest
 /// Tests for the RLR-M0 data-model additions:
 ///   - `RecoverySource` enum + `Recording.recoverySource` property
 ///   - `Recording.ProcessingStatus.partiallyRecovered` case
+///   - optional `Recording.translationTargetLanguageCode`
 ///
 /// The primary concerns are:
 ///   1. Backward compatibility — JSON written before M0 (no `recoverySource` key,
@@ -56,6 +57,12 @@ final class RecordingModelMigrationTests: XCTestCase {
         let recordings = try iso8601.decode([Recording].self, from: data)
         XCTAssertNil(recordings[0].recoverySource,
                      "recordings from before M0 must have recoverySource == nil")
+    }
+
+    func test_legacyJSON_translationTargetLanguageCodeIsNil() throws {
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let recordings = try iso8601.decode([Recording].self, from: data)
+        XCTAssertNil(recordings[0].translationTargetLanguageCode)
     }
 
     func test_legacyJSON_originalFieldsIntact() throws {
@@ -138,6 +145,7 @@ final class RecordingModelMigrationTests: XCTestCase {
             processedAt: Date(timeIntervalSince1970: 1_700_200_120),
             chapters: nil,
             sourceDevice: nil,
+            translationTargetLanguageCode: "fr",
             recoverySource: nil
         )
 
@@ -145,6 +153,7 @@ final class RecordingModelMigrationTests: XCTestCase {
         let decoded = try iso8601.decode([Recording].self, from: data)[0]
 
         XCTAssertEqual(decoded.type, .meetingTranslation)
+        XCTAssertEqual(decoded.translationTargetLanguageCode, "fr")
         XCTAssertTrue(decoded.type.isMeetingLike)
         XCTAssertEqual(decoded.type.clipboardCopyBehavior, .raw)
         XCTAssertTrue(decoded.type.usesTranslatedStatusWhenSavedWithText)


### PR DESCRIPTION
## Summary
- Ship the colorful Shortcuts settings redesign that was previously only local.
- Carry over tested recording/transcription fixes for async jobs, device handling, live transcript rendering, and translation UI state.
- Rebase the release scope onto current main/v1.15.3 so this PR only contains the new release diff.

## Validation
- `xcodebuild -project Diduny.xcodeproj -scheme "Diduny DEV" -configuration Debug -destination "platform=macOS" build`
- `xcodebuild -project Diduny.xcodeproj -scheme "Diduny DEV" -destination "platform=macOS" test`
- Tests: 66 XCTest tests passed, 5 E2E tests skipped by env guard; Swift Testing suites passed.

## Release
- Label: `release:patch`
- Expected next tag after merge: `v1.15.4`