### PR TITLE
perf: make realtime connect latency invisible to the user

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -24,11 +24,13 @@
 		247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */; };
 		247C7BD6AD352D40A40CCFD0 /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = B431F17EA826367ED3C4D989 /* DynamicNotchKit */; };
 		282F528D9F0D4B11455FFA3A /* AppDelegate+FileTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */; };
+		2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */; };
 		2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583D24D80FE19BB49505E371 /* TextTranslationWindowController.swift */; };
 		2EF13108B3414D04405FD360 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF8E52BB2FE2DF4133F56731 /* Accelerate.framework */; };
 		3230AC685182CD2F888DF3BC /* MeetingAudioSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3193B0160E38FA4135969F79 /* MeetingAudioSource.swift */; };
 		37B4946599B2FDB08DEB48E7 /* DidunyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE5770AB5E9601E0DB6B878 /* DidunyApp.swift */; };
 		3857104F9A2310C3DA6E8290 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924F66A90537891F57F1CF0D /* PermissionManager.swift */; };
+		3888E00F99EDC95425112292 /* PreConnectAudioBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */; };
 		3FDACDAE1B8CF7A54595BE9D /* AudioPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */; };
 		416BAE722E64C33169DE1E7F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 1682C3BCEB8B3B3CE61588C9 /* Supabase */; };
 		438C177832C516A8BD571C36 /* WhisperModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71FCAF64D600F8EFA8B20A2 /* WhisperModelManager.swift */; };
@@ -93,6 +95,7 @@
 		BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */; };
 		BF50A7600E9D175A63D987E7 /* AuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90DC34399C728FB2BD9C292 /* AuthServiceTests.swift */; };
 		C24B6F611448AF8CAD8E3DB9 /* MeetingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA64DC6EAB5D1FB38CF7F517 /* MeetingSettingsView.swift */; };
+		C4779B88D927AD824F1A9C3B /* ShareableContentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */; };
 		C5FA530A98A4A76DD9DEA952 /* AppDelegate+MeetingRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */; };
 		C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */; };
 		C8BEA1A38683AA8F1AA4D84E /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1A1D461E4C3229A9A8A486 /* AudioDeviceManager.swift */; };
@@ -170,6 +173,7 @@
 		312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTranslationView.swift; sourceTree = "<group>"; };
 		3193B0160E38FA4135969F79 /* MeetingAudioSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingAudioSource.swift; sourceTree = "<group>"; };
 		31E7F6FB04A54A9F5A3F9A8F /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreConnectAudioBuffer.swift; sourceTree = "<group>"; };
 		37F0D303A220D46E8D6F7A57 /* AudioConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		38BE9CBB73A253BFF5530CBD /* NotchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManager.swift; sourceTree = "<group>"; };
 		39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackService.swift; sourceTree = "<group>"; };
@@ -177,6 +181,7 @@
 		3E35E1F13A5F9761C79FB488 /* AppDelegate+Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Recording.swift"; sourceTree = "<group>"; };
 		3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperContext.swift; sourceTree = "<group>"; };
 		40E7786C88C96F6C70862A1E /* OfflineModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModelsSettingsView.swift; sourceTree = "<group>"; };
+		44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableContentCache.swift; sourceTree = "<group>"; };
 		44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingModelMigrationTests.swift; sourceTree = "<group>"; };
 		452F045E726DADF6E51D7778 /* ConnectMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectMetrics.swift; sourceTree = "<group>"; };
 		459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
@@ -261,6 +266,7 @@
 		F4E5B531DCAD149223A50A75 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		F54AB0D8602B537FB2845507 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F6206FCF30AD9AFE3530CB50 /* WhisperTranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperTranscriptionService.swift; sourceTree = "<group>"; };
+		F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreConnectAudioBufferTests.swift; sourceTree = "<group>"; };
 		F91E893AF3E6C20B492D3CB7 /* SettingsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStorage.swift; sourceTree = "<group>"; };
 		F94036B3B62E2E2464BB3750 /* InProgressRecordingManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressRecordingManifest.swift; sourceTree = "<group>"; };
 		FB2D4C4C36B3BB89D1A2E8BD /* CloudTranscriptionServiceE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTranscriptionServiceE2ETests.swift; sourceTree = "<group>"; };
@@ -407,10 +413,12 @@
 				0491E26240E167BDB5DCACEE /* HotkeyService.swift */,
 				893211B2A0981542B494E03B /* MeetingChunkStitcher.swift */,
 				FE81A3506184A31D459CC1DA /* MeetingRecorderService.swift */,
+				33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */,
 				258680FE2F7ED1EB6DB95757 /* ProtectedLexiconService.swift */,
 				4CDE81820CACD577C91281C9 /* PushToTalkService.swift */,
 				E819431AE3C66AA9B422954A /* RecordingQueueService.swift */,
 				4852162851F73B8352C95E25 /* RemoteConfigService.swift */,
