### PR TITLE
perf: fast realtime transcription start + fix lag under heavy use

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -24,11 +24,13 @@
 		247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */; };
 		247C7BD6AD352D40A40CCFD0 /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = B431F17EA826367ED3C4D989 /* DynamicNotchKit */; };
 		282F528D9F0D4B11455FFA3A /* AppDelegate+FileTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */; };
+		2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */; };
 		2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583D24D80FE19BB49505E371 /* TextTranslationWindowController.swift */; };
 		2EF13108B3414D04405FD360 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF8E52BB2FE2DF4133F56731 /* Accelerate.framework */; };
 		3230AC685182CD2F888DF3BC /* MeetingAudioSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3193B0160E38FA4135969F79 /* MeetingAudioSource.swift */; };
 		37B4946599B2FDB08DEB48E7 /* DidunyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE5770AB5E9601E0DB6B878 /* DidunyApp.swift */; };
 		3857104F9A2310C3DA6E8290 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924F66A90537891F57F1CF0D /* PermissionManager.swift */; };
+		3888E00F99EDC95425112292 /* PreConnectAudioBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */; };
 		3FDACDAE1B8CF7A54595BE9D /* AudioPlaybackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */; };
 		416BAE722E64C33169DE1E7F /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 1682C3BCEB8B3B3CE61588C9 /* Supabase */; };
 		438C177832C516A8BD571C36 /* WhisperModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71FCAF64D600F8EFA8B20A2 /* WhisperModelManager.swift */; };
@@ -93,6 +95,7 @@
 		BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */; };
 		BF50A7600E9D175A63D987E7 /* AuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90DC34399C728FB2BD9C292 /* AuthServiceTests.swift */; };
 		C24B6F611448AF8CAD8E3DB9 /* MeetingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA64DC6EAB5D1FB38CF7F517 /* MeetingSettingsView.swift */; };
+		C4779B88D927AD824F1A9C3B /* ShareableContentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */; };
 		C5FA530A98A4A76DD9DEA952 /* AppDelegate+MeetingRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */; };
 		C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */; };
 		C8BEA1A38683AA8F1AA4D84E /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1A1D461E4C3229A9A8A486 /* AudioDeviceManager.swift */; };
@@ -170,6 +173,7 @@
 		312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTranslationView.swift; sourceTree = "<group>"; };
 		3193B0160E38FA4135969F79 /* MeetingAudioSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingAudioSource.swift; sourceTree = "<group>"; };
 		31E7F6FB04A54A9F5A3F9A8F /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreConnectAudioBuffer.swift; sourceTree = "<group>"; };
 		37F0D303A220D46E8D6F7A57 /* AudioConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
 		38BE9CBB73A253BFF5530CBD /* NotchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManager.swift; sourceTree = "<group>"; };
 		39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackService.swift; sourceTree = "<group>"; };
@@ -177,6 +181,7 @@
 		3E35E1F13A5F9761C79FB488 /* AppDelegate+Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Recording.swift"; sourceTree = "<group>"; };
 		3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperContext.swift; sourceTree = "<group>"; };
 		40E7786C88C96F6C70862A1E /* OfflineModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModelsSettingsView.swift; sourceTree = "<group>"; };
+		44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareableContentCache.swift; sourceTree = "<group>"; };
 		44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingModelMigrationTests.swift; sourceTree = "<group>"; };
 		452F045E726DADF6E51D7778 /* ConnectMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectMetrics.swift; sourceTree = "<group>"; };
 		459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
@@ -261,6 +266,7 @@
 		F4E5B531DCAD149223A50A75 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		F54AB0D8602B537FB2845507 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F6206FCF30AD9AFE3530CB50 /* WhisperTranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperTranscriptionService.swift; sourceTree = "<group>"; };
+		F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreConnectAudioBufferTests.swift; sourceTree = "<group>"; };
 		F91E893AF3E6C20B492D3CB7 /* SettingsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStorage.swift; sourceTree = "<group>"; };
 		F94036B3B62E2E2464BB3750 /* InProgressRecordingManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressRecordingManifest.swift; sourceTree = "<group>"; };
 		FB2D4C4C36B3BB89D1A2E8BD /* CloudTranscriptionServiceE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTranscriptionServiceE2ETests.swift; sourceTree = "<group>"; };
@@ -407,10 +413,12 @@
 				0491E26240E167BDB5DCACEE /* HotkeyService.swift */,
 				893211B2A0981542B494E03B /* MeetingChunkStitcher.swift */,
 				FE81A3506184A31D459CC1DA /* MeetingRecorderService.swift */,
+				33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */,
 				258680FE2F7ED1EB6DB95757 /* ProtectedLexiconService.swift */,
 				4CDE81820CACD577C91281C9 /* PushToTalkService.swift */,
 				E819431AE3C66AA9B422954A /* RecordingQueueService.swift */,
 				4852162851F73B8352C95E25 /* RemoteConfigService.swift */,
+				44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */,
 				24A8CC23A7C474D5EFDFBAC1 /* SleepFlushCoordinator.swift */,
 				22F3DF3DBD7AB2A6B8F1B8D1 /* SupabaseService.swift */,
 				70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */,
@@ -598,6 +606,7 @@
 				4E5E0CC22FD7FC0DA86702AF /* MeetingChunkStitcherTests.swift */,
 				12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */,
 				D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */,
+				F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */,
 				7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */,
 				51CA770F4886473BDED207C7 /* PushToTalkServiceTests.swift */,
 				44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */,
@@ -815,6 +824,7 @@
 				1D8F54C7E34D0BF458CDE89A /* OverviewView.swift in Sources */,
 				3857104F9A2310C3DA6E8290 /* PermissionManager.swift in Sources */,
 				CAA3AF319715F9DD611CCC8B /* PermissionsSettingsView.swift in Sources */,
+				3888E00F99EDC95425112292 /* PreConnectAudioBuffer.swift in Sources */,
 				9082E75ACDAF59018B93B6DF /* ProtectedLexiconService.swift in Sources */,
 				86207F57859F544F066B0140 /* PushToTalkKey.swift in Sources */,
 				497E932204DB8D119B40EAA5 /* PushToTalkService.swift in Sources */,
@@ -831,6 +841,7 @@
 				F1802FC4C604B7FB3AA13B96 /* RemoteConfigService.swift in Sources */,
 				CC8A0AB7ADA44B998EC3E45D /* ServiceProtocols.swift in Sources */,
 				0FFD1A4567A90C61047FD763 /* SettingsStorage.swift in Sources */,
+				C4779B88D927AD824F1A9C3B /* ShareableContentCache.swift in Sources */,
 				1FC13B68C69A30C9FD13E2F0 /* ShortcutsSettingsView.swift in Sources */,
 				E936FF3D499BC2EFB6DC0A14 /* SidebarView.swift in Sources */,
 				B62B0933F7CA028942582A14 /* SleepFlushCoordinator.swift in Sources */,
@@ -865,6 +876,7 @@
 				E7F1B035104E1A79711068B2 /* MeetingChunkStitcherTests.swift in Sources */,
 				007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */,
 				474BEF9A6D5E57064A709DFD /* NotchStateTests.swift in Sources */,
+				2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */,
 				DE51034347AC539254418EF9 /* ProtectedLexiconServiceTests.swift in Sources */,
 				533F7EE6501E899BF20CF259 /* PushToTalkServiceTests.swift in Sources */,
 				9C3AB3F7109D41F8F612797B /* RecordingModelMigrationTests.swift in Sources */,

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		56700AFF9E4935DDDDA72D7D /* MeetingRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE81A3506184A31D459CC1DA /* MeetingRecorderService.swift */; };
 		572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */; };
 		57FF194266BABFA6EA107750 /* HTTPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622D792451975A00E4A3FCBF /* HTTPLogger.swift */; };
+		5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F045E726DADF6E51D7778 /* ConnectMetrics.swift */; };
 		5A18DAA2CFAE9E95CCA51D24 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B9A32E3B977C8D9C16E2DC20 /* Sparkle */; };
 		5B89431A91667B55380925FB /* MainSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15385C5553FC7E235C629D0 /* MainSection.swift */; };
 		5C38E65B15A426A3B51A9EEB /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF35CE111AABBE5F2797242F /* whisper.xcframework */; };
@@ -177,6 +178,7 @@
 		3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperContext.swift; sourceTree = "<group>"; };
 		40E7786C88C96F6C70862A1E /* OfflineModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineModelsSettingsView.swift; sourceTree = "<group>"; };
 		44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingModelMigrationTests.swift; sourceTree = "<group>"; };
+		452F045E726DADF6E51D7778 /* ConnectMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectMetrics.swift; sourceTree = "<group>"; };
 		459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		459DCE179DA235DE6208C013 /* SupportedLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedLanguage.swift; sourceTree = "<group>"; };
 		4852162851F73B8352C95E25 /* RemoteConfigService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigService.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */,
 				001D5E66F362C783C621055C /* CloudRealtimeService.swift */,
 				5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */,
+				452F045E726DADF6E51D7778 /* ConnectMetrics.swift */,
 				792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */,
 				8A2A0045FAC17572590BE16F /* EscapeCancelService.swift */,
 				0491E26240E167BDB5DCACEE /* HotkeyService.swift */,
@@ -771,6 +774,7 @@
 				C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */,
 				F64CD3B70A52B315B4110B8C /* CloudRealtimeService.swift in Sources */,
 				8652A9D79DB6EF0EA183113A /* CloudTranscriptionService.swift in Sources */,
+				5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */,
 				CBD76325F1DE55DA51EDD348 /* DeviceLevelMonitor.swift in Sources */,
 				A16B6680BF413BDD639BAF88 /* DictationOverlayController.swift in Sources */,
 				37B4946599B2FDB08DEB48E7 /* DidunyApp.swift in Sources */,

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */; };
 		03386BD1EB00ACDF8DD60759 /* EscapeCancelServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */; };
+		03BA270D9BB719167A7AA9B3 /* RealtimeTokenCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */; };
 		03EBBAC2178925692C5B0F28 /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */; };
 		0A59DE9F5E2B2FC471865D70 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA793C0790C4F9F4B19764D7 /* MainWindowController.swift */; };
 		0B16463025082AB0F9EF90A5 /* LiveTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C08AEA7B3D9495385E0990 /* LiveTranscriptView.swift */; };
@@ -66,6 +67,7 @@
 		733D324CBB0ADB12B3780BF8 /* WhisperTranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6206FCF30AD9AFE3530CB50 /* WhisperTranscriptionService.swift */; };
 		760CD3415170E644BC1DDCBB /* AudioDictationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAB5C5B84DF4B8F5E37A9FF /* AudioDictationSettingsView.swift */; };
 		78E2E9B4903AA5A8A50AA6FC /* AppDelegate+Hotkeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */; };
+		7A7AA8F88FE669AF3F3D3981 /* RealtimeTokenCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B570652EBADE0FBAE4F9E5 /* RealtimeTokenCoalescerTests.swift */; };
 		7E2725D4B5424D54367BCC82 /* WhisperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06909181E0B9AD3B70E57E3 /* WhisperError.swift */; };
 		8089B2EF55ADCDC2F120C765 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 57D44526E8ECA54C87677F5B /* LaunchAtLogin */; };
 		818876F960D5611C3320AEC9 /* RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58445C3A1AF119838326EC9F /* RemoteConfig.swift */; };
