### PR TITLE
perf: instrument realtime connect and meeting start timings

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		56700AFF9E4935DDDDA72D7D /* MeetingRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE81A3506184A31D459CC1DA /* MeetingRecorderService.swift */; };
 		572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */; };
 		57FF194266BABFA6EA107750 /* HTTPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622D792451975A00E4A3FCBF /* HTTPLogger.swift */; };
+		5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F045E726DADF6E51D7778 /* ConnectMetrics.swift */; };
 		5A18DAA2CFAE9E95CCA51D24 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B9A32E3B977C8D9C16E2DC20 /* Sparkle */; };
 		5B89431A91667B55380925FB /* MainSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15385C5553FC7E235C629D0 /* MainSection.swift */; };
 		5C38E65B15A426A3B51A9EEB /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF35CE111AABBE5F2797242F /* whisper.xcframework */; };
@@ -177,6 +178,7 @@
 		3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperContext.swift; sourceTree = "<group>"; };
 		40E7786C88C96F6C70862A1E /* OfflineModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModelsSettingsView.swift; sourceTree = "<group>"; };
 		44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingModelMigrationTests.swift; sourceTree = "<group>"; };
+		452F045E726DADF6E51D7778 /* ConnectMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectMetrics.swift; sourceTree = "<group>"; };
 		459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		459DCE179DA235DE6208C013 /* SupportedLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedLanguage.swift; sourceTree = "<group>"; };
 		4852162851F73B8352C95E25 /* RemoteConfigService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigService.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */,
 				001D5E66F362C783C621055C /* CloudRealtimeService.swift */,
 				5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */,
+				452F045E726DADF6E51D7778 /* ConnectMetrics.swift */,
 				792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */,
 				8A2A0045FAC17572590BE16F /* EscapeCancelService.swift */,
 				0491E26240E167BDB5DCACEE /* HotkeyService.swift */,
@@ -771,6 +774,7 @@
 				C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */,
 				F64CD3B70A52B315B4110B8C /* CloudRealtimeService.swift in Sources */,
 				8652A9D79DB6EF0EA183113A /* CloudTranscriptionService.swift in Sources */,