+				44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */,
 				24A8CC23A7C474D5EFDFBAC1 /* SleepFlushCoordinator.swift */,
 				22F3DF3DBD7AB2A6B8F1B8D1 /* SupabaseService.swift */,
 				70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */,
@@ -598,6 +606,7 @@
 				4E5E0CC22FD7FC0DA86702AF /* MeetingChunkStitcherTests.swift */,
 				12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */,
 				D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */,
+				F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */,
 				7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */,
 				51CA770F4886473BDED207C7 /* PushToTalkServiceTests.swift */,
 				44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */,
@@ -815,6 +824,7 @@
 				1D8F54C7E34D0BF458CDE89A /* OverviewView.swift in Sources */,
 				3857104F9A2310C3DA6E8290 /* PermissionManager.swift in Sources */,
 				CAA3AF319715F9DD611CCC8B /* PermissionsSettingsView.swift in Sources */,
+				3888E00F99EDC95425112292 /* PreConnectAudioBuffer.swift in Sources */,
 				9082E75ACDAF59018B93B6DF /* ProtectedLexiconService.swift in Sources */,
 				86207F57859F544F066B0140 /* PushToTalkKey.swift in Sources */,
 				497E932204DB8D119B40EAA5 /* PushToTalkService.swift in Sources */,
@@ -831,6 +841,7 @@
 				F1802FC4C604B7FB3AA13B96 /* RemoteConfigService.swift in Sources */,
 				CC8A0AB7ADA44B998EC3E45D /* ServiceProtocols.swift in Sources */,
 				0FFD1A4567A90C61047FD763 /* SettingsStorage.swift in Sources */,
+				C4779B88D927AD824F1A9C3B /* ShareableContentCache.swift in Sources */,
 				1FC13B68C69A30C9FD13E2F0 /* ShortcutsSettingsView.swift in Sources */,
 				E936FF3D499BC2EFB6DC0A14 /* SidebarView.swift in Sources */,
 				B62B0933F7CA028942582A14 /* SleepFlushCoordinator.swift in Sources */,
@@ -865,6 +876,7 @@
 				E7F1B035104E1A79711068B2 /* MeetingChunkStitcherTests.swift in Sources */,
 				007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */,
 				474BEF9A6D5E57064A709DFD /* NotchStateTests.swift in Sources */,
