### PR TITLE
fix: ship translation pair picker on hotkey

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		CBD76325F1DE55DA51EDD348 /* DeviceLevelMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */; };
 		CC8A0AB7ADA44B998EC3E45D /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26809CA162E096F4EA668768 /* ServiceProtocols.swift */; };
 		CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */; };
+		D08BBB9F8D641C3D4ADAD992 /* TranslationPairPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650D5A1F7778A1C35AD2F515 /* TranslationPairPickerControllerTests.swift */; };
 		D0BDBD33AD9969711AEF33E1 /* TypingTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803A2E19B668337A8516CC31 /* TypingTestView.swift */; };
 		D52AFEB3B25B529860D14116 /* AudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118CE8BCA0160E31FD916B10 /* AudioDevice.swift */; };
 		D6203B3BADF3AA7E40186F11 /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0491E26240E167BDB5DCACEE /* HotkeyService.swift */; };
@@ -210,6 +211,7 @@
 		5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTranscriptionService.swift; sourceTree = "<group>"; };
 		622D792451975A00E4A3FCBF /* HTTPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPLogger.swift; sourceTree = "<group>"; };
 		622FD84CF56FC17420114B9C /* NotchContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchContentView.swift; sourceTree = "<group>"; };
+		650D5A1F7778A1C35AD2F515 /* TranslationPairPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPairPickerControllerTests.swift; sourceTree = "<group>"; };
 		65DFFB871345DD916879CEBD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToTalkKey.swift; sourceTree = "<group>"; };
 		684A014D6E9B1A40935A7608 /* UpdaterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterManager.swift; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 				E06685A0367DD0430BCEE035 /* SettingsStorageProviderTests.swift */,
 				C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */,
 				DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */,
+				650D5A1F7778A1C35AD2F515 /* TranslationPairPickerControllerTests.swift */,
 				D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */,
 			);
 			path = DidunyTests;
@@ -911,6 +914,7 @@
 				4E980E04C373EE5FBF3D2DC6 /* SettingsStorageProviderTests.swift in Sources */,
 				CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */,
 				D9A94E2B88149920B8BA2B9E /* TranscriptCleanupServiceTests.swift in Sources */,
+				D08BBB9F8D641C3D4ADAD992 /* TranslationPairPickerControllerTests.swift in Sources */,
 				FFBC1497C42CFFB50037E3EA /* TypingSpeedMeasurementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0FFD1A4567A90C61047FD763 /* SettingsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91E893AF3E6C20B492D3CB7 /* SettingsStorage.swift */; };
 		107FDBF081DEEF30BD2A922D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0D8B455676B571AEC778E72 /* Assets.xcassets */; };
 		154F9E85CEDA37FE7E88EE36 /* CloudTranscriptionServiceE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2D4C4C36B3BB89D1A2E8BD /* CloudTranscriptionServiceE2ETests.swift */; };
+		168E409F3F1A8B6489AD03AC /* TranslationPairPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CACF6F1317164FD269AF83 /* TranslationPairPickerView.swift */; };
+		1781B9D8B99C71B7C5260D8A /* TranslationPairPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E5561A2486B59713A6C3BF /* TranslationPairPickerController.swift */; };
 		1D8F54C7E34D0BF458CDE89A /* OverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D10CEDBC544B56C03986007 /* OverviewView.swift */; };
 		1FC13B68C69A30C9FD13E2F0 /* ShortcutsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B0622318D71BD3A1EEA701 /* ShortcutsSettingsView.swift */; };
 		214683A40F227DDAE1D64C8B /* OnboardingComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A6F95E2FA37D325086B2BC /* OnboardingComponents.swift */; };