@@ -73,6 +75,7 @@
 		8652A9D79DB6EF0EA183113A /* CloudTranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */; };
 		8864F470B8EFDFF965ABAA76 /* SupportedLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DCE179DA235DE6208C013 /* SupportedLanguage.swift */; };
 		8CAA1C227A9788C6A9687E7D /* NotchContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622FD84CF56FC17420114B9C /* NotchContentView.swift */; };
+		8D4D2E64E0D98B0052939BEF /* LiveTranscriptStorePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF436ACD38BA065B33601DBE /* LiveTranscriptStorePerformanceTests.swift */; };
 		8E61D4628397B11E5BCEE03D /* SystemAudioCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */; };
 		8FA6B8A6240D6AE7AEA1754C /* RealtimeTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */; };
 		9082E75ACDAF59018B93B6DF /* ProtectedLexiconService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258680FE2F7ED1EB6DB95757 /* ProtectedLexiconService.swift */; };
@@ -148,11 +151,13 @@
 		001D5E66F362C783C621055C /* CloudRealtimeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudRealtimeService.swift; sourceTree = "<group>"; };
 		01E272A8E12D4EEF5D724E91 /* AppDelegate+TranslationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+TranslationRecording.swift"; sourceTree = "<group>"; };
 		0491E26240E167BDB5DCACEE /* HotkeyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyService.swift; sourceTree = "<group>"; };
+		04B570652EBADE0FBAE4F9E5 /* RealtimeTokenCoalescerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTokenCoalescerTests.swift; sourceTree = "<group>"; };
 		06C864D23789DFC70C7FE0D3 /* MenuBarContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarContentView.swift; sourceTree = "<group>"; };
 		09A53A5FD4196FA12DF76141 /* MeetingChapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingChapter.swift; sourceTree = "<group>"; };
 		0B43D2844894F848F20BFDEB /* MenuBarIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarIconView.swift; sourceTree = "<group>"; };
 		0C49EEDF9A5AEED5B941A6AF /* Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Test.xcconfig; sourceTree = "<group>"; };
 		118CE8BCA0160E31FD916B10 /* AudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevice.swift; sourceTree = "<group>"; };
+		1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTokenCoalescer.swift; sourceTree = "<group>"; };
 		12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManagerTests.swift; sourceTree = "<group>"; };
 		158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTranscription.swift; sourceTree = "<group>"; };
 		18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingRecording.swift"; sourceTree = "<group>"; };
@@ -246,6 +251,7 @@
 		BDE5770AB5E9601E0DB6B878 /* DidunyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DidunyApp.swift; sourceTree = "<group>"; };
 		BECAEC93BAEBC7FB0CE79126 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		BED4AC73DF15E8FB1B784BE2 /* LiveTranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptStore.swift; sourceTree = "<group>"; };
+		BF436ACD38BA065B33601DBE /* LiveTranscriptStorePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptStorePerformanceTests.swift; sourceTree = "<group>"; };
 		C1AFB9C5F772A874A404885C /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeCancelServiceTests.swift; sourceTree = "<group>"; };
 		C737BE018A4A18E4479FAD1F /* LiveDictationOverlayStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveDictationOverlayStore.swift; sourceTree = "<group>"; };
@@ -416,6 +422,7 @@
 				33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */,
 				258680FE2F7ED1EB6DB95757 /* ProtectedLexiconService.swift */,
 				4CDE81820CACD577C91281C9 /* PushToTalkService.swift */,
+				1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */,
 				E819431AE3C66AA9B422954A /* RecordingQueueService.swift */,
 				4852162851F73B8352C95E25 /* RemoteConfigService.swift */,
 				44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */,
@@ -603,12 +610,14 @@
 				FB2D4C4C36B3BB89D1A2E8BD /* CloudTranscriptionServiceE2ETests.swift */,
 				C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */,
 				22ECCCBC345EE579CFE2AD5F /* InProgressRecordingStoreTests.swift */,
+				BF436ACD38BA065B33601DBE /* LiveTranscriptStorePerformanceTests.swift */,
 				4E5E0CC22FD7FC0DA86702AF /* MeetingChunkStitcherTests.swift */,
 				12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */,
 				D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */,
 				F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */,
 				7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */,
 				51CA770F4886473BDED207C7 /* PushToTalkServiceTests.swift */,
+				04B570652EBADE0FBAE4F9E5 /* RealtimeTokenCoalescerTests.swift */,
 				44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */,
 				E06685A0367DD0430BCEE035 /* SettingsStorageProviderTests.swift */,
 				C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */,
@@ -828,6 +837,7 @@
 				9082E75ACDAF59018B93B6DF /* ProtectedLexiconService.swift in Sources */,
 				86207F57859F544F066B0140 /* PushToTalkKey.swift in Sources */,
 				497E932204DB8D119B40EAA5 /* PushToTalkService.swift in Sources */,
+				03BA270D9BB719167A7AA9B3 /* RealtimeTokenCoalescer.swift in Sources */,
 				8FA6B8A6240D6AE7AEA1754C /* RealtimeTranscription.swift in Sources */,
 				E2A1278EF4D20EC10319BBF4 /* Recording.swift in Sources */,
 				572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */,
@@ -873,12 +883,14 @@
 				154F9E85CEDA37FE7E88EE36 /* CloudTranscriptionServiceE2ETests.swift in Sources */,
 				03386BD1EB00ACDF8DD60759 /* EscapeCancelServiceTests.swift in Sources */,
 				45F7A5C71CE4990E10BCFCA0 /* InProgressRecordingStoreTests.swift in Sources */,
+				8D4D2E64E0D98B0052939BEF /* LiveTranscriptStorePerformanceTests.swift in Sources */,
 				E7F1B035104E1A79711068B2 /* MeetingChunkStitcherTests.swift in Sources */,
 				007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */,
 				474BEF9A6D5E57064A709DFD /* NotchStateTests.swift in Sources */,
 				2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */,
 				DE51034347AC539254418EF9 /* ProtectedLexiconServiceTests.swift in Sources */,
 				533F7EE6501E899BF20CF259 /* PushToTalkServiceTests.swift in Sources */,