+				2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */,
 				DE51034347AC539254418EF9 /* ProtectedLexiconServiceTests.swift in Sources */,
 				533F7EE6501E899BF20CF259 /* PushToTalkServiceTests.swift in Sources */,
 				9C3AB3F7109D41F8F612797B /* RecordingModelMigrationTests.swift in Sources */,

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -7,6 +7,10 @@ extension AppDelegate {
     @objc func toggleMeetingRecording() {
         let meetingRecordingState = appState.meetingRecordingState
         Log.app.info("toggleMeetingRecording called, current state: \(meetingRecordingState)")
+        // Recording intent: warm the two slow dependencies of a meeting start
+        // while permission checks and device setup run.
+        ShareableContentCache.shared.prewarm()
+        Task { _ = await AuthService.shared.getAccessToken() }
         meetingPipelineTask?.cancel()
         meetingPipelineTask = Task {
             await self.performToggleMeetingRecording()
@@ -44,8 +48,10 @@ extension AppDelegate {
         // Deactivate escape cancel handler
         EscapeCancelService.shared.deactivate()
 
-        // Disconnect real-time transcription (if active)
-        if appState.liveTranscriptStore != nil {
+        // Disconnect real-time transcription (if active or still connecting)
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = nil
+        if appState.liveTranscriptStore != nil || meetingRecorderService.onRealtimeAudioData != nil {
             await realtimeTranscriptionService.disconnect()
             meetingRecorderService.onRealtimeAudioData = nil
         }
@@ -181,18 +187,22 @@ extension AppDelegate {
                 appState.deviceFallbackWarning = nil
             }
 
-            startMetrics.begin(.recorderStart)
-            try await meetingRecorderService.startRecording()
-            startMetrics.end(.recorderStart)
-            Log.app.info("Meeting recording started")
-
-            // Setup real-time transcription in Cloud mode
+            // Wire realtime transcription and start connecting BEFORE capture
+            // setup, so the WS handshake overlaps ScreenCaptureKit/mic startup
+            // instead of running after it. Audio captured before the socket is
+            // up is buffered by CloudRealtimeService and flushed on connect —
+            // recording never waits for the network.
             var store: LiveTranscriptStore?
             if cloudModeEnabled {
                 store = await setupRealtimeTranscription()
             } else {
                 Log.app.info("Local mode selected — recording audio only")
             }
+
+            startMetrics.begin(.recorderStart)
+            try await meetingRecorderService.startRecording()
+            startMetrics.end(.recorderStart)
+            Log.app.info("Meeting recording started")
 
             // Only set recording state AFTER confirmed working
             let recordingStateAfterStart = appState.meetingRecordingState
@@ -201,6 +211,10 @@ extension AppDelegate {
                     .warning(
                         "startMeetingRecording: state changed during init (now \(recordingStateAfterStart)), aborting"
                     )
+                meetingRealtimeConnectTask?.cancel()
+                meetingRealtimeConnectTask = nil
+                await realtimeTranscriptionService.disconnect()
+                meetingRecorderService.onRealtimeAudioData = nil
                 await meetingRecorderService.cancelRecording()
                 if let token = meetingActivityToken {
                     ProcessInfo.processInfo.endActivity(token)
@@ -247,6 +261,12 @@ extension AppDelegate {
             }
         } catch {
             Log.app.error("Meeting recording failed: \(error)")
+
+            // Abort the in-flight realtime connect — nothing will consume it.
+            meetingRealtimeConnectTask?.cancel()
+            meetingRealtimeConnectTask = nil
+            await realtimeTranscriptionService.disconnect()
+            meetingRecorderService.onRealtimeAudioData = nil
 
             // End App Nap prevention on failed start
             if let token = meetingActivityToken {
@@ -298,25 +318,35 @@ extension AppDelegate {
             // Don't stop recording — file recording continues independently
         }
 
-        // Connect WebSocket (non-blocking — recording works even if this fails)
-        do {
-            let languageHints = SettingsStorage.shared.speechLanguageHints
-
-            try await rtService.connect(
-                languageHints: languageHints,
-                strictLanguageHints: !languageHints.isEmpty
-            )
-            await MainActor.run {
-                store.isActive = true
+        // Connect in the background — recording start never waits for the
+        // network, and CloudRealtimeService buffers audio until the socket is
+        // up. On failure the recording continues (async transcription fallback
+        // on stop); the store's connectionStatus reflects progress in the UI.
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = Task { [weak self, weak store] in
+            guard let self else { return }
+            do {
+                let languageHints = SettingsStorage.shared.speechLanguageHints
+                try await self.realtimeTranscriptionService.connect(
+                    languageHints: languageHints,
+                    strictLanguageHints: !languageHints.isEmpty
+                )
+                await MainActor.run {
+                    store?.isActive = true
+                }
+                Log.transcription.info("Meeting real-time transcription connected successfully")
+            } catch {
+                Log.transcription.error(
+                    "Meeting real-time transcription FAILED to connect: \(error.localizedDescription)"
+                )
+                // Stop/cancel paths abort this task; don't overwrite the store
+                // state they are tearing down.
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    store?.isActive = true
+                    store?.connectionStatus = .failed(error.localizedDescription)
+                }
             }
-            Log.transcription.info("Meeting real-time transcription connected successfully")
-        } catch {
-            Log.transcription.error("Meeting real-time transcription FAILED to connect: \(error.localizedDescription)")
-            await MainActor.run {
-                store.isActive = true
-                store.connectionStatus = .failed(error.localizedDescription)
-            }
-            // Recording continues — fallback to async transcription on stop
         }
 
         return store
@@ -353,6 +383,8 @@ extension AppDelegate {
         }
 
         // Finalize and disconnect real-time transcription (if active)
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = nil
         let hasRealtimeSession = await MainActor.run { appState.liveTranscriptStore != nil }
         var didReceiveRealtimeFinalization = true
         if hasRealtimeSession {
@@ -361,6 +393,9 @@ extension AppDelegate {
             await realtimeTranscriptionService.disconnect()
             meetingRecorderService.onRealtimeAudioData = nil
         }
+
+        // Next meeting start should hit a warm SCShareableContent cache.
+        ShareableContentCache.shared.prewarm()
 
         // Mark store as no longer active
         let store = await MainActor.run { appState.liveTranscriptStore }

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -156,6 +156,10 @@ extension AppDelegate {
             return
         }
 
+        // Pre-warm the auth token so a needed refresh overlaps audio setup
+        // instead of sitting inside the realtime connect.
+        Task { _ = await AuthService.shared.getAccessToken() }
+
         // Request microphone permission on-demand
         let micGranted = await PermissionManager.shared.ensureMicrophonePermission(context: .dictation)
         appState.microphonePermissionGranted = micGranted

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -133,6 +133,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var translationPipelineTask: Task<Void, Never>?
     var meetingPipelineTask: Task<Void, Never>?
     var meetingTranslationPipelineTask: Task<Void, Never>?
+    /// In-flight meeting realtime WS connect, launched before capture setup so
+    /// the handshake overlaps it. Held so stop/cancel can abort a connect that
+    /// is still in progress.
+    var meetingRealtimeConnectTask: Task<Void, Never>?
 
     // Auto-reset Tasks (success/error → idle timers)
     var voiceAutoResetTask: Task<Void, Never>?
@@ -188,6 +192,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // flag) which does not trigger the keychain read.
 
         setupNotchStopHandler()
+
+        // Meeting starts fetch SCShareableContent (0.5-2s from the window
+        // server); warm the cache now so the first start hits it. No-op until
+        // screen-recording permission has been granted.
+        ShareableContentCache.shared.prewarm()
 
         // Listen for push-to-talk key changes
         NotificationCenter.default.addObserver(

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -11,7 +11,13 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         return "\(proxyBase)/api/v1/realtime"
     }
     private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession: URLSession?
+    /// One URLSession for the service's lifetime, so the TLS session cache
+    /// survives across connections (TLS 1.3 resumption saves a round trip on
+    /// every recording start). Never invalidate it — invalidateAndCancel would
+    /// permanently break all future connects. The session retains its delegate
+    /// (self); acceptable, this service lives as long as the app. Guarded by
+    /// lifecycleLock.
+    private var _sharedSession: URLSession?
     private var receiveTask: Task<Void, Never>?
     private var pingTask: Task<Void, Never>?
     /// In-flight reconnect (sleeping during backoff). Held so disconnect() can cancel it —
@@ -19,6 +25,23 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     /// socket after teardown and loops forever with no audio source. Guarded by lifecycleLock.
     private var reconnectTask: Task<Void, Never>?
     private var proxyReady = false
+    /// Resumed exactly once (take-and-nil under lifecycleLock) by whichever
+    /// fires first: proxy_ready, a proxy error frame, the timeout watchdog,
+    /// or disconnect.
+    private var proxyReadyContinuation: CheckedContinuation<Void, Error>?
+    private var proxyReadyTimeoutTask: Task<Void, Never>?
+    /// Audio produced while the socket is connecting or in reconnect backoff.
+    /// Flushed in order on connect, so the first seconds of speech reach
+    /// transcription instead of being dropped. Guarded by lifecycleLock.
+    private var pendingAudio = PreConnectAudioBuffer()
+    private var didWarnPendingAudioOverflow = false
+    /// True from connect() until disconnect() or a terminal failure — the
+    /// window in which buffering audio is worthwhile. Guarded by lifecycleLock.
+    private var sessionActive = false
+    /// True while the post-connect flush drains pendingAudio. New audio must
+    /// join the back of the queue during a flush, never jump straight to the
+    /// socket, or chunks would arrive out of order. Guarded by lifecycleLock.
+    private var flushingPendingAudio = false
     /// Phase timings for the in-flight connect. Guarded by lifecycleLock; the
     /// URLSession delegate and receive loop close phases from other threads.
     private var currentConnectMetrics: ConnectMetrics?
@@ -80,6 +103,13 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         self.translationConfig = translationConfig
         self.enableSpeakerDiarization = enableSpeakerDiarization
         reconnectAttempt = 0
+        // Fresh session: start buffering incoming audio right away, so speech
+        // during the connect handshake is delivered once the socket is up.
+        lifecycleLock.lock()
+        sessionActive = true
+        pendingAudio.removeAll()
+        didWarnPendingAudioOverflow = false
+        lifecycleLock.unlock()
         try await connectWebSocket()
     }
 
@@ -92,15 +122,15 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             )
         }
 
-        // Clean up any existing connection before reconnecting
+        // Clean up any existing connection before reconnecting. Note:
+        // pendingAudio is deliberately NOT cleared — audio buffered during a
+        // reconnect backoff must survive into the new connection.
         pingTask?.cancel()
         pingTask = nil
         receiveTask?.cancel()
         receiveTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
         lifecycleLock.lock()
         audioBytesSent = 0
         audioChunkCount = 0
@@ -117,8 +147,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // only fires when an error path unwinds out of connectWebSocket().
         defer { metrics.finish() }
 
-        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-        self.urlSession = session
+        let session = sharedSession()
 
         var wsURLString = wsURL
 
@@ -187,31 +216,113 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         lifecycleLock.lock()
         isConnected = true
+        // Route new audio to the back of the queue until the flush drains it.
+        flushingPendingAudio = !pendingAudio.isEmpty
+        let needsFlush = flushingPendingAudio
         lifecycleLock.unlock()
 
         startReceiveLoop()
         startPingLoop()
 
-        // Wait for proxy_ready before marking connected
-        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
-        let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
-            lifecycleLock.lock()
-            let ready = proxyReady
-            lifecycleLock.unlock()
-            if ready { break }
-            try? await Task.sleep(for: .milliseconds(50))
+        // Deliver audio captured while connecting. Safe before proxy_ready:
+        // the proxy buffers frames until Soniox is ready (1MB server cap).
+        if needsFlush {
+            await flushPendingAudio(task: task)
         }
-        lifecycleLock.lock()
-        let proxyIsReady = proxyReady
-        lifecycleLock.unlock()
-        guard proxyIsReady else {
+
+        // Wait for proxy_ready before marking connected.
+        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                lifecycleLock.lock()
+                if proxyReady {
+                    lifecycleLock.unlock()
+                    continuation.resume()
+                    return
+                }
+                proxyReadyContinuation = continuation
+                proxyReadyTimeoutTask = Task { [weak self] in
+                    try? await Task.sleep(for: .seconds(10))
+                    guard !Task.isCancelled else { return }
+                    self?.resumeProxyReady(with: .failure(
+                        RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
+                    ))
+                }
+                lifecycleLock.unlock()
+            }
+        } catch {
             await disconnect()
-            throw RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
+            throw error
         }
 
         metrics.finish(outcome: "ok")
         onConnectionStatusChanged?(.connected)
+    }
+
+    /// Thread-safe accessor for the process-lifetime URLSession (see _sharedSession).
+    private func sharedSession() -> URLSession {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        if let session = _sharedSession {
+            return session
+        }
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        _sharedSession = session
+        return session
+    }
+
+    /// Resolves the proxy_ready wait exactly once; later calls are no-ops.
+    private func resumeProxyReady(with result: Result<Void, Error>) {
+        lifecycleLock.lock()
+        let continuation = proxyReadyContinuation
+        proxyReadyContinuation = nil
+        let timeoutTask = proxyReadyTimeoutTask
+        proxyReadyTimeoutTask = nil
+        lifecycleLock.unlock()
+
+        timeoutTask?.cancel()
+        switch result {
+        case .success:
+            continuation?.resume()
+        case let .failure(error):
+            continuation?.resume(throwing: error)
+        }
+    }
+
+    /// Drains pendingAudio to the socket in FIFO order. Sends are awaited so
+    /// ordering is preserved; audio arriving mid-flush is appended behind the
+    /// queued chunks by sendAudioData (flushingPendingAudio gate).
+    private func flushPendingAudio(task: URLSessionWebSocketTask) async {
+        var flushedChunks = 0
+        var flushedBytes = 0
+        while true {
+            lifecycleLock.lock()
+            guard isConnected, let chunk = pendingAudio.removeFirst() else {
+                flushingPendingAudio = false
+                lifecycleLock.unlock()
+                break
+            }
+            audioBytesSent += chunk.count
+            audioChunkCount += 1
+            lifecycleLock.unlock()
+
+            do {
+                try await task.send(.data(chunk))
+                flushedChunks += 1
+                flushedBytes += chunk.count
+            } catch {
+                Log.transcription.error("Cloud RT: Buffered audio flush failed - \(error.localizedDescription)")
+                // The connection is failing; the receive loop / delegate will
+                // drive reconnect, and remaining chunks stay buffered for it.
+                lifecycleLock.lock()
+                flushingPendingAudio = false
+                lifecycleLock.unlock()
+                break
+            }
+        }
+        if flushedChunks > 0 {
+            NSLog("[Cloud RT] Flushed %d buffered audio chunks (%d bytes)", flushedChunks, flushedBytes)
+        }
     }
 
     // MARK: - Send Audio Data
@@ -225,7 +336,25 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // Capture task reference under the lock so we don't race with disconnect.
         // Do NOT hold the lock while calling task.send (may block on internal queues).
         lifecycleLock.lock()
-        guard isConnected, let task = webSocketTask else {
+        // Not connected yet (connecting or reconnect backoff), or a flush is
+        // still draining: buffer so nothing is lost and ordering holds.
+        if !isConnected || flushingPendingAudio || !pendingAudio.isEmpty {
+            guard sessionActive else {
+                lifecycleLock.unlock()
+                return
+            }
+            pendingAudio.append(data)
+            let overflowed = pendingAudio.didOverflow && !didWarnPendingAudioOverflow
+            if overflowed {
+                didWarnPendingAudioOverflow = true
+            }
+            lifecycleLock.unlock()
+            if overflowed {
+                Log.transcription.warning("Cloud RT: pre-connect audio buffer overflow — dropping oldest audio")
+            }
+            return
+        }
+        guard let task = webSocketTask else {
             lifecycleLock.unlock()
             return
         }
@@ -351,6 +480,11 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     func disconnect() async {
         Log.transcription.info("Cloud RT: Disconnecting...")
 
+        // Unblock a connect() stuck waiting for proxy_ready.
+        resumeProxyReady(with: .failure(
+            RealtimeTranscriptionError.connectionFailed("Disconnected while connecting")
+        ))
+
         pingTask?.cancel()
         pingTask = nil
         receiveTask?.cancel()
@@ -360,17 +494,30 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         let task = webSocketTask
         webSocketTask = nil
         isConnected = false
+        sessionActive = false
+        pendingAudio.removeAll()
+        flushingPendingAudio = false
         // Kill any reconnect scheduled by a drop that raced just before this disconnect.
         reconnectTask?.cancel()
         reconnectTask = nil
         lifecycleLock.unlock()
 
         task?.cancel(with: .normalClosure, reason: nil)
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
+        // The shared URLSession stays alive: its TLS session cache makes the
+        // next connect cheaper, and invalidating it would break future connects.
         onConnectionStatusChanged?(.disconnected)
 
         Log.transcription.info("Cloud RT: Disconnected")
+    }
+
+    /// Stops buffering and drops pending audio — the session has terminally
+    /// failed and nothing will consume the buffer.
+    private func endBufferingSession() {
+        lifecycleLock.lock()
+        sessionActive = false
+        pendingAudio.removeAll()
+        flushingPendingAudio = false
+        lifecycleLock.unlock()
     }
 
     // MARK: - Receive Loop
@@ -427,6 +574,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             let metrics = currentConnectMetrics
             lifecycleLock.unlock()
             metrics?.end(.proxyReadyWait)
+            resumeProxyReady(with: .success(()))
             NSLog("[Cloud RT] Received proxy_ready signal")
             return
         }
@@ -437,6 +585,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
            json["tokens"] == nil {
             let error = RealtimeTranscriptionError.connectionFailed(errorMsg)
             Log.transcription.error("Cloud RT: Proxy error - \(errorMsg)")
+            // An error frame before proxy_ready means the connect failed —
+            // fail it now instead of waiting out the 10s timeout.
+            resumeProxyReady(with: .failure(error))
             onError?(error)
             onConnectionStatusChanged?(.failed(errorMsg))
             return
@@ -553,8 +704,14 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // refusing — and would surface a generic "Connection lost" instead of the
         // real reason. Detect it synchronously to stop the reconnect, then surface
         // the typed usage error with the best numbers we have.
+        // Whatever path led here, a connect() awaiting proxy_ready must not hang.
+        resumeProxyReady(with: .failure(
+            RealtimeTranscriptionError.connectionFailed("Connection lost while connecting")
+        ))
+
         if (webSocketTask?.response as? HTTPURLResponse)?.statusCode == 402 {
             Log.transcription.warning("Cloud RT: WS upgrade returned 402 — usage limit, not reconnecting")
+            endBufferingSession()
             Task { [weak self] in
                 guard let self else { return }
                 let usage = await UsageService.shared.cachedUsage
@@ -572,6 +729,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // Per ADR-0004: save partial transcript, show non-error UI, do NOT reconnect.
         if closeCode?.rawValue == 1001 {
             Log.transcription.info("Cloud RT: WS 1001 Going Away — session cap reached, not reconnecting")
+            endBufferingSession()
             onConnectionStatusChanged?(.disconnected)
             // Signal upstream (AppDelegate / MeetingRecorderService) to flush partial transcript.
             // We reuse the existing segmentBoundary path: emit .endpoint so callers finalise.
@@ -581,6 +739,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         guard reconnectAttempt < maxReconnectAttempts else {
             Log.transcription.error("Cloud RT: Max reconnect attempts reached")
+            endBufferingSession()
             onConnectionStatusChanged?(.failed("Connection lost after \(maxReconnectAttempts) attempts"))
             return
         }
@@ -617,6 +776,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
                         Log.transcription.info("Cloud RT: Reconnected after token refresh")
                     } catch {
                         Log.transcription.error("Cloud RT: Reconnect after token refresh failed - \(error.localizedDescription)")
+                        self.endBufferingSession()
                         self.onError?(error)
                         self.onConnectionStatusChanged?(.failed("Session expired — please log in again"))
                     }

--- a/Diduny/Core/Services/PreConnectAudioBuffer.swift
+++ b/Diduny/Core/Services/PreConnectAudioBuffer.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Bounded FIFO for audio produced while the realtime socket is still
+/// connecting (or reconnecting). Once the cap is exceeded the oldest chunks
+/// are evicted, so a stalled connection costs the oldest audio, never
+/// unbounded memory. Not thread-safe — callers synchronize externally
+/// (CloudRealtimeService guards it with lifecycleLock).
+struct PreConnectAudioBuffer {
+    /// ~15s of 16kHz mono s16le — enough to cover connect plus one
+    /// reconnect backoff without losing speech.
+    static let defaultMaxBytes = 480_000
+
+    private(set) var totalBytes = 0
+    private(set) var didOverflow = false
+    private var chunks: [Data] = []
+    let maxBytes: Int
+
+    init(maxBytes: Int = PreConnectAudioBuffer.defaultMaxBytes) {
+        self.maxBytes = maxBytes
+    }
+
+    var isEmpty: Bool { chunks.isEmpty }
+    var count: Int { chunks.count }
+
+    mutating func append(_ data: Data) {
+        chunks.append(data)
+        totalBytes += data.count
+        while totalBytes > maxBytes, chunks.count > 1 {
+            totalBytes -= chunks.removeFirst().count
+            didOverflow = true
+        }
+    }
+
+    mutating func removeFirst() -> Data? {
+        guard !chunks.isEmpty else { return nil }
+        let chunk = chunks.removeFirst()
+        totalBytes -= chunk.count
+        return chunk
+    }
+
+    mutating func removeAll() {
+        chunks.removeAll()
+        totalBytes = 0
+        didOverflow = false
+    }
+}

--- a/Diduny/Core/Services/ShareableContentCache.swift
+++ b/Diduny/Core/Services/ShareableContentCache.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+/// Caches SCShareableContent, whose window-server fetch takes 0.5–2s+ and sits
+/// on the meeting-start critical path. Pre-warmed at app launch, on meeting
+/// hotkey intent, and after each meeting stop, so the actual start usually
+/// hits a fresh cache.
+actor ShareableContentCache {
+    static let shared = ShareableContentCache()
+
+    private var content: SCShareableContent?
+    private var fetchedAt: Date?
+    private var inflight: Task<SCShareableContent, Error>?
+
+    /// Kick off a background refresh; cheap to call often. Fetches only when
+    /// screen-recording permission is already granted — an ungranted fetch
+    /// would surprise the user with the system permission prompt.
+    nonisolated func prewarm() {
+        guard CGPreflightScreenCaptureAccess() else { return }
+        Task { _ = try? await self.refresh() }
+    }
+
+    /// Cached content if fresh enough, else a fresh fetch. Cached content can
+    /// reference since-removed displays — callers that build an SCStream from
+    /// it must retry once with `refresh()` on stream-start failure.
+    func current(maxAge: TimeInterval = 60) async throws -> SCShareableContent {
+        if let content, let fetchedAt, Date().timeIntervalSince(fetchedAt) < maxAge {
+            return content
+        }
+        return try await refresh()
+    }
+
+    /// Always fetches fresh and updates the cache. Concurrent callers share
+    /// one in-flight fetch.
+    func refresh() async throws -> SCShareableContent {
+        if let inflight {
+            return try await inflight.value
+        }
+        let task = Task {
+            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        }
+        inflight = task
+        defer { inflight = nil }
+        let fresh = try await task.value
+        content = fresh
+        fetchedAt = Date()
+        return fresh
+    }
+}

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -202,10 +202,25 @@ final class SystemAudioCaptureService: NSObject {
     }
 
     private func createAndStartSystemStream() async throws {
-        let content = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
-            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let cachedContent = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
+            try await ShareableContentCache.shared.current()
         }
 
+        do {
+            try await startSystemStream(with: cachedContent)
+        } catch {
+            // Cached content can reference a display that is gone (monitor
+            // unplugged since the prewarm) — retry once with a fresh fetch.
+            NSLog(
+                "[AudioCapture] SCStream start failed (%@) — retrying with fresh shareable content",
+                String(describing: error)
+            )
+            let freshContent = try await ShareableContentCache.shared.refresh()
+            try await startSystemStream(with: freshContent)
+        }
+    }
+
+    private func startSystemStream(with content: SCShareableContent) async throws {
         guard let display = content.displays.first else {
             throw SystemAudioError.noDisplayFound
         }

--- a/DidunyTests/PreConnectAudioBufferTests.swift
+++ b/DidunyTests/PreConnectAudioBufferTests.swift
@@ -1,0 +1,77 @@
+@testable import Diduny
+import XCTest
+
+/// Tests for `PreConnectAudioBuffer` — the bounded FIFO that holds audio
+/// produced while the realtime socket is still connecting, so the first
+/// seconds of speech survive the handshake instead of being dropped.
+final class PreConnectAudioBufferTests: XCTestCase {
+    private func chunk(_ byte: UInt8, count: Int) -> Data {
+        Data(repeating: byte, count: count)
+    }
+
+    func testDrainsInFIFOOrder() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 1000)
+        buffer.append(chunk(1, count: 10))
+        buffer.append(chunk(2, count: 20))
+        buffer.append(chunk(3, count: 30))
+
+        XCTAssertEqual(buffer.count, 3)
+        XCTAssertEqual(buffer.totalBytes, 60)
+        XCTAssertEqual(buffer.removeFirst(), chunk(1, count: 10))
+        XCTAssertEqual(buffer.removeFirst(), chunk(2, count: 20))
+        XCTAssertEqual(buffer.removeFirst(), chunk(3, count: 30))
+        XCTAssertNil(buffer.removeFirst())
+        XCTAssertEqual(buffer.totalBytes, 0)
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
+    func testEvictsOldestBeyondByteCap() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 100)
+        buffer.append(chunk(1, count: 40))
+        buffer.append(chunk(2, count: 40))
+        XCTAssertFalse(buffer.didOverflow)
+
+        buffer.append(chunk(3, count: 40)) // 120 > 100 → chunk 1 evicted
+
+        XCTAssertTrue(buffer.didOverflow)
+        XCTAssertEqual(buffer.count, 2)
+        XCTAssertEqual(buffer.totalBytes, 80)
+        XCTAssertEqual(buffer.removeFirst(), chunk(2, count: 40))
+        XCTAssertEqual(buffer.removeFirst(), chunk(3, count: 40))
+    }
+
+    func testKeepsLatestChunkEvenWhenLargerThanCap() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 10)
+        buffer.append(chunk(1, count: 50))
+
+        // A single oversized chunk is kept — dropping it would lose the only
+        // audio we have; the cap bounds accumulation, not chunk size.
+        XCTAssertEqual(buffer.count, 1)
+        XCTAssertEqual(buffer.removeFirst(), chunk(1, count: 50))
+    }
+
+    func testRemoveAllResetsStateIncludingOverflowFlag() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 50)
+        buffer.append(chunk(1, count: 40))
+        buffer.append(chunk(2, count: 40))
+        XCTAssertTrue(buffer.didOverflow)
+
+        buffer.removeAll()
+
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(buffer.totalBytes, 0)
+        XCTAssertFalse(buffer.didOverflow)
+    }
+
+    func testFifteenSecondsOfRealtimeAudioFitsDefaultCap() {
+        // The realtime stream is 16kHz mono s16le = 32,000 bytes/s, delivered
+        // in ~100ms chunks. 15s of it must fit without eviction.
+        var buffer = PreConnectAudioBuffer()
+        let chunkBytes = 3200
+        for _ in 0 ..< 150 {
+            buffer.append(chunk(7, count: chunkBytes))
+        }
+        XCTAssertFalse(buffer.didOverflow)
+        XCTAssertEqual(buffer.totalBytes, 480_000)
+    }
+}


### PR DESCRIPTION
> **Stacked on #50** (connect metrics) — merge that first; this PR retargets to `main` automatically when #50 lands.
> **Pairs with** rmarinsky/diduny-backend#16 — the server-side 1MB pending-buffer cap should deploy before or with this release.

## Why

Two verified problems in the realtime connect path:

1. Audio produced before the WebSocket was ready was **silently dropped** (`sendAudioData` guard) — users lost the first 1–3 s of speech on every dictation/meeting start, which reads as "the socket takes forever".
2. Meeting starts **awaited the entire connect handshake** (auth token fetch → TLS → server auth/usage → config → `proxy_ready`, up to 10 s) before showing "recording" — despite a comment claiming it was non-blocking. Plus `SCShareableContent` (0.5–2 s) was re-fetched from the window server on every start.

## What

- **Pre-connect audio buffer** (`PreConnectAudioBuffer` + routing in `CloudRealtimeService.sendAudioData`): bounded FIFO (~15 s of 16 kHz s16le, oldest-evicted) filled while connecting or during reconnect backoff, flushed in order once the socket is up. Ordering is protected by a `flushingPendingAudio` gate — audio arriving mid-flush joins the back of the queue. Reconnect gaps become recovered transcript; terminal failures (402, 1001, max attempts, refresh-fail) drop the buffer.
- **`proxy_ready` continuation** instead of the 50 ms busy-wait: resumed exactly once (take-and-nil under `lifecycleLock`) by `proxy_ready`, a proxy error frame (previously waited out the full 10 s!), `disconnect()`, or a 10 s watchdog.
- **Shared URLSession** for the service's lifetime — TLS session resumption cuts a round trip per connect. Never invalidated (documented; invalidation would permanently break connects).
- **Meeting start reorder**: realtime callbacks wired and connect launched in a background task **before** ScreenCaptureKit/mic setup. `.recording` state + transcript window appear as soon as capture starts; the store's `connectionStatus` shows connect progress. Stop/cancel/state-abort/error paths cancel the in-flight connect task and disconnect.
- **`ShareableContentCache`** (actor): pre-warmed at app launch (only if screen-recording permission already granted — no surprise prompt), on meeting-hotkey intent, and after each stop. Stream start retries once with a fresh fetch if cached content references an unplugged display.
- **Auth token pre-warm** at recording intent (dictation + meeting), so a Supabase refresh overlaps audio setup instead of sitting inside the connect.

## Expected effect

- Dictation: zero lost leading audio — say "one two three" immediately after the hotkey and the full phrase transcribes.
- Meetings: time-to-recording drops to recorder-start time (no network term; sub-second SC fetch when pre-warmed). Compare `[Meeting] start timings` / `[Cloud RT] connect timings` log lines before/after (from #50).

## Testing

- `xcodebuild build` — BUILD SUCCEEDED; full test suite passes.
- New `PreConnectAudioBufferTests` (5 tests): FIFO ordering, byte-cap eviction, oversized-chunk retention, reset semantics, 15 s capacity fit.
- Manual verification checklist: dictation with immediate speech (full phrase present), meeting start with `log stream --predicate 'eventMessage CONTAINS "timings"'`, stop/cancel during connect (no hang, no stale `.failed` status), Wi-Fi drop mid-meeting (buffered audio recovered after reconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)