@@ -163,6 +165,7 @@
 		18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingRecording.swift"; sourceTree = "<group>"; };
 		1967633DAD0607B3B2756CC8 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		1999FC4728C79F46A514A1E4 /* AppDelegate+MeetingTranslationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingTranslationRecording.swift"; sourceTree = "<group>"; };
+		19CACF6F1317164FD269AF83 /* TranslationPairPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPairPickerView.swift; sourceTree = "<group>"; };
 		1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManager.swift; sourceTree = "<group>"; };
 		22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
 		22ECCCBC345EE579CFE2AD5F /* InProgressRecordingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InProgressRecordingStoreTests.swift; sourceTree = "<group>"; };
@@ -171,6 +174,7 @@
 		24A8CC23A7C474D5EFDFBAC1 /* SleepFlushCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepFlushCoordinator.swift; sourceTree = "<group>"; };
 		258680FE2F7ED1EB6DB95757 /* ProtectedLexiconService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedLexiconService.swift; sourceTree = "<group>"; };
 		26809CA162E096F4EA668768 /* ServiceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
+		26E5561A2486B59713A6C3BF /* TranslationPairPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPairPickerController.swift; sourceTree = "<group>"; };
 		2A69C86E608DDD0D38D8AB54 /* WhisperBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WhisperBridge.h; sourceTree = "<group>"; };
 		2ABF3F1FBD81398469047BB4 /* DidunyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DidunyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C88AE153FCAA14A227A7E16 /* AudioPlaybackControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackControlView.swift; sourceTree = "<group>"; };
@@ -480,6 +484,7 @@
 				8F1DB771BE47D76906F11C84 /* Settings */,
 				80BA8191113D56E490C4FF8A /* TextTranslation */,
 				26025DF9FC1F88D47FBD32E3 /* Transcription */,
+				B3F3B796E316F19F2C32CA5E /* TranslationPicker */,
 				BD2D4F0969973C703C44CC27 /* TypingTest */,
 			);
 			path = Features;
