### PR TITLE
fix(realtime): stop zombie reconnect loop after session ends

### DIFF
--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -14,6 +14,10 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     private var urlSession: URLSession?
     private var receiveTask: Task<Void, Never>?
     private var pingTask: Task<Void, Never>?
+    /// In-flight reconnect (sleeping during backoff). Held so disconnect() can cancel it —
+    /// otherwise a drop that schedules a reconnect just before disconnect resurrects the
+    /// socket after teardown and loops forever with no audio source. Guarded by lifecycleLock.
+    private var reconnectTask: Task<Void, Never>?
     private var proxyReady = false
 
     private var isConnected = false
@@ -337,6 +341,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         let task = webSocketTask
         webSocketTask = nil
         isConnected = false
+        // Kill any reconnect scheduled by a drop that raced just before this disconnect.
+        reconnectTask?.cancel()
+        reconnectTask = nil
         lifecycleLock.unlock()
 
         task?.cancel(with: .normalClosure, reason: nil)
@@ -563,9 +570,16 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         Log.transcription.info("Cloud RT: Reconnecting (attempt \(self.reconnectAttempt))...")
         onConnectionStatusChanged?(.reconnecting(attempt: reconnectAttempt))
 
-        Task { [weak self] in
+        lifecycleLock.lock()
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
             guard let self else { return }
             try? await Task.sleep(for: .seconds(delay))
+            // disconnect() cancels this task during the backoff sleep; bail before reconnecting.
+            guard !Task.isCancelled else {
+                Log.transcription.info("Cloud RT: Reconnect cancelled — session ended during backoff")
+                return
+            }
 
             do {
                 try await self.connectWebSocket()
@@ -596,6 +610,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
                 self.handleDisconnect()
             }
         }
+        lifecycleLock.unlock()
     }
 
     static func makeConnectionConfig(


### PR DESCRIPTION
## Problem

In production, a finished realtime session can fall into an endless reconnect loop
(observed cycling **exactly every 20s**, `sessionReconnects` climbing into the teens),
silently consuming realtime quota on every cycle.

**Root cause:** a WS drop schedules a reconnect via a *fire-and-forget* `Task` that is
held nowhere. If the session ends (`disconnect()`) milliseconds later, that Task wakes
*after* teardown and resurrects the socket — now with **no audio source**. Soniox then
idle-times-out after ~20s and closes (code 1000), the client reconnects, and the loop
never ends.

## Fix

- Hold the reconnect Task in `reconnectTask` (under `lifecycleLock`).
- `disconnect()` cancels it — so a drop that races just before teardown can't resurrect
  the socket.
- After the backoff sleep, `guard !Task.isCancelled` before reconnecting.

Recovery during an *active* recording (long meetings, transient drops) is unchanged.

## Scope
One file, one behavioural change. **Build verified:** `** BUILD SUCCEEDED **` (Diduny DEV, Debug).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnect handling to prevent unwanted reconnects after shutdown.
  * Reconnect attempts are now safely canceled if the connection is torn down, reducing the chance of background retries after leaving the app offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->