### PR TITLE
fix(settings): slider no longer drags the window; default to compact panel

### DIFF
--- a/Diduny/Core/Storage/SettingsStorage.swift
+++ b/Diduny/Core/Storage/SettingsStorage.swift
@@ -250,7 +250,7 @@ final class SettingsStorage {
             guard let rawValue = defaults.string(forKey: Key.recordingFeedbackSurface.rawValue),
                   let surface = RecordingFeedbackSurface(rawValue: rawValue)
             else {
-                return .notch
+                return .compactPanel
             }
             return surface
         }

--- a/Diduny/Features/Settings/ShortcutsSettingsView.swift
+++ b/Diduny/Features/Settings/ShortcutsSettingsView.swift
@@ -533,6 +533,9 @@ struct ShortcutsSettingsView: View {
             }
             .frame(width: width, height: 18, alignment: .center)
             .contentShape(Rectangle())
+            // The settings window is movable-by-background; without this, dragging
+            // the custom slider drags the whole window instead of the knob.
+            .background(WindowDragBlocker())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
@@ -830,4 +833,20 @@ extension Notification.Name {
 #Preview {
     ShortcutsSettingsView()
         .frame(width: 759, height: 666)
+}
+
+/// Marks its region as non-window-draggable. The settings window uses
+/// `isMovableByWindowBackground = true`, and SwiftUI shapes leave
+/// `mouseDownCanMoveWindow == true`, so dragging a custom control (e.g. the
+/// hold-delay slider) would drag the whole window. Placed as a `.background`,
+/// this reports the region as non-draggable while passing mouse events through
+/// to the SwiftUI gesture above it.
+private struct WindowDragBlocker: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { BlockerView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class BlockerView: NSView {
+        override var mouseDownCanMoveWindow: Bool { false }
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    }
 }


### PR DESCRIPTION
Two settings fixes for the shortcuts redesign that's live on `main`.

## 1. Hold-delay slider drags the whole window
The custom slider uses a `DragGesture` inside a window with `isMovableByWindowBackground = true`; SwiftUI shapes leave `mouseDownCanMoveWindow == true`, so dragging the knob moved the whole window. Added a `WindowDragBlocker` (`NSViewRepresentable`, `mouseDownCanMoveWindow = false`) behind the slider.

## 2. Default to compact panel instead of notch
`recordingFeedbackSurface` now defaults to `.compactPanel` (was `.notch`).

## Verification
`Diduny DEV` app target: **BUILD SUCCEEDED** off this `main` base. Two files, +20/-1.

> Please verify the slider drag visually — `WindowDragBlocker` compiles and is the standard pattern, but window-drag behavior can't be confirmed from a build alone.

Label `release:minor` → **1.16.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)