+				7A7AA8F88FE669AF3F3D3981 /* RealtimeTokenCoalescerTests.swift in Sources */,
 				9C3AB3F7109D41F8F612797B /* RecordingModelMigrationTests.swift in Sources */,
 				4E980E04C373EE5FBF3D2DC6 /* SettingsStorageProviderTests.swift in Sources */,
 				CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */,

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -305,8 +305,15 @@ extension AppDelegate {
         // Wire token callbacks. Batches are coalesced to ≤10Hz before touching
         // the @Observable store — per-message main-actor updates made SwiftUI
         // re-render for every WS message and lag grew with the meeting.
-        let coalescer = RealtimeTokenCoalescer { [weak store] tokens in
-            store?.processTokens(tokens)
+        let coalescer = RealtimeTokenCoalescer { [weak store] events in
+            for event in events {
+                switch event {
+                case let .tokens(tokens):
+                    store?.processTokens(tokens)
+                case .segmentBoundary:
+                    store?.markSegmentBoundary()
+                }
+            }
         }
         meetingTokenCoalescer = coalescer
         rtService.onTokensReceived = { [weak coalescer] tokens in
@@ -319,10 +326,10 @@ extension AppDelegate {
             }
         }
 
-        rtService.onSegmentBoundary = { [weak store] _ in
-            Task { @MainActor in
-                store?.markSegmentBoundary()
-            }
+        // Boundaries go through the coalescer so they stay ordered relative to
+        // the token batches it is still holding.
+        rtService.onSegmentBoundary = { [weak coalescer] boundary in
+            coalescer?.addBoundary(boundary)
         }
 
         rtService.onError = { error in

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -7,6 +7,10 @@ extension AppDelegate {
     @objc func toggleMeetingRecording() {
         let meetingRecordingState = appState.meetingRecordingState
         Log.app.info("toggleMeetingRecording called, current state: \(meetingRecordingState)")
+        // Recording intent: warm the two slow dependencies of a meeting start
+        // while permission checks and device setup run.
+        ShareableContentCache.shared.prewarm()
+        Task { _ = await AuthService.shared.getAccessToken() }
         meetingPipelineTask?.cancel()
         meetingPipelineTask = Task {
             await self.performToggleMeetingRecording()
@@ -44,8 +48,10 @@ extension AppDelegate {
         // Deactivate escape cancel handler
         EscapeCancelService.shared.deactivate()
 
-        // Disconnect real-time transcription (if active)
-        if appState.liveTranscriptStore != nil {
+        // Disconnect real-time transcription (if active or still connecting)
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = nil
+        if appState.liveTranscriptStore != nil || meetingRecorderService.onRealtimeAudioData != nil {
             await realtimeTranscriptionService.disconnect()
             meetingRecorderService.onRealtimeAudioData = nil
         }
@@ -181,18 +187,22 @@ extension AppDelegate {
                 appState.deviceFallbackWarning = nil
             }
 
-            startMetrics.begin(.recorderStart)
-            try await meetingRecorderService.startRecording()
-            startMetrics.end(.recorderStart)
-            Log.app.info("Meeting recording started")
-
-            // Setup real-time transcription in Cloud mode
+            // Wire realtime transcription and start connecting BEFORE capture
+            // setup, so the WS handshake overlaps ScreenCaptureKit/mic startup
+            // instead of running after it. Audio captured before the socket is
+            // up is buffered by CloudRealtimeService and flushed on connect —
+            // recording never waits for the network.
             var store: LiveTranscriptStore?
             if cloudModeEnabled {
                 store = await setupRealtimeTranscription()
             } else {
                 Log.app.info("Local mode selected — recording audio only")
             }
+
+            startMetrics.begin(.recorderStart)
+            try await meetingRecorderService.startRecording()
+            startMetrics.end(.recorderStart)
+            Log.app.info("Meeting recording started")
 
             // Only set recording state AFTER confirmed working
             let recordingStateAfterStart = appState.meetingRecordingState
@@ -201,6 +211,10 @@ extension AppDelegate {
                     .warning(
                         "startMeetingRecording: state changed during init (now \(recordingStateAfterStart)), aborting"
                     )
+                meetingRealtimeConnectTask?.cancel()
+                meetingRealtimeConnectTask = nil
+                await realtimeTranscriptionService.disconnect()
+                meetingRecorderService.onRealtimeAudioData = nil
                 await meetingRecorderService.cancelRecording()
                 if let token = meetingActivityToken {
                     ProcessInfo.processInfo.endActivity(token)
@@ -247,6 +261,12 @@ extension AppDelegate {
             }
         } catch {
             Log.app.error("Meeting recording failed: \(error)")
+
+            // Abort the in-flight realtime connect — nothing will consume it.
+            meetingRealtimeConnectTask?.cancel()
+            meetingRealtimeConnectTask = nil
+            await realtimeTranscriptionService.disconnect()
+            meetingRecorderService.onRealtimeAudioData = nil
 
             // End App Nap prevention on failed start
             if let token = meetingActivityToken {
@@ -298,25 +318,35 @@ extension AppDelegate {
             // Don't stop recording — file recording continues independently
         }
 
-        // Connect WebSocket (non-blocking — recording works even if this fails)
-        do {
-            let languageHints = SettingsStorage.shared.speechLanguageHints
-
-            try await rtService.connect(
-                languageHints: languageHints,
-                strictLanguageHints: !languageHints.isEmpty
-            )
-            await MainActor.run {
-                store.isActive = true
+        // Connect in the background — recording start never waits for the
+        // network, and CloudRealtimeService buffers audio until the socket is
+        // up. On failure the recording continues (async transcription fallback
+        // on stop); the store's connectionStatus reflects progress in the UI.
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = Task { [weak self, weak store] in
+            guard let self else { return }
+            do {
+                let languageHints = SettingsStorage.shared.speechLanguageHints
+                try await self.realtimeTranscriptionService.connect(
+                    languageHints: languageHints,
+                    strictLanguageHints: !languageHints.isEmpty
+                )
+                await MainActor.run {
+                    store?.isActive = true
+                }
+                Log.transcription.info("Meeting real-time transcription connected successfully")
+            } catch {
+                Log.transcription.error(
+                    "Meeting real-time transcription FAILED to connect: \(error.localizedDescription)"
+                )
+                // Stop/cancel paths abort this task; don't overwrite the store
+                // state they are tearing down.
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    store?.isActive = true
+                    store?.connectionStatus = .failed(error.localizedDescription)
+                }
             }
-            Log.transcription.info("Meeting real-time transcription connected successfully")
-        } catch {
-            Log.transcription.error("Meeting real-time transcription FAILED to connect: \(error.localizedDescription)")
-            await MainActor.run {
-                store.isActive = true
-                store.connectionStatus = .failed(error.localizedDescription)
-            }
-            // Recording continues — fallback to async transcription on stop
         }
 
         return store
@@ -353,6 +383,8 @@ extension AppDelegate {
         }
 
         // Finalize and disconnect real-time transcription (if active)
+        meetingRealtimeConnectTask?.cancel()
+        meetingRealtimeConnectTask = nil
         let hasRealtimeSession = await MainActor.run { appState.liveTranscriptStore != nil }
         var didReceiveRealtimeFinalization = true
         if hasRealtimeSession {
@@ -361,6 +393,9 @@ extension AppDelegate {
             await realtimeTranscriptionService.disconnect()
             meetingRecorderService.onRealtimeAudioData = nil
         }
+
+        // Next meeting start should hit a warm SCShareableContent cache.
+        ShareableContentCache.shared.prewarm()
 
         // Mark store as no longer active
         let store = await MainActor.run { appState.liveTranscriptStore }

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -132,6 +132,11 @@ extension AppDelegate {
 
         let cloudModeEnabled = SettingsStorage.shared.effectiveMeetingRealtimeTranscriptionEnabled
 
+        // Timed from after the permission check (which can block on a user
+        // prompt) to the .recording state transition.
+        let startMetrics = ConnectMetrics(label: "[Meeting] start")
+        defer { startMetrics.finish() }
+
         // Prevent App Nap during meeting recording
         meetingActivityToken = ProcessInfo.processInfo.beginActivity(
             options: [.userInitiated, .idleSystemSleepDisabled],
@@ -176,7 +181,9 @@ extension AppDelegate {
                 appState.deviceFallbackWarning = nil
             }
 
+            startMetrics.begin(.recorderStart)
             try await meetingRecorderService.startRecording()
+            startMetrics.end(.recorderStart)
             Log.app.info("Meeting recording started")
 
             // Setup real-time transcription in Cloud mode
@@ -207,6 +214,7 @@ extension AppDelegate {
                 appState.liveTranscriptStore = store
                 handleMeetingStateChange(.recording)
             }
+            startMetrics.finish(outcome: "ok")
 
             // Show transcript window only if we have real-time transcription
             if let store {

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -53,8 +53,12 @@ extension AppDelegate {
         meetingRealtimeConnectTask = nil
         if appState.liveTranscriptStore != nil || meetingRecorderService.onRealtimeAudioData != nil {
             await realtimeTranscriptionService.disconnect()
+            realtimeTranscriptionService.clearCallbacks()
             meetingRecorderService.onRealtimeAudioData = nil
+            // The transcript window stays open for review — deliver the tail.
+            await meetingTokenCoalescer?.flushNow()
         }
+        meetingTokenCoalescer = nil
 
         // Capture in-progress recording ID before stopRecording() clears it (RLR-M1).
         let cancelInProgressRecordingId = meetingRecorderService.currentRecordingId
@@ -213,7 +217,9 @@ extension AppDelegate {
                     )
                 meetingRealtimeConnectTask?.cancel()
                 meetingRealtimeConnectTask = nil
+                meetingTokenCoalescer = nil
                 await realtimeTranscriptionService.disconnect()
+                realtimeTranscriptionService.clearCallbacks()
                 meetingRecorderService.onRealtimeAudioData = nil
                 await meetingRecorderService.cancelRecording()
                 if let token = meetingActivityToken {
@@ -265,7 +271,9 @@ extension AppDelegate {
             // Abort the in-flight realtime connect — nothing will consume it.
             meetingRealtimeConnectTask?.cancel()
             meetingRealtimeConnectTask = nil
+            meetingTokenCoalescer = nil
             await realtimeTranscriptionService.disconnect()
+            realtimeTranscriptionService.clearCallbacks()
             meetingRecorderService.onRealtimeAudioData = nil
 
             // End App Nap prevention on failed start
@@ -294,11 +302,15 @@ extension AppDelegate {
             rtService?.sendAudioData(pcmData)
         }
 
-        // Wire token callbacks
-        rtService.onTokensReceived = { [weak store] tokens in
-            Task { @MainActor in
-                store?.processTokens(tokens)
-            }
+        // Wire token callbacks. Batches are coalesced to ≤10Hz before touching
+        // the @Observable store — per-message main-actor updates made SwiftUI
+        // re-render for every WS message and lag grew with the meeting.
+        let coalescer = RealtimeTokenCoalescer { [weak store] tokens in
+            store?.processTokens(tokens)
+        }
+        meetingTokenCoalescer = coalescer
+        rtService.onTokensReceived = { [weak coalescer] tokens in
+            coalescer?.add(tokens)
         }
 
         rtService.onConnectionStatusChanged = { [weak store] status in
@@ -391,8 +403,13 @@ extension AppDelegate {
             let finalizeResult = await realtimeTranscriptionService.finalize(profile: .safe)
             didReceiveRealtimeFinalization = finalizeResult.didReceiveFinishedSignal
             await realtimeTranscriptionService.disconnect()
+            realtimeTranscriptionService.clearCallbacks()
             meetingRecorderService.onRealtimeAudioData = nil
+            // Deliver the transcript tail still sitting in the coalescer
+            // before anything reads the store.
+            await meetingTokenCoalescer?.flushNow()
         }
+        meetingTokenCoalescer = nil
 
         // Next meeting start should hit a warm SCShareableContent cache.
         ShareableContentCache.shared.prewarm()

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -609,8 +609,10 @@ extension AppDelegate {
 
         // The accumulator (correctness path) processes every batch off-main;
         // only the overlay UI update is coalesced to ≤10Hz.
-        let overlayCoalescer = RealtimeTokenCoalescer { [weak self] tokens in
-            self?.updateRecordingFeedbackTokens(tokens, mode: .voice)
+        let overlayCoalescer = RealtimeTokenCoalescer { [weak self] events in
+            for case let .tokens(tokens) in events {
+                self?.updateRecordingFeedbackTokens(tokens, mode: .voice)
+            }
         }
         // The closure owns the coalescer (strong capture); it dies with the
         // callback when stopVoiceRealtimeSession nils onTokensReceived.

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -156,6 +156,10 @@ extension AppDelegate {
             return
         }
 
+        // Pre-warm the auth token so a needed refresh overlaps audio setup
+        // instead of sitting inside the realtime connect.
+        Task { _ = await AuthService.shared.getAccessToken() }
+
         // Request microphone permission on-demand
         let micGranted = await PermissionManager.shared.ensureMicrophonePermission(context: .dictation)
         appState.microphonePermissionGranted = micGranted

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -607,15 +607,20 @@ extension AppDelegate {
             rtService?.sendAudioData(pcmData)
         }
 
-        rtService.onTokensReceived = { [weak self, weak accumulator] tokens in
+        // The accumulator (correctness path) processes every batch off-main;
+        // only the overlay UI update is coalesced to ≤10Hz.
+        let overlayCoalescer = RealtimeTokenCoalescer { [weak self] tokens in
+            self?.updateRecordingFeedbackTokens(tokens, mode: .voice)
+        }
+        // The closure owns the coalescer (strong capture); it dies with the
+        // callback when stopVoiceRealtimeSession nils onTokensReceived.
+        rtService.onTokensReceived = { [weak accumulator] tokens in
             if let accumulator {
                 Task {
                     await accumulator.process(tokens: tokens)
                 }
             }
-            Task { @MainActor in
-                self?.updateRecordingFeedbackTokens(tokens, mode: .voice)
-            }
+            overlayCoalescer.add(tokens)
         }
 
         rtService.onConnectionStatusChanged = { [weak self] status in
@@ -685,10 +690,7 @@ extension AppDelegate {
             audioRecorder.onRealtimeAudioData = nil
             voiceRealtimeSessionEnabled = false
             voiceRealtimeAccumulator = nil
-            realtimeTranscriptionService.onTokensReceived = nil
-            realtimeTranscriptionService.onError = nil
-            realtimeTranscriptionService.onConnectionStatusChanged = nil
-            realtimeTranscriptionService.onSegmentBoundary = nil
+            realtimeTranscriptionService.clearCallbacks()
         }
 
         guard wasEnabled else {

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -133,6 +133,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     var translationPipelineTask: Task<Void, Never>?
     var meetingPipelineTask: Task<Void, Never>?
     var meetingTranslationPipelineTask: Task<Void, Never>?
+    /// In-flight meeting realtime WS connect, launched before capture setup so
+    /// the handshake overlaps it. Held so stop/cancel can abort a connect that
+    /// is still in progress.
+    var meetingRealtimeConnectTask: Task<Void, Never>?
 
     // Auto-reset Tasks (success/error → idle timers)
     var voiceAutoResetTask: Task<Void, Never>?
@@ -188,6 +192,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // flag) which does not trigger the keychain read.
 
         setupNotchStopHandler()
+
+        // Meeting starts fetch SCShareableContent (0.5-2s from the window
+        // server); warm the cache now so the first start hits it. No-op until
+        // screen-recording permission has been granted.
+        ShareableContentCache.shared.prewarm()
 
         // Listen for push-to-talk key changes
         NotificationCenter.default.addObserver(

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -137,6 +137,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the handshake overlaps it. Held so stop/cancel can abort a connect that
     /// is still in progress.
     var meetingRealtimeConnectTask: Task<Void, Never>?
+    /// Batches meeting realtime tokens to ≤10Hz store updates. Held so the
+    /// stop path can flush the tail before reading the transcript.
+    var meetingTokenCoalescer: RealtimeTokenCoalescer?
 
     // Auto-reset Tasks (success/error → idle timers)
     var voiceAutoResetTask: Task<Void, Never>?
@@ -971,6 +974,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func handleMeetingStateChange(_ state: RecordingState) {
+        // Belt-and-braces: an error mid-meeting must never leave the global
+        // Escape key monitor installed (stop/cancel paths deactivate it
+        // themselves; error paths reach here). Meeting .error implies meeting
+        // was the active mode, so no other mode's monitor can be live.
+        if state == .error {
+            EscapeCancelService.shared.deactivate()
+        }
         meetingAutoResetTask?.cancel()
         handleStateChange(
             state,

--- a/Diduny/Core/Models/LiveTranscriptStore.swift
+++ b/Diduny/Core/Models/LiveTranscriptStore.swift
@@ -72,7 +72,7 @@ final class LiveTranscriptStore {
         if let lastIndex = segments.indices.last,
            segments[lastIndex].speaker == token.speaker
         {
-            segments[lastIndex].tokens.append(token)
+            segments[lastIndex].append(token)
         } else {
             // New speaker or first segment
             let segment = TranscriptSegment(

--- a/Diduny/Core/Models/RealtimeTranscription.swift
+++ b/Diduny/Core/Models/RealtimeTranscription.swift
@@ -40,18 +40,25 @@ struct RealtimeToken: Identifiable, Equatable {
 struct TranscriptSegment: Identifiable {
     let id: UUID
     var speaker: String?
-    var tokens: [RealtimeToken]
+    private(set) var tokens: [RealtimeToken]
+    /// Concatenated token text, maintained incrementally by append(_:).
+    /// Stored rather than computed: the growing segment is on screen and
+    /// re-rendered on every token, so re-joining all tokens per access made
+    /// live-transcript cost O(n²) over a long single-speaker stretch.
+    private(set) var text: String
     var startMs: Int
 
     init(speaker: String? = nil, tokens: [RealtimeToken] = [], startMs: Int = 0) {
         self.id = UUID()
         self.speaker = speaker
         self.tokens = tokens
+        self.text = tokens.map(\.text).joined()
         self.startMs = startMs
     }
 
-    var text: String {
-        tokens.map(\.text).joined()
+    mutating func append(_ token: RealtimeToken) {
+        tokens.append(token)
+        text += token.text
     }
 
     var isFinal: Bool {

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -19,6 +19,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     /// socket after teardown and loops forever with no audio source. Guarded by lifecycleLock.
     private var reconnectTask: Task<Void, Never>?
     private var proxyReady = false
+    /// Phase timings for the in-flight connect. Guarded by lifecycleLock; the
+    /// URLSession delegate and receive loop close phases from other threads.
+    private var currentConnectMetrics: ConnectMetrics?
 
     private var isConnected = false
     private var reconnectAttempt = 0
@@ -106,13 +109,24 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         onConnectionStatusChanged?(.connecting)
 
+        let metrics = ConnectMetrics(label: "[Cloud RT] connect")
+        lifecycleLock.lock()
+        currentConnectMetrics = metrics
+        lifecycleLock.unlock()
+        // Idempotent: the success path below finishes with "ok" first, so this
+        // only fires when an error path unwinds out of connectWebSocket().
+        defer { metrics.finish() }
+
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         self.urlSession = session
 
         var wsURLString = wsURL
 
         // Pass auth token as query param (WebSocket headers are limited)
-        if let accessToken = await AuthService.shared.getAccessToken() {
+        metrics.begin(.tokenFetch)
+        let accessToken = await AuthService.shared.getAccessToken()
+        metrics.end(.tokenFetch)
+        if let accessToken {
             let separator = wsURLString.contains("?") ? "&" : "?"
             wsURLString += "\(separator)token=\(accessToken)"
         }
@@ -141,6 +155,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         }
 
         self.webSocketTask = task
+        metrics.begin(.wsUpgrade) // ended by didOpenWithProtocol on the delegate queue
         task.resume()
 
         let config = Self.makeConnectionConfig(
@@ -155,6 +170,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         let configString = String(data: configData, encoding: .utf8) ?? "{}"
 
         NSLog("[Cloud RT] Sending config: %@", configString)
+        metrics.begin(.configSend)
         do {
             try await task.send(.string(configString))
         } catch {
@@ -166,6 +182,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             }
             throw error
         }
+        metrics.end(.configSend)
         NSLog("[Cloud RT] Config sent successfully, WebSocket connected")
 
         lifecycleLock.lock()
@@ -176,6 +193,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         startPingLoop()
 
         // Wait for proxy_ready before marking connected
+        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
         let deadline = Date().addingTimeInterval(10)
         while Date() < deadline {
             lifecycleLock.lock()
@@ -192,6 +210,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             throw RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
         }
 
+        metrics.finish(outcome: "ok")
         onConnectionStatusChanged?(.connected)
     }
 
@@ -405,7 +424,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
            json["type"] as? String == "proxy_ready" {
             lifecycleLock.lock()
             proxyReady = true
+            let metrics = currentConnectMetrics
             lifecycleLock.unlock()
+            metrics?.end(.proxyReadyWait)
             NSLog("[Cloud RT] Received proxy_ready signal")
             return
         }
@@ -760,6 +781,10 @@ extension CloudRealtimeService: URLSessionWebSocketDelegate {
         webSocketTask _: URLSessionWebSocketTask,
         didOpenWithProtocol protocol: String?
     ) {
+        lifecycleLock.lock()
+        let metrics = currentConnectMetrics
+        lifecycleLock.unlock()
+        metrics?.end(.wsUpgrade)
         Log.transcription.info("Cloud RT: WebSocket opened, protocol: \(String(describing: `protocol`))")
     }
 

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -11,7 +11,13 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         return "\(proxyBase)/api/v1/realtime"
     }
     private var webSocketTask: URLSessionWebSocketTask?
-    private var urlSession: URLSession?
+    /// One URLSession for the service's lifetime, so the TLS session cache
+    /// survives across connections (TLS 1.3 resumption saves a round trip on
+    /// every recording start). Never invalidate it — invalidateAndCancel would
+    /// permanently break all future connects. The session retains its delegate
+    /// (self); acceptable, this service lives as long as the app. Guarded by
+    /// lifecycleLock.
+    private var _sharedSession: URLSession?
     private var receiveTask: Task<Void, Never>?
     private var pingTask: Task<Void, Never>?
     /// In-flight reconnect (sleeping during backoff). Held so disconnect() can cancel it —
@@ -19,6 +25,23 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     /// socket after teardown and loops forever with no audio source. Guarded by lifecycleLock.
     private var reconnectTask: Task<Void, Never>?
     private var proxyReady = false
+    /// Resumed exactly once (take-and-nil under lifecycleLock) by whichever
+    /// fires first: proxy_ready, a proxy error frame, the timeout watchdog,
+    /// or disconnect.
+    private var proxyReadyContinuation: CheckedContinuation<Void, Error>?
+    private var proxyReadyTimeoutTask: Task<Void, Never>?
+    /// Audio produced while the socket is connecting or in reconnect backoff.
+    /// Flushed in order on connect, so the first seconds of speech reach
+    /// transcription instead of being dropped. Guarded by lifecycleLock.
+    private var pendingAudio = PreConnectAudioBuffer()
+    private var didWarnPendingAudioOverflow = false
+    /// True from connect() until disconnect() or a terminal failure — the
+    /// window in which buffering audio is worthwhile. Guarded by lifecycleLock.
+    private var sessionActive = false
+    /// True while the post-connect flush drains pendingAudio. New audio must
+    /// join the back of the queue during a flush, never jump straight to the
+    /// socket, or chunks would arrive out of order. Guarded by lifecycleLock.
+    private var flushingPendingAudio = false
     /// Phase timings for the in-flight connect. Guarded by lifecycleLock; the
     /// URLSession delegate and receive loop close phases from other threads.
     private var currentConnectMetrics: ConnectMetrics?
@@ -80,6 +103,13 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         self.translationConfig = translationConfig
         self.enableSpeakerDiarization = enableSpeakerDiarization
         reconnectAttempt = 0
+        // Fresh session: start buffering incoming audio right away, so speech
+        // during the connect handshake is delivered once the socket is up.
+        lifecycleLock.lock()
+        sessionActive = true
+        pendingAudio.removeAll()
+        didWarnPendingAudioOverflow = false
+        lifecycleLock.unlock()
         try await connectWebSocket()
     }
 
@@ -92,15 +122,15 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             )
         }
 
-        // Clean up any existing connection before reconnecting
+        // Clean up any existing connection before reconnecting. Note:
+        // pendingAudio is deliberately NOT cleared — audio buffered during a
+        // reconnect backoff must survive into the new connection.
         pingTask?.cancel()
         pingTask = nil
         receiveTask?.cancel()
         receiveTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
         lifecycleLock.lock()
         audioBytesSent = 0
         audioChunkCount = 0
@@ -117,8 +147,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // only fires when an error path unwinds out of connectWebSocket().
         defer { metrics.finish() }
 
-        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-        self.urlSession = session
+        let session = sharedSession()
 
         var wsURLString = wsURL
 
@@ -187,31 +216,113 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         lifecycleLock.lock()
         isConnected = true
+        // Route new audio to the back of the queue until the flush drains it.
+        flushingPendingAudio = !pendingAudio.isEmpty
+        let needsFlush = flushingPendingAudio
         lifecycleLock.unlock()
 
         startReceiveLoop()
         startPingLoop()
 
-        // Wait for proxy_ready before marking connected
-        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
-        let deadline = Date().addingTimeInterval(10)
-        while Date() < deadline {
-            lifecycleLock.lock()
-            let ready = proxyReady
-            lifecycleLock.unlock()
-            if ready { break }
-            try? await Task.sleep(for: .milliseconds(50))
+        // Deliver audio captured while connecting. Safe before proxy_ready:
+        // the proxy buffers frames until Soniox is ready (1MB server cap).
+        if needsFlush {
+            await flushPendingAudio(task: task)
         }
-        lifecycleLock.lock()
-        let proxyIsReady = proxyReady
-        lifecycleLock.unlock()
-        guard proxyIsReady else {
+
+        // Wait for proxy_ready before marking connected.
+        metrics.begin(.proxyReadyWait) // ended by parseResponse when proxy_ready arrives
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                lifecycleLock.lock()
+                if proxyReady {
+                    lifecycleLock.unlock()
+                    continuation.resume()
+                    return
+                }
+                proxyReadyContinuation = continuation
+                proxyReadyTimeoutTask = Task { [weak self] in
+                    try? await Task.sleep(for: .seconds(10))
+                    guard !Task.isCancelled else { return }
+                    self?.resumeProxyReady(with: .failure(
+                        RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
+                    ))
+                }
+                lifecycleLock.unlock()
+            }
+        } catch {
             await disconnect()
-            throw RealtimeTranscriptionError.connectionFailed("Proxy did not send ready signal")
+            throw error
         }
 
         metrics.finish(outcome: "ok")
         onConnectionStatusChanged?(.connected)
+    }
+
+    /// Thread-safe accessor for the process-lifetime URLSession (see _sharedSession).
+    private func sharedSession() -> URLSession {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        if let session = _sharedSession {
+            return session
+        }
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        _sharedSession = session
+        return session
+    }
+
+    /// Resolves the proxy_ready wait exactly once; later calls are no-ops.
+    private func resumeProxyReady(with result: Result<Void, Error>) {
+        lifecycleLock.lock()
+        let continuation = proxyReadyContinuation
+        proxyReadyContinuation = nil
+        let timeoutTask = proxyReadyTimeoutTask
+        proxyReadyTimeoutTask = nil
+        lifecycleLock.unlock()
+
+        timeoutTask?.cancel()
+        switch result {
+        case .success:
+            continuation?.resume()
+        case let .failure(error):
+            continuation?.resume(throwing: error)
+        }
+    }
+
+    /// Drains pendingAudio to the socket in FIFO order. Sends are awaited so
+    /// ordering is preserved; audio arriving mid-flush is appended behind the
+    /// queued chunks by sendAudioData (flushingPendingAudio gate).
+    private func flushPendingAudio(task: URLSessionWebSocketTask) async {
+        var flushedChunks = 0
+        var flushedBytes = 0
+        while true {
+            lifecycleLock.lock()
+            guard isConnected, let chunk = pendingAudio.removeFirst() else {
+                flushingPendingAudio = false
+                lifecycleLock.unlock()
+                break
+            }
+            audioBytesSent += chunk.count
+            audioChunkCount += 1
+            lifecycleLock.unlock()
+
+            do {
+                try await task.send(.data(chunk))
+                flushedChunks += 1
+                flushedBytes += chunk.count
+            } catch {
+                Log.transcription.error("Cloud RT: Buffered audio flush failed - \(error.localizedDescription)")
+                // The connection is failing; the receive loop / delegate will
+                // drive reconnect, and remaining chunks stay buffered for it.
+                lifecycleLock.lock()
+                flushingPendingAudio = false
+                lifecycleLock.unlock()
+                break
+            }
+        }
+        if flushedChunks > 0 {
+            NSLog("[Cloud RT] Flushed %d buffered audio chunks (%d bytes)", flushedChunks, flushedBytes)
+        }
     }
 
     // MARK: - Send Audio Data
@@ -225,7 +336,25 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // Capture task reference under the lock so we don't race with disconnect.
         // Do NOT hold the lock while calling task.send (may block on internal queues).
         lifecycleLock.lock()
-        guard isConnected, let task = webSocketTask else {
+        // Not connected yet (connecting or reconnect backoff), or a flush is
+        // still draining: buffer so nothing is lost and ordering holds.
+        if !isConnected || flushingPendingAudio || !pendingAudio.isEmpty {
+            guard sessionActive else {
+                lifecycleLock.unlock()
+                return
+            }
+            pendingAudio.append(data)
+            let overflowed = pendingAudio.didOverflow && !didWarnPendingAudioOverflow
+            if overflowed {
+                didWarnPendingAudioOverflow = true
+            }
+            lifecycleLock.unlock()
+            if overflowed {
+                Log.transcription.warning("Cloud RT: pre-connect audio buffer overflow — dropping oldest audio")
+            }
+            return
+        }
+        guard let task = webSocketTask else {
             lifecycleLock.unlock()
             return
         }
@@ -351,6 +480,11 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
     func disconnect() async {
         Log.transcription.info("Cloud RT: Disconnecting...")
 
+        // Unblock a connect() stuck waiting for proxy_ready.
+        resumeProxyReady(with: .failure(
+            RealtimeTranscriptionError.connectionFailed("Disconnected while connecting")
+        ))
+
         pingTask?.cancel()
         pingTask = nil
         receiveTask?.cancel()
@@ -360,17 +494,30 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         let task = webSocketTask
         webSocketTask = nil
         isConnected = false
+        sessionActive = false
+        pendingAudio.removeAll()
+        flushingPendingAudio = false
         // Kill any reconnect scheduled by a drop that raced just before this disconnect.
         reconnectTask?.cancel()
         reconnectTask = nil
         lifecycleLock.unlock()
 
         task?.cancel(with: .normalClosure, reason: nil)
-        urlSession?.invalidateAndCancel()
-        urlSession = nil
+        // The shared URLSession stays alive: its TLS session cache makes the
+        // next connect cheaper, and invalidating it would break future connects.
         onConnectionStatusChanged?(.disconnected)
 
         Log.transcription.info("Cloud RT: Disconnected")
+    }
+
+    /// Stops buffering and drops pending audio — the session has terminally
+    /// failed and nothing will consume the buffer.
+    private func endBufferingSession() {
+        lifecycleLock.lock()
+        sessionActive = false
+        pendingAudio.removeAll()
+        flushingPendingAudio = false
+        lifecycleLock.unlock()
     }
 
     // MARK: - Receive Loop
@@ -427,6 +574,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             let metrics = currentConnectMetrics
             lifecycleLock.unlock()
             metrics?.end(.proxyReadyWait)
+            resumeProxyReady(with: .success(()))
             NSLog("[Cloud RT] Received proxy_ready signal")
             return
         }
@@ -437,6 +585,9 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
            json["tokens"] == nil {
             let error = RealtimeTranscriptionError.connectionFailed(errorMsg)
             Log.transcription.error("Cloud RT: Proxy error - \(errorMsg)")
+            // An error frame before proxy_ready means the connect failed —
+            // fail it now instead of waiting out the 10s timeout.
+            resumeProxyReady(with: .failure(error))
             onError?(error)
             onConnectionStatusChanged?(.failed(errorMsg))
             return
@@ -553,8 +704,14 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // refusing — and would surface a generic "Connection lost" instead of the
         // real reason. Detect it synchronously to stop the reconnect, then surface
         // the typed usage error with the best numbers we have.
+        // Whatever path led here, a connect() awaiting proxy_ready must not hang.
+        resumeProxyReady(with: .failure(
+            RealtimeTranscriptionError.connectionFailed("Connection lost while connecting")
+        ))
+
         if (webSocketTask?.response as? HTTPURLResponse)?.statusCode == 402 {
             Log.transcription.warning("Cloud RT: WS upgrade returned 402 — usage limit, not reconnecting")
+            endBufferingSession()
             Task { [weak self] in
                 guard let self else { return }
                 let usage = await UsageService.shared.cachedUsage
@@ -572,6 +729,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         // Per ADR-0004: save partial transcript, show non-error UI, do NOT reconnect.
         if closeCode?.rawValue == 1001 {
             Log.transcription.info("Cloud RT: WS 1001 Going Away — session cap reached, not reconnecting")
+            endBufferingSession()
             onConnectionStatusChanged?(.disconnected)
             // Signal upstream (AppDelegate / MeetingRecorderService) to flush partial transcript.
             // We reuse the existing segmentBoundary path: emit .endpoint so callers finalise.
@@ -581,6 +739,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
         guard reconnectAttempt < maxReconnectAttempts else {
             Log.transcription.error("Cloud RT: Max reconnect attempts reached")
+            endBufferingSession()
             onConnectionStatusChanged?(.failed("Connection lost after \(maxReconnectAttempts) attempts"))
             return
         }
@@ -617,6 +776,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
                         Log.transcription.info("Cloud RT: Reconnected after token refresh")
                     } catch {
                         Log.transcription.error("Cloud RT: Reconnect after token refresh failed - \(error.localizedDescription)")
+                        self.endBufferingSession()
                         self.onError?(error)
                         self.onConnectionStatusChanged?(.failed("Session expired — please log in again"))
                     }

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -102,10 +102,10 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         self.audioConfig = audioConfig
         self.translationConfig = translationConfig
         self.enableSpeakerDiarization = enableSpeakerDiarization
-        reconnectAttempt = 0
         // Fresh session: start buffering incoming audio right away, so speech
         // during the connect handshake is delivered once the socket is up.
         lifecycleLock.lock()
+        reconnectAttempt = 0
         sessionActive = true
         pendingAudio.removeAll()
         didWarnPendingAudioOverflow = false
@@ -510,6 +510,27 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         Log.transcription.info("Cloud RT: Disconnected")
     }
 
+    /// Drops all four session callbacks. Call from the owning teardown path
+    /// once the session is truly over — stale closures from a finished session
+    /// otherwise keep receiving tokens/status (e.g. from a racing reconnect)
+    /// and retain whatever they captured. NOT called inside disconnect():
+    /// reconnect-failure paths disconnect first and then report .failed
+    /// through these callbacks.
+    func clearCallbacks() {
+        finalizeStateLock.lock()
+        _onTokensReceived = nil
+        _onError = nil
+        _onConnectionStatusChanged = nil
+        _onSegmentBoundary = nil
+        finalizeStateLock.unlock()
+    }
+
+    private func resetReconnectAttempts() {
+        lifecycleLock.lock()
+        reconnectAttempt = 0
+        lifecycleLock.unlock()
+    }
+
     /// Stops buffering and drops pending audio — the session has terminally
     /// failed and nothing will consume the buffer.
     private func endBufferingSession() {
@@ -737,18 +758,25 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
             return
         }
 
-        guard reconnectAttempt < maxReconnectAttempts else {
+        lifecycleLock.lock()
+        let attempt = reconnectAttempt + 1
+        let withinLimit = attempt <= maxReconnectAttempts
+        if withinLimit {
+            reconnectAttempt = attempt
+        }
+        lifecycleLock.unlock()
+
+        guard withinLimit else {
             Log.transcription.error("Cloud RT: Max reconnect attempts reached")
             endBufferingSession()
             onConnectionStatusChanged?(.failed("Connection lost after \(maxReconnectAttempts) attempts"))
             return
         }
 
-        reconnectAttempt += 1
-        let delay = pow(2.0, Double(reconnectAttempt)) // 2s, 4s, 8s
+        let delay = pow(2.0, Double(attempt)) // 2s, 4s, 8s
 
-        Log.transcription.info("Cloud RT: Reconnecting (attempt \(self.reconnectAttempt))...")
-        onConnectionStatusChanged?(.reconnecting(attempt: reconnectAttempt))
+        Log.transcription.info("Cloud RT: Reconnecting (attempt \(attempt))...")
+        onConnectionStatusChanged?(.reconnecting(attempt: attempt))
 
         lifecycleLock.lock()
         reconnectTask?.cancel()
@@ -763,7 +791,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
             do {
                 try await self.connectWebSocket()
-                self.reconnectAttempt = 0
+                self.resetReconnectAttempts()
                 Log.transcription.info("Cloud RT: Reconnected successfully")
             } catch let error as RealtimeTranscriptionError {
                 // ADR-0004: if WS upgrade returned 401, refresh Supabase token and retry once.
@@ -772,7 +800,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
                     do {
                         try await AuthService.shared.refreshTokens()
                         try await self.connectWebSocket()
-                        self.reconnectAttempt = 0
+                        self.resetReconnectAttempts()
                         Log.transcription.info("Cloud RT: Reconnected after token refresh")
                     } catch {
                         Log.transcription.error("Cloud RT: Reconnect after token refresh failed - \(error.localizedDescription)")

--- a/Diduny/Core/Services/ConnectMetrics.swift
+++ b/Diduny/Core/Services/ConnectMetrics.swift
@@ -1,0 +1,106 @@
+import Foundation
+import os
+
+/// Collects phase timings for one realtime connect (or meeting start) and emits
+/// them as os_signpost intervals plus a single summary log line, so connect
+/// latency can be measured from Console / `log stream` or Instruments and
+/// compared before/after optimizations.
+///
+/// Thread-safe: phases may begin/end on different threads (e.g. `upgrade`
+/// ends on the URLSession delegate queue while `config` runs on the caller).
+final class ConnectMetrics: @unchecked Sendable {
+    enum Phase: String {
+        case tokenFetch = "token"
+        case wsUpgrade = "upgrade"
+        case configSend = "config"
+        case proxyReadyWait = "ready"
+        case recorderStart = "recorder"
+    }
+
+    private static let signposter = OSSignposter(
+        subsystem: "ua.com.rmarinsky.diduny",
+        category: "connect"
+    )
+
+    private let label: String
+    private let lock = NSLock()
+    private let signpostID: OSSignpostID
+    private let totalState: OSSignpostIntervalState
+    private let startedAt = ContinuousClock.now
+    private var openPhases: [Phase: (state: OSSignpostIntervalState, start: ContinuousClock.Instant)] = [:]
+    private var completedPhases: [(phase: Phase, ms: Int)] = []
+    private var summaryEmitted = false
+
+    init(label: String) {
+        self.label = label
+        signpostID = Self.signposter.makeSignpostID()
+        totalState = Self.signposter.beginInterval("total", id: signpostID, "\(label)")
+    }
+
+    func begin(_ phase: Phase) {
+        let state = Self.signposter.beginInterval("phase", id: signpostID, "\(self.label).\(phase.rawValue)")
+        lock.lock()
+        openPhases[phase] = (state, .now)
+        lock.unlock()
+    }
+
+    func end(_ phase: Phase) {
+        lock.lock()
+        guard let entry = openPhases.removeValue(forKey: phase) else {
+            lock.unlock()
+            return
+        }
+        completedPhases.append((phase, Self.milliseconds(since: entry.start)))
+        lock.unlock()
+        Self.signposter.endInterval("phase", entry.state)
+    }
+
+    /// Ends the total interval and logs one summary line. Idempotent, so error
+    /// paths can rely on a `defer { metrics.finish(outcome: "aborted") }` while
+    /// the success path calls `finish(outcome: "ok")` explicitly first.
+    func finish(outcome: String = "aborted") {
+        lock.lock()
+        guard !summaryEmitted else {
+            lock.unlock()
+            return
+        }
+        summaryEmitted = true
+        // Close phases left open by an error path so their time is still reported.
+        let abandoned = openPhases
+        openPhases.removeAll()
+        for (phase, entry) in abandoned {
+            completedPhases.append((phase, Self.milliseconds(since: entry.start)))
+        }
+        let phases = completedPhases
+            .map { "\($0.phase.rawValue)=\($0.ms)ms" }
+            .joined(separator: " ")
+        lock.unlock()
+
+        for (_, entry) in abandoned {
+            Self.signposter.endInterval("phase", entry.state)
+        }
+        Self.signposter.endInterval("total", totalState)
+
+        let totalMs = Self.milliseconds(since: startedAt)
+        NSLog("%@", "\(label) timings: \(phases) total=\(totalMs)ms outcome=\(outcome)")
+    }
+
+    /// One-shot interval around an async operation, for call sites that don't
+    /// carry a ConnectMetrics instance (e.g. deep inside capture services).
+    static func measure<T>(_ label: String, _ body: () async throws -> T) async rethrows -> T {
+        let signpostID = signposter.makeSignpostID()
+        let state = signposter.beginInterval("measure", id: signpostID, "\(label)")
+        let start = ContinuousClock.now
+        defer {
+            signposter.endInterval("measure", state)
+            NSLog("%@", "\(label) took \(milliseconds(since: start))ms")
+        }
+        return try await body()
+    }
+
+    private static func milliseconds(since start: ContinuousClock.Instant) -> Int {
+        let duration = start.duration(to: .now)
+        return Int(duration.components.seconds) * 1000
+            + Int(duration.components.attoseconds / 1_000_000_000_000_000)
+    }
+}

--- a/Diduny/Core/Services/PreConnectAudioBuffer.swift
+++ b/Diduny/Core/Services/PreConnectAudioBuffer.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Bounded FIFO for audio produced while the realtime socket is still
+/// connecting (or reconnecting). Once the cap is exceeded the oldest chunks
+/// are evicted, so a stalled connection costs the oldest audio, never
+/// unbounded memory. Not thread-safe — callers synchronize externally
+/// (CloudRealtimeService guards it with lifecycleLock).
+struct PreConnectAudioBuffer {
+    /// ~15s of 16kHz mono s16le — enough to cover connect plus one
+    /// reconnect backoff without losing speech.
+    static let defaultMaxBytes = 480_000
+
+    private(set) var totalBytes = 0
+    private(set) var didOverflow = false
+    private var chunks: [Data] = []
+    let maxBytes: Int
+
+    init(maxBytes: Int = PreConnectAudioBuffer.defaultMaxBytes) {
+        self.maxBytes = maxBytes
+    }
+
+    var isEmpty: Bool { chunks.isEmpty }
+    var count: Int { chunks.count }
+
+    mutating func append(_ data: Data) {
+        chunks.append(data)
+        totalBytes += data.count
+        while totalBytes > maxBytes, chunks.count > 1 {
+            totalBytes -= chunks.removeFirst().count
+            didOverflow = true
+        }
+    }
+
+    mutating func removeFirst() -> Data? {
+        guard !chunks.isEmpty else { return nil }
+        let chunk = chunks.removeFirst()
+        totalBytes -= chunk.count
+        return chunk
+    }
+
+    mutating func removeAll() {
+        chunks.removeAll()
+        totalBytes = 0
+        didOverflow = false
+    }
+}

--- a/Diduny/Core/Services/RealtimeTokenCoalescer.swift
+++ b/Diduny/Core/Services/RealtimeTokenCoalescer.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Coalesces per-WebSocket-message token batches into main-actor flushes at
+/// most every `interval` (~10Hz by default). Realtime tokens can arrive many
+/// times per second; delivering each batch straight to an @Observable store
+/// re-renders SwiftUI per message and lets main-thread cost grow with the
+/// session. Batching preserves token order and caps UI work at a fixed rate.
+final class RealtimeTokenCoalescer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending: [RealtimeToken] = []
+    private var flushTask: Task<Void, Never>?
+    private let interval: Duration
+    private let onFlush: @MainActor ([RealtimeToken]) -> Void
+
+    init(
+        interval: Duration = .milliseconds(100),
+        onFlush: @escaping @MainActor ([RealtimeToken]) -> Void
+    ) {
+        self.interval = interval
+        self.onFlush = onFlush
+    }
+
+    /// Queue a batch; schedules a flush `interval` from now unless one is
+    /// already pending. Callable from any thread.
+    func add(_ tokens: [RealtimeToken]) {
+        guard !tokens.isEmpty else { return }
+        lock.lock()
+        pending.append(contentsOf: tokens)
+        if flushTask == nil {
+            flushTask = Task { [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: interval)
+                await self.deliverPending()
+            }
+        }
+        lock.unlock()
+    }
+
+    /// Deliver everything queued right now — used at stop/finalize so the
+    /// transcript tail is in the store before it is read.
+    func flushNow() async {
+        lock.lock()
+        flushTask?.cancel()
+        flushTask = nil
+        lock.unlock()
+        await deliverPending()
+    }
+
+    private func deliverPending() async {
+        lock.lock()
+        flushTask = nil
+        let tokens = pending
+        pending = []
+        lock.unlock()
+        guard !tokens.isEmpty else { return }
+        await onFlush(tokens)
+    }
+}

--- a/Diduny/Core/Services/RealtimeTokenCoalescer.swift
+++ b/Diduny/Core/Services/RealtimeTokenCoalescer.swift
@@ -1,38 +1,64 @@
 import Foundation
 
+/// Ordered output of the coalescer: merged token runs interleaved with
+/// segment boundaries, preserving arrival order.
+enum CoalescedTranscriptEvent {
+    case tokens([RealtimeToken])
+    case segmentBoundary(RealtimeSegmentBoundary)
+}
+
 /// Coalesces per-WebSocket-message token batches into main-actor flushes at
 /// most every `interval` (~10Hz by default). Realtime tokens can arrive many
 /// times per second; delivering each batch straight to an @Observable store
 /// re-renders SwiftUI per message and lets main-thread cost grow with the
-/// session. Batching preserves token order and caps UI work at a fixed rate.
+/// session.
+///
+/// Merging is semantics-aware: final tokens are append-only and accumulate,
+/// but non-final tokens are FULL SNAPSHOTS of the provisional tail, re-sent on
+/// every message — only the latest batch's snapshot survives a merge.
+/// Concatenating snapshots across messages would show duplicated provisional
+/// text until the next flush replaced it.
 final class RealtimeTokenCoalescer: @unchecked Sendable {
     private let lock = NSLock()
-    private var pending: [RealtimeToken] = []
+    /// Compacted, ordered events for the next flush. Consecutive token batches
+    /// merge into one run; a boundary closes the current run so ordering
+    /// relative to tokens is preserved.
+    private var events: [CoalescedTranscriptEvent] = []
+    private var runFinals: [RealtimeToken] = []
+    private var runLatestNonFinals: [RealtimeToken] = []
+    private var hasOpenRun = false
     private var flushTask: Task<Void, Never>?
     private let interval: Duration
-    private let onFlush: @MainActor ([RealtimeToken]) -> Void
+    private let onFlush: @MainActor ([CoalescedTranscriptEvent]) -> Void
 
     init(
         interval: Duration = .milliseconds(100),
-        onFlush: @escaping @MainActor ([RealtimeToken]) -> Void
+        onFlush: @escaping @MainActor ([CoalescedTranscriptEvent]) -> Void
     ) {
         self.interval = interval
         self.onFlush = onFlush
     }
 
-    /// Queue a batch; schedules a flush `interval` from now unless one is
-    /// already pending. Callable from any thread.
+    /// Queue a message's token batch; schedules a flush `interval` from now
+    /// unless one is already pending. Callable from any thread.
     func add(_ tokens: [RealtimeToken]) {
         guard !tokens.isEmpty else { return }
         lock.lock()
-        pending.append(contentsOf: tokens)
-        if flushTask == nil {
-            flushTask = Task { [weak self] in
-                guard let self else { return }
-                try? await Task.sleep(for: interval)
-                await self.deliverPending()
-            }
-        }
+        runFinals.append(contentsOf: tokens.filter(\.isFinal))
+        // Snapshot semantics: this message's non-final set REPLACES the
+        // previous one (an all-final message legitimately clears it).
+        runLatestNonFinals = tokens.filter { !$0.isFinal }
+        hasOpenRun = true
+        scheduleFlushLocked()
+        lock.unlock()
+    }
+
+    /// Queue a segment boundary in order relative to token batches.
+    func addBoundary(_ boundary: RealtimeSegmentBoundary) {
+        lock.lock()
+        closeRunLocked()
+        events.append(.segmentBoundary(boundary))
+        scheduleFlushLocked()
         lock.unlock()
     }
 
@@ -46,13 +72,34 @@ final class RealtimeTokenCoalescer: @unchecked Sendable {
         await deliverPending()
     }
 
+    private func scheduleFlushLocked() {
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: interval)
+            await self.deliverPending()
+        }
+    }
+
+    private func closeRunLocked() {
+        guard hasOpenRun else { return }
+        let run = runFinals + runLatestNonFinals
+        if !run.isEmpty {
+            events.append(.tokens(run))
+        }
+        runFinals = []
+        runLatestNonFinals = []
+        hasOpenRun = false
+    }
+
     private func deliverPending() async {
         lock.lock()
         flushTask = nil
-        let tokens = pending
-        pending = []
+        closeRunLocked()
+        let toDeliver = events
+        events = []
         lock.unlock()
-        guard !tokens.isEmpty else { return }
-        await onFlush(tokens)
+        guard !toDeliver.isEmpty else { return }
+        await onFlush(toDeliver)
     }
 }

--- a/Diduny/Core/Services/ShareableContentCache.swift
+++ b/Diduny/Core/Services/ShareableContentCache.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+/// Caches SCShareableContent, whose window-server fetch takes 0.5–2s+ and sits
+/// on the meeting-start critical path. Pre-warmed at app launch, on meeting
+/// hotkey intent, and after each meeting stop, so the actual start usually
+/// hits a fresh cache.
+actor ShareableContentCache {
+    static let shared = ShareableContentCache()
+
+    private var content: SCShareableContent?
+    private var fetchedAt: Date?
+    private var inflight: Task<SCShareableContent, Error>?
+
+    /// Kick off a background refresh; cheap to call often. Fetches only when
+    /// screen-recording permission is already granted — an ungranted fetch
+    /// would surprise the user with the system permission prompt.
+    nonisolated func prewarm() {
+        guard CGPreflightScreenCaptureAccess() else { return }
+        Task { _ = try? await self.refresh() }
+    }
+
+    /// Cached content if fresh enough, else a fresh fetch. Cached content can
+    /// reference since-removed displays — callers that build an SCStream from
+    /// it must retry once with `refresh()` on stream-start failure.
+    func current(maxAge: TimeInterval = 60) async throws -> SCShareableContent {
+        if let content, let fetchedAt, Date().timeIntervalSince(fetchedAt) < maxAge {
+            return content
+        }
+        return try await refresh()
+    }
+
+    /// Always fetches fresh and updates the cache. Concurrent callers share
+    /// one in-flight fetch.
+    func refresh() async throws -> SCShareableContent {
+        if let inflight {
+            return try await inflight.value
+        }
+        let task = Task {
+            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        }
+        inflight = task
+        defer { inflight = nil }
+        let fresh = try await task.value
+        content = fresh
+        fetchedAt = Date()
+        return fresh
+    }
+}

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -202,10 +202,25 @@ final class SystemAudioCaptureService: NSObject {
     }
 
     private func createAndStartSystemStream() async throws {
-        let content = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
-            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let cachedContent = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
+            try await ShareableContentCache.shared.current()
         }
 
+        do {
+            try await startSystemStream(with: cachedContent)
+        } catch {
+            // Cached content can reference a display that is gone (monitor
+            // unplugged since the prewarm) — retry once with a fresh fetch.
+            NSLog(
+                "[AudioCapture] SCStream start failed (%@) — retrying with fresh shareable content",
+                String(describing: error)
+            )
+            let freshContent = try await ShareableContentCache.shared.refresh()
+            try await startSystemStream(with: freshContent)
+        }
+    }
+
+    private func startSystemStream(with content: SCShareableContent) async throws {
         guard let display = content.displays.first else {
             throw SystemAudioError.noDisplayFound
         }

--- a/Diduny/Core/Services/SystemAudioCaptureService.swift
+++ b/Diduny/Core/Services/SystemAudioCaptureService.swift
@@ -202,7 +202,9 @@ final class SystemAudioCaptureService: NSObject {
     }
 
     private func createAndStartSystemStream() async throws {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        let content = try await ConnectMetrics.measure("[Meeting] sc_content_fetch") {
+            try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+        }
 
         guard let display = content.displays.first else {
             throw SystemAudioError.noDisplayFound
@@ -218,7 +220,9 @@ final class SystemAudioCaptureService: NSObject {
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: streamOutputQueue)
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: streamOutputQueue)
             self.stream = stream
-            try await stream.startCapture()
+            try await ConnectMetrics.measure("[Meeting] sc_stream_start") {
+                try await stream.startCapture()
+            }
         } catch {
             self.stream = nil
             throw error

--- a/Diduny/Features/Transcription/LiveTranscriptView.swift
+++ b/Diduny/Features/Transcription/LiveTranscriptView.swift
@@ -103,15 +103,14 @@ struct LiveTranscriptView: View {
                 .padding(16)
                 .textSelection(.enabled)
             }
+            // Unanimated: these fire on every store flush (≤10Hz), and an
+            // easing animation per flush kept a layout animation running on
+            // the main thread for the whole meeting.
             .onChange(of: store.segments.count) {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo("bottom", anchor: .bottom)
-                }
+                proxy.scrollTo("bottom", anchor: .bottom)
             }
             .onChange(of: store.provisionalText) {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    proxy.scrollTo("bottom", anchor: .bottom)
-                }
+                proxy.scrollTo("bottom", anchor: .bottom)
             }
         }
     }

--- a/DidunyTests/LiveTranscriptStorePerformanceTests.swift
+++ b/DidunyTests/LiveTranscriptStorePerformanceTests.swift
@@ -1,0 +1,78 @@
+@testable import Diduny
+import XCTest
+
+/// Correctness and scaling tests for the live-transcript hot path: the stored
+/// (incrementally maintained) `TranscriptSegment.text` must always match the
+/// join of its tokens, and per-token cost must not grow with segment length.
+@MainActor
+final class LiveTranscriptStorePerformanceTests: XCTestCase {
+    private func token(
+        _ text: String,
+        isFinal: Bool = true,
+        speaker: String? = "1",
+        startMs: Int = 0
+    ) -> RealtimeToken {
+        RealtimeToken(text: text, isFinal: isFinal, speaker: speaker, startMs: startMs)
+    }
+
+    func testStoredSegmentTextMatchesJoinedTokens() {
+        let store = LiveTranscriptStore()
+        let tokens = (0 ..< 500).map { token($0 % 7 == 0 ? " word\($0)" : "x") }
+        store.processTokens(tokens)
+
+        XCTAssertEqual(store.segments.count, 1)
+        let segment = store.segments[0]
+        XCTAssertEqual(segment.text, segment.tokens.map(\.text).joined())
+    }
+
+    func testSpeakerChangeStartsNewSegmentWithCorrectText() {
+        let store = LiveTranscriptStore()
+        store.processTokens([token("hello ", speaker: "1"), token("world", speaker: "1")])
+        store.processTokens([token("hi ", speaker: "2"), token("there", speaker: "2")])
+
+        XCTAssertEqual(store.segments.count, 2)
+        XCTAssertEqual(store.segments[0].text, "hello world")
+        XCTAssertEqual(store.segments[1].text, "hi there")
+    }
+
+    func testSegmentBoundaryForcesNewSegmentAndPreservesText() {
+        let store = LiveTranscriptStore()
+        store.processTokens([token("first")])
+        store.markSegmentBoundary()
+        store.processTokens([token("second")])
+
+        XCTAssertEqual(store.segments.count, 2)
+        XCTAssertEqual(store.segments[0].text, "first")
+        XCTAssertEqual(store.segments[1].text, "second")
+    }
+
+    func testFinalTranscriptTextIncludesAllSegments() {
+        let store = LiveTranscriptStore()
+        store.processTokens([token("alpha", speaker: "1", startMs: 0)])
+        store.processTokens([token("beta", speaker: "2", startMs: 65000)])
+
+        let text = store.finalTranscriptText
+        XCTAssertTrue(text.contains("Speaker 1: alpha"))
+        XCTAssertTrue(text.contains("Speaker 2: beta"))
+        XCTAssertTrue(text.contains("[01:05]"))
+    }
+
+    /// Appending into one long segment must stay cheap regardless of how much
+    /// text the segment already holds. Before text was stored incrementally,
+    /// 20k tokens in one segment took quadratic time via re-joins per render;
+    /// the raw append path measured here must scale linearly.
+    func testLongSingleSpeakerSegmentAppendScalesLinearly() {
+        let store = LiveTranscriptStore()
+        let batch = (0 ..< 100).map { _ in token("word ") }
+
+        measure {
+            for _ in 0 ..< 200 {
+                store.processTokens(batch)
+            }
+        }
+
+        XCTAssertGreaterThanOrEqual(store.segments[0].tokens.count, 20_000)
+        // Reading the full text afterwards is a single O(length) pass.
+        XCTAssertTrue(store.finalTranscriptText.hasSuffix("word"))
+    }
+}

--- a/DidunyTests/PreConnectAudioBufferTests.swift
+++ b/DidunyTests/PreConnectAudioBufferTests.swift
@@ -1,0 +1,77 @@
+@testable import Diduny
+import XCTest
+
+/// Tests for `PreConnectAudioBuffer` — the bounded FIFO that holds audio
+/// produced while the realtime socket is still connecting, so the first
+/// seconds of speech survive the handshake instead of being dropped.
+final class PreConnectAudioBufferTests: XCTestCase {
+    private func chunk(_ byte: UInt8, count: Int) -> Data {
+        Data(repeating: byte, count: count)
+    }
+
+    func testDrainsInFIFOOrder() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 1000)
+        buffer.append(chunk(1, count: 10))
+        buffer.append(chunk(2, count: 20))
+        buffer.append(chunk(3, count: 30))
+
+        XCTAssertEqual(buffer.count, 3)
+        XCTAssertEqual(buffer.totalBytes, 60)
+        XCTAssertEqual(buffer.removeFirst(), chunk(1, count: 10))
+        XCTAssertEqual(buffer.removeFirst(), chunk(2, count: 20))
+        XCTAssertEqual(buffer.removeFirst(), chunk(3, count: 30))
+        XCTAssertNil(buffer.removeFirst())
+        XCTAssertEqual(buffer.totalBytes, 0)
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
+    func testEvictsOldestBeyondByteCap() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 100)
+        buffer.append(chunk(1, count: 40))
+        buffer.append(chunk(2, count: 40))
+        XCTAssertFalse(buffer.didOverflow)
+
+        buffer.append(chunk(3, count: 40)) // 120 > 100 → chunk 1 evicted
+
+        XCTAssertTrue(buffer.didOverflow)
+        XCTAssertEqual(buffer.count, 2)
+        XCTAssertEqual(buffer.totalBytes, 80)
+        XCTAssertEqual(buffer.removeFirst(), chunk(2, count: 40))
+        XCTAssertEqual(buffer.removeFirst(), chunk(3, count: 40))
+    }
+
+    func testKeepsLatestChunkEvenWhenLargerThanCap() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 10)
+        buffer.append(chunk(1, count: 50))
+
+        // A single oversized chunk is kept — dropping it would lose the only
+        // audio we have; the cap bounds accumulation, not chunk size.
+        XCTAssertEqual(buffer.count, 1)
+        XCTAssertEqual(buffer.removeFirst(), chunk(1, count: 50))
+    }
+
+    func testRemoveAllResetsStateIncludingOverflowFlag() {
+        var buffer = PreConnectAudioBuffer(maxBytes: 50)
+        buffer.append(chunk(1, count: 40))
+        buffer.append(chunk(2, count: 40))
+        XCTAssertTrue(buffer.didOverflow)
+
+        buffer.removeAll()
+
+        XCTAssertTrue(buffer.isEmpty)
+        XCTAssertEqual(buffer.totalBytes, 0)
+        XCTAssertFalse(buffer.didOverflow)
+    }
+
+    func testFifteenSecondsOfRealtimeAudioFitsDefaultCap() {
+        // The realtime stream is 16kHz mono s16le = 32,000 bytes/s, delivered
+        // in ~100ms chunks. 15s of it must fit without eviction.
+        var buffer = PreConnectAudioBuffer()
+        let chunkBytes = 3200
+        for _ in 0 ..< 150 {
+            buffer.append(chunk(7, count: chunkBytes))
+        }
+        XCTAssertFalse(buffer.didOverflow)
+        XCTAssertEqual(buffer.totalBytes, 480_000)
+    }
+}

--- a/DidunyTests/RealtimeTokenCoalescerTests.swift
+++ b/DidunyTests/RealtimeTokenCoalescerTests.swift
@@ -2,17 +2,30 @@
 import XCTest
 
 /// Tests for `RealtimeTokenCoalescer` — per-message token batches must arrive
-/// merged, in order, at a bounded rate, and `flushNow()` must deliver the tail
-/// synchronously enough for stop paths to read a complete transcript.
+/// merged with snapshot semantics (finals accumulate, only the latest
+/// non-final snapshot survives), in order, at a bounded rate, and `flushNow()`
+/// must deliver the tail synchronously enough for stop paths to read a
+/// complete transcript.
 final class RealtimeTokenCoalescerTests: XCTestCase {
-    private func token(_ text: String) -> RealtimeToken {
-        RealtimeToken(text: text, isFinal: true)
+    private func token(_ text: String, isFinal: Bool = true) -> RealtimeToken {
+        RealtimeToken(text: text, isFinal: isFinal)
     }
 
-    func testCoalescesManyBatchesIntoFewFlushesPreservingOrder() async throws {
+    private func tokenTexts(_ events: [[CoalescedTranscriptEvent]]) -> [String] {
+        events.flatMap { flush in
+            flush.flatMap { event -> [String] in
+                if case let .tokens(tokens) = event {
+                    return tokens.map(\.text)
+                }
+                return []
+            }
+        }
+    }
+
+    func testCoalescesManyBatchesIntoFewFlushesPreservingFinalOrder() async throws {
         let collected = Collector()
-        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(50)) { tokens in
-            collected.record(tokens)
+        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(50)) { events in
+            collected.record(events)
         }
 
         for i in 0 ..< 20 {
@@ -23,28 +36,91 @@ final class RealtimeTokenCoalescerTests: XCTestCase {
         let flushes = collected.flushes()
         XCTAssertLessThan(flushes.count, 20, "batches must be merged, not delivered per message")
         XCTAssertEqual(
-            flushes.flatMap { $0.map(\.text) },
+            tokenTexts(flushes),
             (0 ..< 20).map { "t\($0)" },
-            "token order must be preserved across coalesced flushes"
+            "final token order must be preserved across coalesced flushes"
         )
+    }
+
+    /// Regression: non-final tokens are full snapshots of the provisional tail,
+    /// re-sent on every message. Merging messages by concatenation showed the
+    /// previous snapshot alongside the new one (stale text that then got
+    /// replaced). Only the LATEST snapshot may survive a merge.
+    func testMergeKeepsOnlyLatestNonFinalSnapshot() async {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { events in
+            collected.record(events)
+        }
+
+        coalescer.add([token("hello wor", isFinal: false)])
+        coalescer.add([token("hello world", isFinal: false)])
+        coalescer.add([token("hello ", isFinal: true), token("world, hi", isFinal: false)])
+        await coalescer.flushNow()
+
+        XCTAssertEqual(
+            tokenTexts(collected.flushes()),
+            ["hello ", "world, hi"],
+            "merged flush must carry accumulated finals + only the latest provisional snapshot"
+        )
+    }
+
+    /// An all-final message clears the provisional tail; a merged flush must
+    /// preserve that (finals present, no non-finals) so consumers reset
+    /// provisional text.
+    func testAllFinalMessageClearsSnapshotInMergedFlush() async {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { events in
+            collected.record(events)
+        }
+
+        coalescer.add([token("provisional", isFinal: false)])
+        coalescer.add([token("final.", isFinal: true)])
+        await coalescer.flushNow()
+
+        let flushes = collected.flushes()
+        XCTAssertEqual(tokenTexts(flushes), ["final."])
+    }
+
+    func testBoundaryStaysOrderedRelativeToTokenRuns() async {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { events in
+            collected.record(events)
+        }
+
+        coalescer.add([token("before")])
+        coalescer.addBoundary(.endpoint)
+        coalescer.add([token("after")])
+        await coalescer.flushNow()
+
+        let flush = collected.flushes().first ?? []
+        XCTAssertEqual(flush.count, 3)
+        guard flush.count == 3,
+              case let .tokens(first) = flush[0],
+              case .segmentBoundary = flush[1],
+              case let .tokens(last) = flush[2]
+        else {
+            return XCTFail("expected tokens / boundary / tokens, got \(flush)")
+        }
+        XCTAssertEqual(first.map(\.text), ["before"])
+        XCTAssertEqual(last.map(\.text), ["after"])
     }
 
     func testFlushNowDeliversPendingImmediately() async {
         let collected = Collector()
-        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { tokens in
-            collected.record(tokens)
+        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { events in
+            collected.record(events)
         }
 
         coalescer.add([token("tail")])
         await coalescer.flushNow()
 
-        XCTAssertEqual(collected.flushes().flatMap { $0.map(\.text) }, ["tail"])
+        XCTAssertEqual(tokenTexts(collected.flushes()), ["tail"])
     }
 
     func testEmptyAddDoesNotScheduleFlush() async throws {
         let collected = Collector()
-        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(20)) { tokens in
-            collected.record(tokens)
+        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(20)) { events in
+            collected.record(events)
         }
 
         coalescer.add([])
@@ -57,15 +133,15 @@ final class RealtimeTokenCoalescerTests: XCTestCase {
 /// Thread-safe flush recorder (flushes land on the main actor).
 private final class Collector: @unchecked Sendable {
     private let lock = NSLock()
-    private var recorded: [[RealtimeToken]] = []
+    private var recorded: [[CoalescedTranscriptEvent]] = []
 
-    func record(_ tokens: [RealtimeToken]) {
+    func record(_ events: [CoalescedTranscriptEvent]) {
         lock.lock()
-        recorded.append(tokens)
+        recorded.append(events)
         lock.unlock()
     }
 
-    func flushes() -> [[RealtimeToken]] {
+    func flushes() -> [[CoalescedTranscriptEvent]] {
         lock.lock()
         defer { lock.unlock() }
         return recorded

--- a/DidunyTests/RealtimeTokenCoalescerTests.swift
+++ b/DidunyTests/RealtimeTokenCoalescerTests.swift
@@ -1,0 +1,73 @@
+@testable import Diduny
+import XCTest
+
+/// Tests for `RealtimeTokenCoalescer` — per-message token batches must arrive
+/// merged, in order, at a bounded rate, and `flushNow()` must deliver the tail
+/// synchronously enough for stop paths to read a complete transcript.
+final class RealtimeTokenCoalescerTests: XCTestCase {
+    private func token(_ text: String) -> RealtimeToken {
+        RealtimeToken(text: text, isFinal: true)
+    }
+
+    func testCoalescesManyBatchesIntoFewFlushesPreservingOrder() async throws {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(50)) { tokens in
+            collected.record(tokens)
+        }
+
+        for i in 0 ..< 20 {
+            coalescer.add([token("t\(i)")])
+        }
+        try await Task.sleep(for: .milliseconds(200))
+
+        let flushes = collected.flushes()
+        XCTAssertLessThan(flushes.count, 20, "batches must be merged, not delivered per message")
+        XCTAssertEqual(
+            flushes.flatMap { $0.map(\.text) },
+            (0 ..< 20).map { "t\($0)" },
+            "token order must be preserved across coalesced flushes"
+        )
+    }
+
+    func testFlushNowDeliversPendingImmediately() async {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .seconds(10)) { tokens in
+            collected.record(tokens)
+        }
+
+        coalescer.add([token("tail")])
+        await coalescer.flushNow()
+
+        XCTAssertEqual(collected.flushes().flatMap { $0.map(\.text) }, ["tail"])
+    }
+
+    func testEmptyAddDoesNotScheduleFlush() async throws {
+        let collected = Collector()
+        let coalescer = RealtimeTokenCoalescer(interval: .milliseconds(20)) { tokens in
+            collected.record(tokens)
+        }
+
+        coalescer.add([])
+        try await Task.sleep(for: .milliseconds(80))
+
+        XCTAssertTrue(collected.flushes().isEmpty)
+    }
+}
+
+/// Thread-safe flush recorder (flushes land on the main actor).
+private final class Collector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [[RealtimeToken]] = []
+
+    func record(_ tokens: [RealtimeToken]) {
+        lock.lock()
+        recorded.append(tokens)
+        lock.unlock()
+    }
+
+    func flushes() -> [[RealtimeToken]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -72,6 +72,8 @@ targets:
       - path: Diduny
         excludes:
           - "**/.DS_Store"
+          - ".claude"
+          - "**/.claude"
     dependencies:
       - package: KeyboardShortcuts
       - package: DynamicNotchKit


### PR DESCRIPTION
Consolidates #50, #51, and the transcript-lag fixes into one PR (three commits). Pairs with rmarinsky/diduny-backend#16 — the server-side 1MB pending-buffer cap and upgrade-latency cuts should deploy before or with this release.

## Why

Two user-facing problems, both verified in code:

1. **Transcription start felt slow.** Meetings awaited the *entire* WebSocket handshake (auth token fetch → TLS → server auth/usage queries → config → `proxy_ready`, up to 10 s) before showing "recording" — despite a comment claiming it was non-blocking — plus a fresh 0.5–2 s `SCShareableContent` fetch on every start. Dictation connected in the background, but audio produced before the socket was ready was **silently dropped**, losing the first words of every utterance.
2. **The app lagged progressively under heavy use.** The live transcript path was O(n²): `TranscriptSegment.text` re-joined every token on each render of the always-visible growing segment, the `@Observable` store mutated on the main actor per WebSocket message, and an easing scroll animation fired per token batch.

## What

**Commit 1 — instrumentation (`ConnectMetrics`)**
- os_signpost intervals + one greppable summary line per realtime connect (`token`/`upgrade`/`config`/`ready`/`total`) and per meeting start (SC fetch, stream start, recorder, total to `.recording`).
- Incidental fix: `project.yml` excludes `.claude/` from XcodeGen sources — stray local agent-memory files broke project regeneration with duplicate resource outputs.

**Commit 2 — zero-perceived connect latency**
- **Pre-connect audio buffer** (`PreConnectAudioBuffer`): bounded FIFO (~15 s of 16 kHz s16le, oldest-evicted) filled while connecting or during reconnect backoff, flushed in order once the socket is up (`flushingPendingAudio` gate keeps FIFO order). Reconnect gaps become recovered transcript; terminal failures (402, 1001, max attempts) drop the buffer.
- **`proxy_ready` continuation** instead of the 50 ms busy-wait — resumed exactly once (take-and-nil under `lifecycleLock`) by `proxy_ready`, a proxy error frame (previously waited out the full 10 s), `disconnect()`, or a 10 s watchdog.
- **Shared URLSession** across connections (TLS session resumption; never invalidated — documented).
- **Meeting start reorder**: realtime wiring + connect launched in a background task *before* ScreenCaptureKit/mic setup; `.recording` and the transcript window no longer wait on the network. Stop/cancel/abort/error paths cancel the in-flight connect.
- **`ShareableContentCache`** (actor) pre-warmed at launch (only when screen-recording permission is already granted), on meeting-hotkey intent, and after each stop; stream start retries once with a fresh fetch if cached content references an unplugged display.
- **Auth token pre-warm** at recording intent (dictation + meeting).

**Commit 3 — lag fixes + teardown hygiene**
- `TranscriptSegment.text` stored and maintained incrementally by `append(_:)` — kills the O(n²) re-join.
- **`RealtimeTokenCoalescer`** batches token delivery to ≤10 Hz for the meeting store and dictation overlay; the `RealtimeVoiceAccumulator` correctness path still processes every batch. Stop/cancel paths `flushNow()` the tail before reading the transcript.
- Unanimated, coalesced auto-scroll in `LiveTranscriptView`.
- **`clearCallbacks()`** on owning teardown paths (meeting stop/cancel/error, voice defer) so stale closures from finished sessions stop receiving tokens and release their captures. Deliberately not inside `disconnect()` — reconnect-failure paths disconnect first, then report `.failed` through those callbacks.
- `reconnectAttempt` moved under `lifecycleLock`; meeting `.error` deactivates the global Escape monitor.

Follow-up (not in scope): meeting-translation path coalescing + callback cleanup (it inherits the stored-text fix automatically); server usage-sum RPC.

## Testing

- `xcodebuild build` + full suite: **79 XCTest + 53 Swift Testing tests, 0 failures** (5 pre-existing skips).
- New tests: `PreConnectAudioBufferTests` (FIFO order, byte-cap eviction, oversized-chunk retention, reset, 15 s capacity), `RealtimeTokenCoalescerTests` (merge + order, `flushNow`, empty no-op), `LiveTranscriptStorePerformanceTests` (stored-text == joined-tokens invariant, segmentation, formatting, 20k-token `measure` soak).
- Dev build installed and running locally. Verify with:
  `log stream --predicate 'eventMessage CONTAINS "timings" OR eventMessage CONTAINS "Flushed"'`
  - Dictation: speak immediately after the hotkey — full first phrase transcribes (previously lost).
  - Meeting: `.recording` appears at recorder-start time; warm `sc_content_fetch` on second start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)