@@ -573,6 +578,15 @@
 				1FD5AFC9EA02A0334CB2B377 /* Whisper */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		B3F3B796E316F19F2C32CA5E /* TranslationPicker */ = {
+			isa = PBXGroup;
+			children = (
+				26E5561A2486B59713A6C3BF /* TranslationPairPickerController.swift */,
+				19CACF6F1317164FD269AF83 /* TranslationPairPickerView.swift */,
+			);
+			path = TranslationPicker;
 			sourceTree = "<group>";
 		};
 		B6C1477395B1431F550CF057 = {
@@ -863,6 +877,8 @@
 				BB39149383C71119B82FE3AD /* TranscriptCleanupService.swift in Sources */,
 				F293480FBFF36536227A5878 /* TranscriptionProvider.swift in Sources */,
 				50CD068CB639D75D27C09787 /* TranscriptionWindowController.swift in Sources */,
+				1781B9D8B99C71B7C5260D8A /* TranslationPairPickerController.swift in Sources */,
+				168E409F3F1A8B6489AD03AC /* TranslationPairPickerView.swift in Sources */,
 				4D10D5466C7B83FF47A47945 /* TypingSpeedMeasurement.swift in Sources */,
 				D0BDBD33AD9969711AEF33E1 /* TypingTestView.swift in Sources */,
 				4E4C0DD6E977C6306BD0289C /* UpdaterManager.swift in Sources */,

--- a/Diduny/App/AppDelegate+TranslationRecording.swift
+++ b/Diduny/App/AppDelegate+TranslationRecording.swift
@@ -81,17 +81,42 @@ extension AppDelegate {
         let translationRecordingState = appState.translationRecordingState
         Log.app.info("toggleTranslationRecording called, current state: \(translationRecordingState)")
 
+        // Second hotkey press while the picker is open confirms the
+        // highlighted pair — "hotkey, hotkey" starts with the default. Don't
+        // cancel the pipeline task: it is suspended awaiting this choice.
+        if TranslationPairPickerController.shared.isVisible {
+            TranslationPairPickerController.shared.confirmCurrentSelection()
+            return
+        }
+
         translationPipelineTask?.cancel()
         translationPipelineTask = Task {
-            await self.performToggleTranslationRecording()
+            await self.performToggleTranslationRecording(promptForLanguagePair: true)
         }
     }
 
-    func performToggleTranslationRecording() async {
+    /// - Parameter promptForLanguagePair: when true (translation hotkey) and
+    ///   more than one pair is configured, shows the pair picker before
+    ///   starting. Push-to-talk passes false — recording must start instantly
+    ///   while keys are held.
+    func performToggleTranslationRecording(promptForLanguagePair: Bool = false) async {
         let translationRecordingState = appState.translationRecordingState
         switch translationRecordingState {
         case .idle:
-            await startTranslationRecording()
+            let pairs = SettingsStorage.shared.translationLanguagePairs
+            if promptForLanguagePair, pairs.count > 1 {
+                let preselected = SettingsStorage.shared.resolveTranslationLanguagePair()
+                guard let pair = await TranslationPairPickerController.shared.pick(
+                    pairs: pairs,
+                    preselected: preselected
+                ) else {
+                    Log.app.info("Translation pair picker cancelled")
+                    return
+                }
+                await startTranslationRecording(languagePair: pair)
+            } else {
+                await startTranslationRecording()
+            }
         case .recording:
             await stopTranslationRecording()
         case .processing:

--- a/Diduny/Features/MenuBar/MenuBarContentView.swift
+++ b/Diduny/Features/MenuBar/MenuBarContentView.swift
@@ -1,8 +1,34 @@
 import KeyboardShortcuts
 import SwiftUI
 
+struct MenuBarProcessingModeSelection {
+    private let settings: SettingsStorage
+    private(set) var provider: TranscriptionProvider
+
+    init(settings: SettingsStorage = .shared) {
+        self.settings = settings
+        provider = settings.effectiveTranscriptionProvider == .cloud
+            && settings.effectiveTranslationProvider == .cloud ? .cloud : .local
+    }
+
+    mutating func refresh() {
+        provider = settings.effectiveTranscriptionProvider == .cloud
+            && settings.effectiveTranslationProvider == .cloud ? .cloud : .local
+    }
+
+    mutating func select(_ provider: TranscriptionProvider) {
+        settings.transcriptionProvider = provider
+        settings.translationProvider = provider
+        if provider == .local {
+            settings.meetingRealtimeTranscriptionEnabled = false
+        }
+        self.provider = provider
+    }
+}
+
 struct MenuBarContentView: View {
     @Environment(AppState.self) var appState
+    @State private var processingMode = MenuBarProcessingModeSelection()
     var audioDeviceManager: AudioDeviceManager
 
     var onToggleRecording: @MainActor () -> Void
@@ -132,6 +158,7 @@ struct MenuBarContentView: View {
             .keyboardShortcut("q", modifiers: .command)
         }
         .padding(.vertical, 4)
+        .onAppear { processingMode.refresh() }
     }
 
     private var recordingButtonTitle: String {
@@ -258,9 +285,7 @@ struct MenuBarContentView: View {
     }
 
     private var isCloudMode: Bool {
-        let settings = SettingsStorage.shared
-        return settings.effectiveTranscriptionProvider == .cloud
-            && settings.effectiveTranslationProvider == .cloud
+        processingMode.provider == .cloud
     }
 
     private func selectCloudMode() {
@@ -269,15 +294,10 @@ struct MenuBarContentView: View {
             onOpenMainWindow(.account)
             return
         }
-        let settings = SettingsStorage.shared
-        settings.transcriptionProvider = .cloud
-        settings.translationProvider = .cloud
+        processingMode.select(.cloud)
     }
 
     private func selectLocalMode() {
-        let settings = SettingsStorage.shared
-        settings.transcriptionProvider = .local
-        settings.translationProvider = .local
-        settings.meetingRealtimeTranscriptionEnabled = false
+        processingMode.select(.local)
     }
 }

--- a/Diduny/Features/TranslationPicker/TranslationPairPickerController.swift
+++ b/Diduny/Features/TranslationPicker/TranslationPairPickerController.swift
@@ -1,0 +1,157 @@
+import AppKit
+import SwiftUI
+
+/// Floating keyboard-first picker for choosing which language pair to
+/// translate into. Shown by the translation hotkey when more than one pair is
+/// configured; push-to-talk deliberately skips it (recording must start
+/// instantly while keys are held).
+///
+/// Keys: ↑/↓ move, 1–9 select directly, ⏎ confirms, esc cancels. Pressing the
+/// translation hotkey again while the picker is open confirms the highlighted
+/// pair, so "hotkey, hotkey" starts recording with the default pair.
+@MainActor
+final class TranslationPairPickerController: NSObject, NSWindowDelegate {
+    static let shared = TranslationPairPickerController()
+
+    private var panel: NSPanel?
+    private var eventMonitor: Any?
+    private var model: TranslationPairPickerModel?
+    private var continuation: CheckedContinuation<TranslationLanguagePair?, Never>?
+
+    override private init() {
+        super.init()
+    }
+
+    var isVisible: Bool {
+        panel?.isVisible == true
+    }
+
+    /// Shows the picker and suspends until the user picks a pair or cancels.
+    /// Returns nil on cancel. Reentrant calls cancel the previous invocation.
+    func pick(
+        pairs: [TranslationLanguagePair],
+        preselected: TranslationLanguagePair?
+    ) async -> TranslationLanguagePair? {
+        dismiss(returning: nil)
+
+        guard !pairs.isEmpty else { return nil }
+
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            show(pairs: pairs, preselected: preselected)
+        }
+    }
+
+    /// Confirms the currently highlighted pair (used by a repeated hotkey press).
+    func confirmCurrentSelection() {
+        guard let model else { return }
+        dismiss(returning: model.selectedPair)
+    }
+
+    private func show(pairs: [TranslationLanguagePair], preselected: TranslationLanguagePair?) {
+        let model = TranslationPairPickerModel(
+            pairs: pairs,
+            selectedIndex: pairs.firstIndex(where: { $0.id == preselected?.id }) ?? 0
+        )
+        model.onCommit = { [weak self] pair in
+            self?.dismiss(returning: pair)
+        }
+        self.model = model
+
+        let hostingView = NSHostingView(rootView: TranslationPairPickerPanelView(model: model))
+        hostingView.setFrameSize(hostingView.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: hostingView.fittingSize),
+            styleMask: [.titled, .hudWindow, .utilityWindow, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Translate to"
+        panel.contentView = hostingView
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.isReleasedWhenClosed = false
+        panel.level = .floating
+        panel.becomesKeyOnlyIfNeeded = false
+        panel.center()
+        panel.delegate = self
+        self.panel = panel
+        // Non-activating panel: takes key events without stealing app focus,
+        // so the eventual paste still lands in the user's frontmost app.
+        panel.makeKeyAndOrderFront(nil)
+
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, let model = self.model else { return event }
+
+            switch event.keyCode {
+            case 53: // Escape
+                self.dismiss(returning: nil)
+                return nil
+            case 36, 76: // Return / keypad Enter
+                self.dismiss(returning: model.selectedPair)
+                return nil
+            case 126: // Up
+                model.moveSelection(by: -1)
+                return nil
+            case 125: // Down
+                model.moveSelection(by: 1)
+                return nil
+            default:
+                if let characters = event.charactersIgnoringModifiers,
+                   let digit = Int(characters), (1 ... 9).contains(digit),
+                   digit <= model.pairs.count {
+                    self.dismiss(returning: model.pairs[digit - 1])
+                    return nil
+                }
+                return event
+            }
+        }
+    }
+
+    /// Resolves the pending pick exactly once and tears the panel down.
+    private func dismiss(returning pair: TranslationLanguagePair?) {
+        let continuation = self.continuation
+        self.continuation = nil
+        model = nil
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        panel?.delegate = nil
+        panel?.close()
+        panel = nil
+        continuation?.resume(returning: pair)
+    }
+
+    nonisolated func windowWillClose(_: Notification) {
+        Task { @MainActor in
+            // Closed by the system (e.g. app hide) without an explicit choice.
+            self.dismiss(returning: nil)
+        }
+    }
+}
+
+// MARK: - Model
+
+@Observable
+@MainActor
+final class TranslationPairPickerModel {
+    let pairs: [TranslationLanguagePair]
+    var selectedIndex: Int
+    var onCommit: ((TranslationLanguagePair?) -> Void)?
+
+    init(pairs: [TranslationLanguagePair], selectedIndex: Int) {
+        self.pairs = pairs
+        self.selectedIndex = min(max(selectedIndex, 0), max(pairs.count - 1, 0))
+    }
+
+    var selectedPair: TranslationLanguagePair? {
+        pairs.indices.contains(selectedIndex) ? pairs[selectedIndex] : pairs.first
+    }
+
+    func moveSelection(by delta: Int) {
+        guard !pairs.isEmpty else { return }
+        selectedIndex = (selectedIndex + delta + pairs.count) % pairs.count
+    }
+}

--- a/Diduny/Features/TranslationPicker/TranslationPairPickerView.swift
+++ b/Diduny/Features/TranslationPicker/TranslationPairPickerView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct TranslationPairPickerPanelView: View {
+    let model: TranslationPairPickerModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 2) {
+                ForEach(Array(model.pairs.enumerated()), id: \.element.id) { index, pair in
+                    row(index: index, pair: pair)
+                }
+            }
+            .padding(6)
+
+            Divider()
+
+            HStack(spacing: 8) {
+                hint("↑↓", "move")
+                hint("1–\(min(model.pairs.count, 9))", "pick")
+                hint("⏎", "start")
+                hint("esc", "cancel")
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+        }
+        .frame(width: 260)
+    }
+
+    private func row(index: Int, pair: TranslationLanguagePair) -> some View {
+        let isSelected = index == model.selectedIndex
+        return Button {
+            model.onCommit?(pair)
+        } label: {
+            HStack(spacing: 10) {
+                Text("\(index + 1)")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(isSelected ? .white.opacity(0.8) : .secondary)
+                    .frame(width: 14)
+
+                Text(pair.displayLabel)
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(isSelected ? .white : .primary)
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "return")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? Color("BrandAccentDeep") : .clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering {
+                model.selectedIndex = index
+            }
+        }
+    }
+
+    private func hint(_ key: String, _ label: String) -> some View {
+        HStack(spacing: 3) {
+            Text(key)
+                .font(.system(size: 9, design: .monospaced))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.secondary.opacity(0.15))
+                )
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/DidunyTests/SettingsStorageProviderTests.swift
+++ b/DidunyTests/SettingsStorageProviderTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class SettingsStorageProviderTests: XCTestCase {
     private let transcriptionProviderKey = "transcriptionProvider"
+    private let translationProviderKey = "translationProvider"
+    private let sessionPresentKey = "_diduny_supabase_session_present"
     private let dictationRetentionKey = "dictationTranslationHistoryRetentionPolicy"
     private let meetingRetentionKey = "meetingHistoryRetentionPolicy"
     private let favoriteLanguagesKey = "favoriteLanguages"
@@ -18,6 +20,8 @@ final class SettingsStorageProviderTests: XCTestCase {
     private let textTranslationSourceLanguageKey = "textTranslationSourceLanguage"
     private let textTranslationTargetLanguageKey = "textTranslationTargetLanguage"
     private var storedProvider: Any?
+    private var storedTranslationProvider: Any?
+    private var storedSessionPresent: Any?
     private var storedDictationRetention: Any?
     private var storedMeetingRetention: Any?
     private var storedFavoriteLanguages: Any?
@@ -36,6 +40,8 @@ final class SettingsStorageProviderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storedProvider = UserDefaults.standard.object(forKey: transcriptionProviderKey)
+        storedTranslationProvider = UserDefaults.standard.object(forKey: translationProviderKey)
+        storedSessionPresent = UserDefaults.standard.object(forKey: sessionPresentKey)
         storedDictationRetention = UserDefaults.standard.object(forKey: dictationRetentionKey)
         storedMeetingRetention = UserDefaults.standard.object(forKey: meetingRetentionKey)
         storedFavoriteLanguages = UserDefaults.standard.object(forKey: favoriteLanguagesKey)
@@ -56,6 +62,8 @@ final class SettingsStorageProviderTests: XCTestCase {
 
     override func tearDown() {
         restore(storedProvider, key: transcriptionProviderKey)
+        restore(storedTranslationProvider, key: translationProviderKey)
+        restore(storedSessionPresent, key: sessionPresentKey)
         restore(storedDictationRetention, key: dictationRetentionKey)
         restore(storedMeetingRetention, key: meetingRetentionKey)
         restore(storedFavoriteLanguages, key: favoriteLanguagesKey)
@@ -83,6 +91,19 @@ final class SettingsStorageProviderTests: XCTestCase {
         UserDefaults.standard.set(TranscriptionProvider.local.rawValue, forKey: transcriptionProviderKey)
 
         XCTAssertEqual(SettingsStorage.shared.transcriptionProvider, .local)
+    }
+
+    func test_menuBarProcessingModeSelection_updatesDisplayedAndStoredProviders() {
+        UserDefaults.standard.set(true, forKey: sessionPresentKey)
+        SettingsStorage.shared.transcriptionProvider = .local
+        SettingsStorage.shared.translationProvider = .local
+        var selection = MenuBarProcessingModeSelection()
+
+        selection.select(.cloud)
+
+        XCTAssertEqual(selection.provider, .cloud)
+        XCTAssertEqual(SettingsStorage.shared.transcriptionProvider, .cloud)
+        XCTAssertEqual(SettingsStorage.shared.translationProvider, .cloud)
     }
 
     func test_defaultHistoryRetentionPolicies_areForever() {

--- a/DidunyTests/TranslationPairPickerControllerTests.swift
+++ b/DidunyTests/TranslationPairPickerControllerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Diduny
+
+@MainActor
+final class TranslationPairPickerControllerTests: XCTestCase {
+    func testPickShowsPickerForConfiguredPairs() async {
+        let pairs = [
+            TranslationLanguagePair(languageA: "uk", languageB: "en"),
+            TranslationLanguagePair(languageA: "en", languageB: "es"),
+        ]
+
+        let selection = Task {
+            await TranslationPairPickerController.shared.pick(
+                pairs: pairs,
+                preselected: pairs[0]
+            )
+        }
+        await Task.yield()
+
+        XCTAssertTrue(TranslationPairPickerController.shared.isVisible)
+        TranslationPairPickerController.shared.confirmCurrentSelection()
+        let selectedPair = await selection.value
+        XCTAssertEqual(selectedPair, pairs[0])
+    }
+}


### PR DESCRIPTION
## Root cause

PR #53 was merged into perf/transcript-lag-fixes 20 seconds after that base branch had already merged to main, so the picker implementation never reached main or a release.

The menu processing-mode selector also read directly from UserDefaults without reactive SwiftUI state, so switching Local to Cloud persisted but stayed visually stale.

## Fix

- restore the existing translation pair picker on main
- show it before translation recording when multiple pairs are configured
- keep translation push-to-talk immediate
- make the menu processing-mode selection update immediately and persist both providers
- add regression coverage for the picker and menu provider selection

## Verification

- picker regression test: 1 passed
- processing-mode regression test: red before fix, green after fix
- SettingsStorageProviderTests: 21/21 passed
- full XCTest before the menu follow-up: 82/83 passed, 5 skipped; one unrelated RealtimeTokenCoalescer timing test passed immediately in isolation
- Swift Testing: 53/53 passed
- DEV build installed and launched from /Applications/Diduny DEV.app
- CI check and CodeRabbit: passed
- two review passes clean: correctness and scope/simplicity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a language-pair picker for translation, supporting mouse selection and keyboard shortcuts.
  * Repeated translation hotkey presses can confirm the currently highlighted language pair.
  * Added a floating picker panel with clear selection, confirmation, and cancellation controls.
  * Improved processing mode selection between cloud and local options.

* **Bug Fixes**
  * Canceling language-pair selection no longer starts translation unexpectedly.

* **Tests**
  * Added coverage for language-pair selection and processing mode settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->