### PR TITLE
fix(swift): paste cancellation, recording metadata/race, TIS main-thread guard

### DIFF
--- a/Diduny/Core/Models/SupportedLanguage.swift
+++ b/Diduny/Core/Models/SupportedLanguage.swift
@@ -215,17 +215,24 @@ struct KeyboardLanguageDetector {
     }
 
     static func detectedLanguages() -> [DetectedLanguage] {
-        selectableInputSources().flatMap { source -> [DetectedLanguage] in
-            let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
-            let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
-            let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
-            return languageCodes(
-                inputSourceLanguages: languages,
-                inputSourceID: id,
-                localizedName: name
-            ).map { DetectedLanguage(code: $0, sourceName: name, sourceID: id) }
+        // Text Input Source APIs (TISCreateInputSourceList) must run on the main
+        // thread. On macOS 26 they assert the dispatch queue and hard-crash when
+        // called off-main, which happens because this is reached from background
+        // transcription Tasks. Hop to main so every caller is safe regardless of
+        // the thread it runs on.
+        runOnMainThread {
+            selectableInputSources().flatMap { source -> [DetectedLanguage] in
+                let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
+                let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
+                let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
+                return languageCodes(
+                    inputSourceLanguages: languages,
+                    inputSourceID: id,
+                    localizedName: name
+                ).map { DetectedLanguage(code: $0, sourceName: name, sourceID: id) }
+            }
+            .deduplicatedByCode()
         }
-        .deduplicatedByCode()
     }
 
     static func detectedLanguageCodes() -> [String] {
@@ -233,11 +240,23 @@ struct KeyboardLanguageDetector {
     }
 
     static func currentLanguageCode() -> String? {
-        let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
-        let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
-        let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
-        let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
-        return languageCodes(inputSourceLanguages: languages, inputSourceID: id, localizedName: name).first
+        // See note in detectedLanguages(): TIS APIs are main-thread only.
+        runOnMainThread {
+            let source = TISCopyCurrentKeyboardInputSource().takeRetainedValue()
+            let id = stringProperty(source, key: kTISPropertyInputSourceID) ?? ""
+            let name = stringProperty(source, key: kTISPropertyLocalizedName) ?? id
+            let languages = stringArrayProperty(source, key: kTISPropertyInputSourceLanguages)
+            return languageCodes(inputSourceLanguages: languages, inputSourceID: id, localizedName: name).first
+        }
+    }
+
+    /// Runs `work` on the main thread, blocking the caller until it completes.
+    /// Executes inline when already on the main thread to avoid a deadlock.
+    private static func runOnMainThread<T>(_ work: () -> T) -> T {
+        if Thread.isMainThread {
+            return work()
+        }
+        return DispatchQueue.main.sync(execute: work)
     }
 
     static func languageCodes(

--- a/Diduny/Core/Services/ClipboardService.swift
+++ b/Diduny/Core/Services/ClipboardService.swift
@@ -77,7 +77,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         // Keep only a short focus handoff delay. NSPasteboard writes above are synchronous.
         try await Task.sleep(nanoseconds: Self.pasteReadinessDelayNanoseconds)
 
-        try postCommandShortcut(keyCode: CGKeyCode(9), error: .pasteEventFailed)
+        try await postCommandShortcut(keyCode: CGKeyCode(9), error: .pasteEventFailed)
 
         Log.app.info("Paste event sent successfully to frontmost app")
     }
@@ -93,7 +93,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         }
 
         let initialChangeCount = pasteboard.changeCount
-        try postCommandShortcut(keyCode: CGKeyCode(8), error: .copyEventFailed)
+        try await postCommandShortcut(keyCode: CGKeyCode(8), error: .copyEventFailed)
 
         let timeout = Date().addingTimeInterval(0.8)
         while Date() < timeout {
@@ -114,7 +114,7 @@ final class ClipboardService: ClipboardServiceProtocol {
         pasteboard.string(forType: .string)
     }
 
-    private func postCommandShortcut(keyCode: CGKeyCode, error: ClipboardError) throws {
+    private func postCommandShortcut(keyCode: CGKeyCode, error: ClipboardError) async throws {
         guard let source = CGEventSource(stateID: .hidSystemState) else {
             Log.app.error("Failed to create event source")
             throw error
@@ -125,16 +125,21 @@ final class ClipboardService: ClipboardServiceProtocol {
             throw error
         }
         keyDown.flags = .maskCommand
-        keyDown.post(tap: .cgAnnotatedSessionEventTap)
 
-        // Keep a tiny delay between key down/up so target apps can process shortcuts reliably.
-        usleep(Self.shortcutKeyHoldMicroseconds)
-
+        // Build the key-up up front and post it via defer so it always fires —
+        // even if the hold-interval sleep below is cancelled (e.g. the user
+        // re-triggers recording mid-paste). Otherwise the virtual ⌘ stays
+        // "held" in the target app until the next real key event.
         guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else {
             Log.app.error("Failed to create keyUp event")
             throw error
         }
         keyUp.flags = .maskCommand
-        keyUp.post(tap: .cgAnnotatedSessionEventTap)
+
+        keyDown.post(tap: .cgAnnotatedSessionEventTap)
+        defer { keyUp.post(tap: .cgAnnotatedSessionEventTap) }
+
+        // Suspend rather than park the thread for the key-hold interval.
+        try await Task.sleep(for: .milliseconds(12))
     }
 }

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -26,9 +26,9 @@ final class RecordingsLibraryStorage {
         try? fm.createDirectory(at: appDir, withIntermediateDirectories: true)
         metadataURL = appDir.appendingPathComponent("recordings_metadata.json")
 
-        loadMetadata()
-        pruneOrphaned()
-        pruneExpiredRecordings()
+        Task { @MainActor [weak self] in
+            await self?.loadAndPruneAsync()
+        }
     }
 
     // MARK: - Save (from Data — voice/translation)
@@ -39,7 +39,8 @@ final class RecordingsLibraryStorage {
         type: Recording.RecordingType,
         duration: TimeInterval,
         transcriptionText: String? = nil,
-        sourceDevice: RecordingDeviceInfo? = nil
+        sourceDevice: RecordingDeviceInfo? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard shouldSaveRecording(type: type) else { return }
 
@@ -70,7 +71,8 @@ final class RecordingsLibraryStorage {
             status: status,
             transcriptionText: transcriptionText,
             processedAt: transcriptionText != nil ? Date() : nil,
-            sourceDevice: sourceDevice
+            sourceDevice: sourceDevice,
+            translationTargetLanguageCode: translationTargetLanguageCode
         )
 
         recordings.insert(recording, at: 0)
@@ -87,7 +89,8 @@ final class RecordingsLibraryStorage {
         type: Recording.RecordingType,
         duration: TimeInterval,
         transcriptionText: String? = nil,
-        sourceDevice: RecordingDeviceInfo? = nil
+        sourceDevice: RecordingDeviceInfo? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard shouldSaveRecording(type: type) else { return }
 
@@ -127,7 +130,8 @@ final class RecordingsLibraryStorage {
             status: status,
             transcriptionText: transcriptionText,
             processedAt: transcriptionText != nil ? Date() : nil,
-            sourceDevice: sourceDevice
+            sourceDevice: sourceDevice,
+            translationTargetLanguageCode: translationTargetLanguageCode
         )
 
         recordings.insert(recording, at: 0)
@@ -180,12 +184,16 @@ final class RecordingsLibraryStorage {
         id: UUID,
         status: Recording.ProcessingStatus,
         text: String? = nil,
-        error: String? = nil
+        error: String? = nil,
+        translationTargetLanguageCode: String? = nil
     ) {
         guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
         recordings[index].status = status
         recordings[index].transcriptionText = text ?? recordings[index].transcriptionText
         recordings[index].errorMessage = error
+        if let translationTargetLanguageCode {
+            recordings[index].translationTargetLanguageCode = translationTargetLanguageCode
+        }
         if status == .transcribed || status == .translated {
             recordings[index].processedAt = Date()
         }
@@ -242,43 +250,57 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Persistence
 
-    private func loadMetadata() {
-        guard let data = try? Data(contentsOf: metadataURL) else { return }
-        do {
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            recordings = try decoder.decode([Recording].self, from: data)
-        } catch {
-            Log.app.error("Failed to load recordings metadata: \(error.localizedDescription)")
+    private func loadAndPruneAsync() async {
+        let url = metadataURL
+        let recDir = recordingsDir
+        let result = await Task.detached(priority: .utility) { () -> [Recording]? in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                var loaded = try decoder.decode([Recording].self, from: data)
+                // Prune orphans with a single directory scan instead of per-file fileExists
+                if let contents = try? FileManager.default.contentsOfDirectory(
+                    at: recDir, includingPropertiesForKeys: nil
+                ) {
+                    let names = Set(contents.map(\.lastPathComponent))
+                    loaded.removeAll { !names.contains($0.audioFileName) }
+                }
+                return loaded
+            } catch {
+                Log.app.error("Failed to load recordings metadata: \(error.localizedDescription)")
+                return nil
+            }
+        }.value
+        if let result {
+            if recordings.isEmpty {
+                recordings = result
+            } else {
+                // A save landed while we were loading from disk. Don't clobber the
+                // freshly inserted in-memory entries — merge the disk snapshot in,
+                // keeping in-memory (newer) records on id conflicts.
+                let existingIDs = Set(recordings.map(\.id))
+                recordings.append(contentsOf: result.filter { !existingIDs.contains($0.id) })
+            }
+            pruneExpiredRecordings()
         }
     }
 
     private func saveMetadata() {
-        do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(recordings)
-            try data.write(to: metadataURL)
-        } catch {
-            Log.app.error("Failed to save recordings metadata: \(error.localizedDescription)")
+        let snapshot = recordings
+        let url = metadataURL
+        Task.detached(priority: .utility) {
+            do {
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let data = try encoder.encode(snapshot)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                Log.app.error("Failed to save recordings metadata: \(error.localizedDescription)")
+            }
         }
     }
 
-    private func pruneOrphaned() {
-        let before = recordings.count
-        let recordingsDir = self.recordingsDir
-        let fileManager = self.fileManager
-        recordings.removeAll { recording in
-            let fileURL = recordingsDir.appendingPathComponent(recording.audioFileName)
-            return !fileManager.fileExists(atPath: fileURL.path)
-        }
-        if recordings.count != before {
-            let prunedCount = before - recordings.count
-            Log.app.info("Pruned \(prunedCount) orphaned recording entries")
-            saveMetadata()
-        }
-    }
 
     private func shouldSaveRecording(type: Recording.RecordingType) -> Bool {
         let policy = SettingsStorage.shared.historyRetentionPolicy(for: type)
@@ -329,6 +351,7 @@ final class RecordingsLibraryStorage {
                 processedAt: recording.processedAt,
                 chapters: recording.chapters,
                 sourceDevice: recording.sourceDevice,
+                translationTargetLanguageCode: recording.translationTargetLanguageCode,
                 recoverySource: recording.recoverySource
             )
             saveMetadata()


### PR DESCRIPTION
Targets **`redesign/diduny`** (these fixes belong to the redesign line). Pulls three correctness fixes out of the uncommitted working tree so they're not lost. Two files also carry the in-progress async-paste refactor / library edits that were already uncommitted in them.

## Fixes
1. **ClipboardService — stuck ⌘ on paste cancellation.** `postCommandShortcut` became `async`; if the hold-interval `Task.sleep` is cancelled (e.g. re-triggering recording mid-paste) the key-up was never posted, leaving the virtual ⌘ held in the target app. Now builds key-up up front and posts it via `defer`.
2. **RecordingsLibraryStorage — lost metadata + startup race.** `replaceStoredAudioFile` dropped `translationTargetLanguageCode` on FLAC/rename (carried through now). The async startup load could clobber a recording saved during the load window — now merges by id instead of overwriting.
3. **SupportedLanguage — TIS main-thread guard.** All Text Input Source calls now hop to the main thread; macOS 26 hard-crashes (SIGTRAP) when they run off-main from background transcription Tasks. (Already shipped on `main` as v1.15.2; included here so the redesign branch doesn't crash.)

## Verification
Built + tested earlier this session on this exact tree: `Diduny DEV` **BUILD SUCCEEDED**, `DidunyTests` **53/53**. (Diduny has no PR CI gate yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)