+				5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */,
 				CBD76325F1DE55DA51EDD348 /* DeviceLevelMonitor.swift in Sources */,
 				A16B6680BF413BDD639BAF88 /* DictationOverlayController.swift in Sources */,
 				37B4946599B2FDB08DEB48E7 /* DidunyApp.swift in Sources */,

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -132,6 +132,11 @@ extension AppDelegate {
 
         let cloudModeEnabled = SettingsStorage.shared.effectiveMeetingRealtimeTranscriptionEnabled
 
+        // Timed from after the permission check (which can block on a user
+        // prompt) to the .recording state transition.
+        let startMetrics = ConnectMetrics(label: "[Meeting] start")
+        defer { startMetrics.finish() }
+
         // Prevent App Nap during meeting recording
         meetingActivityToken = ProcessInfo.processInfo.beginActivity(
             options: [.userInitiated, .idleSystemSleepDisabled],
@@ -176,7 +181,9 @@ extension AppDelegate {
                 appState.deviceFallbackWarning = nil
             }
 
+            startMetrics.begin(.recorderStart)
             try await meetingRecorderService.startRecording()
+            startMetrics.end(.recorderStart)
             Log.app.info("Meeting recording started")
 
             // Setup real-time transcription in Cloud mode
@@ -207,6 +214,7 @@ extension AppDelegate {
                 appState.liveTranscriptStore = store
                 handleMeetingStateChange(.recording)
             }
+            startMetrics.finish(outcome: "ok")
 
             // Show transcript window only if we have real-time transcription
             if let store {

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -19,6 +19,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     /// socket after teardown and loops forever with no audio source. Guarded by lifecycleLock.
     private var reconnectTask: Task<Void, Never>?
     private var proxyReady = false
+    /// Phase timings for the in-flight connect. Guarded by lifecycleLock; the
+    /// URLSession delegate and receive loop close phases from other threads.
+    private var currentConnectMetrics: ConnectMetrics?
 
     private var isConnected = false
     private var reconnectAttempt = 0
@@ -106,13 +109,24 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         onConnectionStatusChanged?(.connecting)
 
+        let metrics = ConnectMetrics(label: "[Cloud RT] connect")
+        lifecycleLock.lock()
+        currentConnectMetrics = metrics
+        lifecycleLock.unlock()
+        // Idempotent: the success path below finishes with "ok" first, so this
+        // only fires when an error path unwinds out of connectWebSocket().
+        defer { metrics.finish() }
+
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         self.urlSession = session
 
         var wsURLString = wsURL
 
         // Pass auth token as query param (WebSocket headers are limited)
-        if let accessToken = await AuthService.shared.getAccessToken() {
+        metrics.begin(.tokenFetch)
+        let accessToken = await AuthService.shared.getAccessToken()
+        metrics.end(.tokenFetch)
+        if let accessToken {
             let separator = wsURLString.contains("?") ? "&" : "?"
             wsURLString += "\(separator)token=\(accessToken)"
         }
@@ -141,6 +155,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         }
 
         self.webSocketTask = task
+        metrics.begin(.wsUpgrade) // ended by didOpenWithProtocol on the delegate queue
         task.resume()
 
         let config = Self.makeConnectionConfig(
@@ -155,6 +170,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         let configString = String(data: configData, encoding: .utf8) ?? "{}"
 
         NSLog("[Cloud RT] Sending config: %@", configString)
+        metrics.begin(.configSend)
         do {
             try await task.send(.string(configString))
         } catch {
@@ -166,6 +182,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             }
             throw error
         }
+        metrics.end(.configSend)
         NSLog("[Cloud RT] Config sent successfully, WebSocket connected")
 
         lifecycleLock.lock()
@@ -176,6 +193,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         startPingLoop()
 
         // Wait for proxy_ready before marking connected
+        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
         let deadline = Date().addingTimeInterval(10)
         while Date() < deadline {
             lifecycleLock.lock()
@@ -192,6 +210,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             throw RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
         }
 
+        metrics.finish(outcome: "ok")
         onConnectionStatusChanged?(.connected)
     }
 
@@ -405,7 +424,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
            json["type"] as? String == "proxy_ready" {
             lifecycleLock.lock()
             proxyReady = true
+            let metrics = currentConnectMetrics
             lifecycleLock.unlock()
+            metrics?.end(.proxyReadyWait)
             NSLog("[Cloud RT] Received proxy_ready signal")
             return
         }
@@ -760,6 +781,10 @@ extension CloudRealtimeService: URLSessionWebSocketDelegate {
         webSocketTask _: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
     ) {
+        lifecycleLock.lock()
+        let metrics = currentConnectMetrics
+        lifecycleLock.unlock()
+        metrics?.end(.wsUpgrade)
         Log.transcription.info("Cloud RT: WebSocket opened, protocol: \(String(describing: `protocol`))")
     }
 

--- a/Diduny/Core/Services/ConnectMetrics.swift
+++ b/Diduny/Core/Services/ConnectMetrics.swift
@@ -1,0 +1,106 @@
+import Foundation
+import os
+
+/// Collects phase timings for one realtime connect (or meeting start) and emits
+/// them as os_signpost intervals plus a single summary log line, so connect
+/// latency can be measured from Console / `log stream` or Instruments and
+/// compared before/after optimizations.
+///
+/// Thread-safe: phases may begin/end on different threads (e.g. `upgrade`
+/// ends on the URLSession delegate queue while `config` runs on the caller).
+final class ConnectMetrics: @unchecked Sendable {
+    enum Phase: String {
+        case tokenFetch = "token"
+        case wsUpgrade = "upgrade"
+        case configSend = "config"
+        case proxyReadyWait = "ready"
+        case recorderStart = "recorder"
+    }
+
+    private static let signposter = OSSignposter(
+        subsystem: "ua.com.rmarinsky.diduny",
+        category: "connect"
+    )
+
+    private let label: String
+    private let lock = NSLock()
+    private let signpostID: OSSignpostID
+    private let totalState: OSSignpostIntervalState
+    private let startedAt = ContinuousClock.now
+    private var openPhases: [Phase: (state: OSSignpostIntervalState, start: ContinuousClock.Instant)] = [:]
+    private var completedPhases: [(phase: Phase, ms: Int)] = []
+    private var summaryEmitted = false
+
+    init(label: String) {
+        self.label = label
+        signpostID = Self.signposter.makeSignpostID()
+        totalState = Self.signposter.beginInterval("total", id: signpostID, "\(label)")
+    }
+
+    func begin(_ phase: Phase) {
+        let state = Self.signposter.beginInterval("phase", id: signpostID, "\(self.label).\(phase.rawValue)")
+        lock.lock()
+        openPhases[phase] = (state, .now)
+        lock.unlock()
+    }
+
+    func end(_ phase: Phase) {
+        lock.lock()
+        guard let entry = openPhases.removeValue(forKey: phase) else {
+            lock.unlock()
+            return
+        }
+        completedPhases.append((phase, Self.milliseconds(since: entry.start)))
+        lock.unlock()
+        Self.signposter.endInterval("phase", entry.state)
+    }
+
+    /// Ends the total interval and logs one summary line. Idempotent, so error
+    /// paths can rely on a `defer { metrics.finish(outcome: "aborted") }` while
+    /// the success path calls `finish(outcome: "ok")` explicitly first.
+    func finish(outcome: String = "aborted") {
+        lock.lock()
+        guard !summaryEmitted else {
+            lock.unlock()
+            return
+        }
+        summaryEmitted = true
+        // Close phases left open by an error path so their time is still reported.
+        let abandoned = openPhases
+        openPhases.removeAll()
+        for (phase, entry) in abandoned {
+            completedPhases.append((phase, Self.milliseconds(since: entry.start)))
+        }
+        let phases = completedPhases
+            .map { "\($0.phase.rawValue)=\($0.ms)ms" }
+            .joined(separator: " ")
+        lock.unlock()
+
+        for (_, entry) in abandoned {
+            Self.signposter.endInterval("phase", entry.state)
+        }
+        Self.signposter.endInterval("total", totalState)
+
+        let totalMs = Self.milliseconds(since: startedAt)
+        NSLog("%@", "\(label) timings: \(phases) total=\(totalMs)ms outcome=\(outcome)")
+    }
+
+    /// One-shot interval around an async operation, for call sites that don't
+    /// carry a ConnectMetrics instance (e.g. deep inside capture services).
+    static func measure<T>(_ label: String, _ body: () async throws -> T) async rethrows -> T {
+        let signpostID = signposter.makeSignpostID()
+        let state = signposter.beginInterval("measure", id: signpostID, "\(label)")
+        let start = ContinuousClock.now
+        defer {
+            signposter.endInterval("measure", state)
+            NSLog("%@", "\(label) took \(milliseconds(since: start))ms")
+        }
+        return try await body()
+    }
+
+    private static func milliseconds(since start: ContinuousClock.Instant) -> Int {
+        let duration = start.duration(to: .now)
+        return Int(duration.components.seconds) * 1000
+            + Int(duration.components.attoseconds / 1_000_000_000_000_000)
+    }
+}

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -202,7 +202,9 @@ final class SystemAudioCaptureService: NSObject {
     }
 
     private func createAndStartSystemStream() async throws {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let content = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
+            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        }
 
         guard let display = content.displays.first else {
             throw SystemAudioError.noDisplayFound
@@ -218,7 +220,9 @@ final class SystemAudioCaptureService: NSObject {
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: streamOutputQueue)
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: streamOutputQueue)
             self.stream = stream
-            try await stream.startCapture()
+            try await ConnectMetrics.measure("[Meeting] sc_stream_start") {
+                try await stream.startCapture()
+            }
         } catch {
             self.stream = nil
             throw error

--- a/project.yml
+++ b/project.yml
@@ -72,6 +72,8 @@ targets:
       - path: Diduny
         excludes:
           - "**/.DS_Store"
+          - ".claude"
+          - "**/.claude"
     dependencies:
       - package: KeyboardShortcuts
       - package: DynamicNotchKit


### PR DESCRIPTION
## What

Adds `ConnectMetrics` — os_signpost intervals + one greppable summary log line — and instruments:

- **Realtime WS connect** (`CloudRealtimeService.connectWebSocket`): `token` (auth token fetch), `upgrade` (task.resume → didOpenWithProtocol), `config` (config message send), `ready` (config sent → proxy_ready), `total`. Summary: `[Cloud RT] connect timings: token=…ms upgrade=…ms config=…ms ready=…ms total=…ms outcome=ok`.
- **Meeting start** (`startMeetingRecording`): `recorder` phase + total to `.recording` state, plus one-shot measures around `SCShareableContent` fetch and `SCStream.startCapture` (`[Meeting] sc_content_fetch took …ms`).

## Why

Baseline for the connect-latency work (client audio buffering, meeting-start parallelization, server upgrade parallelism). Collect with:

```
log stream --predicate 'eventMessage CONTAINS "timings"'
```

or Instruments (subsystem `ua.com.rmarinsky.diduny`, category `connect`).

## Incidental fix

`project.yml` now excludes `.claude/` from sources — stray local agent-memory files under `Diduny/Diduny/.claude/` produced duplicate `MEMORY.md` resource outputs and broke any freshly regenerated project.

## Testing

- `xcodebuild build` — BUILD SUCCEEDED
- `xcodebuild test` — 53/53 tests pass
- No behavior changes; instrumentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved timing and diagnostics for meeting recording, realtime connection, and audio capture startup.
* **Bug Fixes**
  * Better handles connection phases across the app so completed and interrupted flows are tracked more accurately.
* **Chores**
  * Updated project settings to include the new app source and ignore local Claude-related files during project processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->