### PR TITLE
feat: add recording batches and inspector workflows

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,46 @@ The language used for bringing recorded media into Diduny and producing reusable
 
 ## Language
 
+**Transcription Batch**:
+A persisted snapshot of one grouped transcription run. Items may be added while the run is processing, but normal membership editing ends when processing finishes. Its name and description remain editable. Deleting a recording is an explicit exception that removes its membership and updates the batch.
+_Avoid_: Project, folder, permanent collection
+
+**Batch Member**:
+A reference to any recording included in a transcription batch, including Voice, Meeting, File, YouTube, or a recording with a translation. The same recording may belong to multiple batches without being moved or copied. A batch may combine existing Library recordings with newly supplied files and URLs. Adding an existing completed recording reuses its transcript artifacts without transcribing it again; reprocessing requires an explicit Transcribe Again request.
+_Avoid_: Copied recording, moved recording, automatic retranscription
+
+**Batch Processing Status**:
+A batch-level status derived from its members rather than edited by the user. It is Processing while work remains, Completed when every member succeeds, and Completed with Issues when processing finishes with at least one failed or partial result.
+_Avoid_: Manual project status, progress percentage
+
+**Processing Checkpoint**:
+The latest durable successful result in a recording's multi-step workflow. Retrying resumes at the failed step and reuses valid earlier results, such as remote metadata, source captions, acquired audio, or prepared audio. Intermediate files are retained until the item succeeds or its batch is deleted.
+_Avoid_: Restart batch, repeat all steps
+
+**Batch Deletion**:
+A destructive operation that deletes the transcription batch and every recording referenced by it. Recordings shared with other batches are removed from those batches as part of the same operation. The user sees an explicit confirmation with the affected recording count before deletion.
+_Avoid_: Delete grouping only, preserve shared recordings
+
+**Recording Deletion**:
+Removal of a recording from the Library and every batch that references it. Completed batches update their membership and counts after the recording is deleted.
+_Avoid_: Batch tombstone, immutable deleted member
+
+**Batch Transcript Export**:
+A Markdown document produced by Copy All Transcripts. Each batch member has a heading with its recording name and source type followed by its transcript; members without a completed transcript retain a labeled status placeholder.
+_Avoid_: Unlabeled text concatenation, format picker
+
+**Batch Creation Date**:
+The immutable date and time when a transcription batch is created. Batch lists sort by this value with the newest batch first.
+_Avoid_: Last updated date, last activity
+
+**Default Batch Name**:
+An editable generated name containing the batch creation date and time, used when the user does not provide a name.
+_Avoid_: Required name, first recording name
+
+**Translation Artifact**:
+Translated text attached to a recording. It is searchable and filterable as Has Translation but is not a separate recording type in the target Library model.
+_Avoid_: Translation recording, translated source
+
 **Remote Media Source**:
 A media item identified by a URL rather than a file already available on the user's Mac.
 _Avoid_: URL file, web video

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		23C6396709CDCA776807C023 /* LiveDictationOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0020FC49058C60D9F2F8B4 /* LiveDictationOverlayView.swift */; };
 		247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */; };
 		247C7BD6AD352D40A40CCFD0 /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = B431F17EA826367ED3C4D989 /* DynamicNotchKit */; };
+		25EDCFE17C039B0D2ED31505 /* TranscriptionBatchStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DDE5421515DDFE13E751C6 /* TranscriptionBatchStorageTests.swift */; };
 		282F528D9F0D4B11455FFA3A /* AppDelegate+FileTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */; };
 		2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */; };
 		2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583D24D80FE19BB49505E371 /* TextTranslationWindowController.swift */; };
@@ -103,6 +104,7 @@
 		B62B0933F7CA028942582A14 /* SleepFlushCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A8CC23A7C474D5EFDFBAC1 /* SleepFlushCoordinator.swift */; };
 		BB39149383C71119B82FE3AD /* TranscriptCleanupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEA00E234538355F573DD94 /* TranscriptCleanupService.swift */; };
 		BBADC47A055725DC6323CDF5 /* InProgressRecordingManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94036B3B62E2E2464BB3750 /* InProgressRecordingManifest.swift */; };
+		BD02DFD78A33EC5DCD611727 /* TranscriptionBatchStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77238C47B6DDEAC2B07A129E /* TranscriptionBatchStorage.swift */; };
 		BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 22385D60DC75174064B0DF0F /* ObjCExceptionCatcher.m */; };
 		BF50A7600E9D175A63D987E7 /* AuthServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90DC34399C728FB2BD9C292 /* AuthServiceTests.swift */; };
 		C24B6F611448AF8CAD8E3DB9 /* MeetingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA64DC6EAB5D1FB38CF7F517 /* MeetingSettingsView.swift */; };
@@ -175,6 +177,7 @@
 		1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTokenCoalescer.swift; sourceTree = "<group>"; };
 		12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManagerTests.swift; sourceTree = "<group>"; };
 		158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTranscription.swift; sourceTree = "<group>"; };
+		17DDE5421515DDFE13E751C6 /* TranscriptionBatchStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionBatchStorageTests.swift; sourceTree = "<group>"; };
 		18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingRecording.swift"; sourceTree = "<group>"; };
 		1967633DAD0607B3B2756CC8 /* OnboardingContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerView.swift; sourceTree = "<group>"; };
 		1999FC4728C79F46A514A1E4 /* AppDelegate+MeetingTranslationRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingTranslationRecording.swift"; sourceTree = "<group>"; };
@@ -239,6 +242,7 @@
 		7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedLexiconServiceTests.swift; sourceTree = "<group>"; };
 		741C4E6B6495E48C5D14392E /* AudioCompressionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCompressionService.swift; sourceTree = "<group>"; };
 		741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingDetailView.swift; sourceTree = "<group>"; };
+		77238C47B6DDEAC2B07A129E /* TranscriptionBatchStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionBatchStorage.swift; sourceTree = "<group>"; };
 		78ADA0228DC80DA0ACD8CE17 /* JobModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobModels.swift; sourceTree = "<group>"; };
 		792A94C41C191C4A22150F2F /* DeviceLevelMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLevelMonitor.swift; sourceTree = "<group>"; };
 		7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Hotkeys.swift"; sourceTree = "<group>"; };
@@ -572,6 +576,7 @@
 				865E86F8079EAE7A9BFB178E /* RecordingsLibraryStorage.swift */,
 				E2133D27EF1A261954A78BEB /* RecoveryStateManager.swift */,
 				F91E893AF3E6C20B492D3CB7 /* SettingsStorage.swift */,
+				77238C47B6DDEAC2B07A129E /* TranscriptionBatchStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -672,6 +677,7 @@
 				C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */,
 				DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */,
 				650D5A1F7778A1C35AD2F515 /* TranslationPairPickerControllerTests.swift */,
+				17DDE5421515DDFE13E751C6 /* TranscriptionBatchStorageTests.swift */,
 				D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */,
 			);
 			path = DidunyTests;
@@ -946,6 +952,7 @@
 				247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */,
 				2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */,
 				BB39149383C71119B82FE3AD /* TranscriptCleanupService.swift in Sources */,
+				BD02DFD78A33EC5DCD611727 /* TranscriptionBatchStorage.swift in Sources */,
 				F293480FBFF36536227A5878 /* TranscriptionProvider.swift in Sources */,
 				50CD068CB639D75D27C09787 /* TranscriptionWindowController.swift in Sources */,
 				1781B9D8B99C71B7C5260D8A /* TranslationPairPickerController.swift in Sources */,
@@ -988,6 +995,7 @@
 				CF97708F72740E5C035B3479 /* SleepFlushCoordinatorTests.swift in Sources */,
 				D9A94E2B88149920B8BA2B9E /* TranscriptCleanupServiceTests.swift in Sources */,
 				D08BBB9F8D641C3D4ADAD992 /* TranslationPairPickerControllerTests.swift in Sources */,
+				25EDCFE17C039B0D2ED31505 /* TranscriptionBatchStorageTests.swift in Sources */,
 				FFBC1497C42CFFB50037E3EA /* TypingSpeedMeasurementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		C4779B88D927AD824F1A9C3B /* ShareableContentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C5A3AF31756F85C9143656 /* ShareableContentCache.swift */; };
 		C5FA530A98A4A76DD9DEA952 /* AppDelegate+MeetingRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */; };
 		C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */; };
+		C10000000000000000000001 /* TranscriptionBatchesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000000000000000000002 /* TranscriptionBatchesView.swift */; };
 		C8BEA1A38683AA8F1AA4D84E /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1A1D461E4C3229A9A8A486 /* AudioDeviceManager.swift */; };
 		C8F29AF8B551E388C4C6F2A0 /* AudioConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F0D303A220D46E8D6F7A57 /* AudioConverter.swift */; };
 		CAA3AF319715F9DD611CCC8B /* PermissionsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C8A25D3FCD6DE742A1274E /* PermissionsSettingsView.swift */; };
@@ -285,6 +286,7 @@
 		C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapeCancelServiceTests.swift; sourceTree = "<group>"; };
 		C737BE018A4A18E4479FAD1F /* LiveDictationOverlayStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveDictationOverlayStore.swift; sourceTree = "<group>"; };
 		C84CF4471CC20033174713CB /* SleepFlushCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepFlushCoordinatorTests.swift; sourceTree = "<group>"; };
+		C10000000000000000000002 /* TranscriptionBatchesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionBatchesView.swift; sourceTree = "<group>"; };
 		CB03AFCF7D534F613B88F580 /* AsyncTranscriptionJobFileUploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTranscriptionJobFileUploadTests.swift; sourceTree = "<group>"; };
 		CC7B8E01BE6E59078F7581EF /* MultipartFormDataFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataFileTests.swift; sourceTree = "<group>"; };
 		D1B0622318D71BD3A1EEA701 /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 			children = (
 				808FCBFBB94E4D0B49112534 /* BatchTranscriptionProgressViews.swift */,
 				E5D043E23A4D9D4F86317120 /* BatchTranscriptionWindowController.swift */,
+				C10000000000000000000002 /* TranscriptionBatchesView.swift */,
 				54C08AEA7B3D9495385E0990 /* LiveTranscriptView.swift */,
 				8E688172624B1B937A789D9E /* TranscriptionWindowController.swift */,
 			);
@@ -951,6 +954,7 @@
 				8E61D4628397B11E5BCEE03D /* SystemAudioCaptureService.swift in Sources */,
 				247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */,
 				2C3DFECDC8802F2F4EFACC66 /* TextTranslationWindowController.swift in Sources */,
+				C10000000000000000000001 /* TranscriptionBatchesView.swift in Sources */,
 				BB39149383C71119B82FE3AD /* TranscriptCleanupService.swift in Sources */,
 				BD02DFD78A33EC5DCD611727 /* TranscriptionBatchStorage.swift in Sources */,
 				F293480FBFF36536227A5878 /* TranscriptionProvider.swift in Sources */,

--- a/Diduny/App/AppDelegate+FileTranscription.swift
+++ b/Diduny/App/AppDelegate+FileTranscription.swift
@@ -3,15 +3,8 @@ import Foundation
 // MARK: - File Transcription
 
 extension AppDelegate {
-    func transcribeFiles() {
-        if FileTranscriptionBatchService.shared.isProcessing {
-            BatchTranscriptionWindowController.shared.showWindow()
-        } else {
-            BatchTranscriptionWindowController.shared.selectFilesForNewBatch()
-        }
-    }
-
-    func transcribeURL() {
-        BatchTranscriptionWindowController.shared.selectYouTubeURLsForNewBatch()
+    func batchFilesAndURLs() {
+        MainWindowController.shared.requestBatchComposer()
+        MainWindowController.shared.showWindow()
     }
 }

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -596,9 +596,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await stopMeetingTranslationRecording()
             return
         }
+        if appState.meetingTranslationRecordingState == .processing,
+           appState.meetingTranslationRecordingStartTime == nil {
+            await cancelMeetingTranslationRecording()
+            return
+        }
 
         if appState.meetingRecordingState == .recording {
             await stopMeetingRecording()
+            return
+        }
+        if appState.meetingRecordingState == .processing,
+           appState.meetingRecordingStartTime == nil {
+            await cancelMeetingRecording()
             return
         }
 
@@ -606,9 +616,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             await stopTranslationRecording()
             return
         }
+        if appState.translationRecordingState == .processing,
+           appState.translationRecordingStartTime == nil {
+            await cancelTranslationRecording()
+            return
+        }
 
         if appState.recordingState == .recording {
             await stopRecording()
+            return
+        }
+        if appState.recordingState == .processing,
+           appState.recordingStartTime == nil {
+            await cancelRecording()
             return
         }
 

--- a/Diduny/App/DidunyApp.swift
+++ b/Diduny/App/DidunyApp.swift
@@ -12,8 +12,7 @@ struct DidunyApp: App {
                 onToggleTranslationRecording: { appDelegate.toggleTranslationRecording() },
                 onToggleMeetingRecording: { appDelegate.toggleMeetingRecording() },
                 onToggleMeetingTranslationRecording: { appDelegate.toggleMeetingTranslationRecording() },
-                onTranscribeFiles: { appDelegate.transcribeFiles() },
-                onTranscribeURL: { appDelegate.transcribeURL() },
+                onBatchFilesAndURLs: { appDelegate.batchFilesAndURLs() },
                 onOpenMainWindow: { section in appDelegate.openMainWindow(section: section) },
                 onCheckForUpdates: { appDelegate.updaterManager.checkForUpdates() }
             )
@@ -25,10 +24,10 @@ struct DidunyApp: App {
         .menuBarExtraStyle(.menu)
         .commands {
             CommandGroup(after: .newItem) {
-                Button("Transcribe URL…") {
-                    appDelegate.transcribeURL()
+                Button(MainWindowController.batchComposerActionTitle) {
+                    appDelegate.batchFilesAndURLs()
                 }
-                .keyboardShortcut("u", modifiers: [.command, .shift])
+                .keyboardShortcut("b", modifiers: [.command, .shift])
             }
         }
     }

--- a/Diduny/Core/Models/Recording.swift
+++ b/Diduny/Core/Models/Recording.swift
@@ -48,6 +48,49 @@ struct TimedTranscriptSegment: Codable, Equatable {
     }
 }
 
+struct TranscriptVersion: Identifiable, Codable, Equatable {
+    enum Kind: String, Codable {
+        case cloud
+        case local
+        case translation
+    }
+
+    let id: UUID
+    let createdAt: Date
+    let kind: Kind
+    let provider: String?
+    let modelIdentifier: String?
+    let sourceLanguageCode: String?
+    let targetLanguageCode: String?
+    let text: String
+    let segments: [TimedTranscriptSegment]?
+    let provenance: GeneratedTranscriptProvenance?
+
+    init(
+        id: UUID = UUID(),
+        createdAt: Date = Date(),
+        kind: Kind,
+        provider: String? = nil,
+        modelIdentifier: String? = nil,
+        sourceLanguageCode: String? = nil,
+        targetLanguageCode: String? = nil,
+        text: String,
+        segments: [TimedTranscriptSegment]? = nil,
+        provenance: GeneratedTranscriptProvenance? = nil
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.kind = kind
+        self.provider = provider
+        self.modelIdentifier = modelIdentifier
+        self.sourceLanguageCode = sourceLanguageCode
+        self.targetLanguageCode = targetLanguageCode
+        self.text = text
+        self.segments = segments
+        self.provenance = provenance
+    }
+}
+
 struct Recording: Identifiable, Codable, Equatable {
     let id: UUID
     let createdAt: Date
@@ -83,6 +126,9 @@ struct Recording: Identifiable, Codable, Equatable {
     /// Phrase-level timestamps from the generated transcript provider.
     /// Optional so recordings created by older releases remain decodable.
     var transcriptSegments: [TimedTranscriptSegment]?
+    var title: String? = nil
+    var description: String? = nil
+    var transcriptHistory: [TranscriptVersion]? = nil
 
     var isYouTubeVideo: Bool {
         remoteSource?.provider == YouTubeRemoteMediaSource.provider
@@ -98,6 +144,40 @@ struct Recording: Identifiable, Codable, Equatable {
 
     var libraryBrandColor: Color {
         isYouTubeVideo ? .red : type.brandColor
+    }
+
+    var displayTitle: String {
+        if let title = title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+            return title
+        }
+        return remoteSource?.title ?? sourceFileName ?? libraryDisplayName
+    }
+
+    var resolvedTranscriptHistory: [TranscriptVersion] {
+        if let transcriptHistory, !transcriptHistory.isEmpty {
+            return transcriptHistory
+        }
+        guard let transcriptionText, !transcriptionText.isEmpty else { return [] }
+        let provider = generatedTranscriptProvenance?.provider
+        let kind: TranscriptVersion.Kind = if status == .translated || translationTargetLanguageCode != nil {
+            .translation
+        } else if provider?.localizedCaseInsensitiveContains("local") == true
+            || provider?.localizedCaseInsensitiveContains("whisper") == true
+        {
+            .local
+        } else {
+            .cloud
+        }
+        return [TranscriptVersion(
+            id: id,
+            createdAt: processedAt ?? createdAt,
+            kind: kind,
+            provider: provider,
+            targetLanguageCode: translationTargetLanguageCode,
+            text: transcriptionText,
+            segments: transcriptSegments,
+            provenance: generatedTranscriptProvenance
+        )]
     }
 
     var displayTranscriptText: String? {

--- a/Diduny/Core/Services/AsyncTranscriptionJobService.swift
+++ b/Diduny/Core/Services/AsyncTranscriptionJobService.swift
@@ -337,6 +337,7 @@ final class AsyncTranscriptionJobService {
         config: [String: Any],
         source: String? = nil,
         sourceDurationSeconds: TimeInterval? = nil,
+        onSubmitted: ((String) -> Void)? = nil,
         onProgressUpdate: @escaping (JobProgressUpdate) -> Void
     ) async throws -> GeneratedTranscript {
         try Task.checkCancellation()
@@ -347,9 +348,22 @@ final class AsyncTranscriptionJobService {
             source: source,
             sourceDurationSeconds: sourceDurationSeconds
         )
+        onSubmitted?(submission.jobId)
         return try await waitForResult(
             submission: submission,
             preferSpeakerDiarization: preferSpeakerDiarization,
+            onProgressUpdate: onProgressUpdate
+        )
+    }
+
+    func resumeFileDetailed(
+        jobID: String,
+        config: [String: Any],
+        onProgressUpdate: @escaping (JobProgressUpdate) -> Void
+    ) async throws -> GeneratedTranscript {
+        try await waitForResult(
+            submission: JobSubmission(jobId: jobID, status: "processing", createdAt: ""),
+            preferSpeakerDiarization: shouldPreferSpeakerDiarization(config: config),
             onProgressUpdate: onProgressUpdate
         )
     }

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -1536,7 +1536,9 @@ private final class LiveFileTranscriptionBatchRecordingStore: FileTranscriptionB
             status: .transcribed,
             text: transcript.text,
             segments: transcript.segments.isEmpty ? nil : transcript.segments,
-            generatedTranscriptProvenance: provenance
+            generatedTranscriptProvenance: provenance,
+            kind: .cloud,
+            provider: provenance?.provider ?? "cloud"
         )
     }
 

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -397,16 +397,13 @@ final class FileTranscriptionBatchService {
         description: String,
         existingRecordingIDs: [UUID]
     ) {
-        guard !urls.isEmpty || !existingRecordingIDs.isEmpty else { return }
-        resetFinishedBatchIfNeeded()
-        guard createPersistentBatch(
+        beginBatch(
+            urls: urls,
+            remoteSources: [],
             name: name,
             description: description,
             existingRecordingIDs: existingRecordingIDs
-        ) else { return }
-        add(urls: urls)
-        startIfNeeded()
-        finalizePersistentBatchIfFinished()
+        )
     }
 
     func beginBatch(remoteSources: [YouTubeRemoteMediaSource]) {
@@ -424,13 +421,32 @@ final class FileTranscriptionBatchService {
         description: String,
         existingRecordingIDs: [UUID]
     ) {
-        guard !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else { return }
+        beginBatch(
+            urls: [],
+            remoteSources: remoteSources,
+            name: name,
+            description: description,
+            existingRecordingIDs: existingRecordingIDs
+        )
+    }
+
+    func beginBatch(
+        urls: [URL],
+        remoteSources: [YouTubeRemoteMediaSource],
+        name: String,
+        description: String,
+        existingRecordingIDs: [UUID]
+    ) {
+        guard !urls.isEmpty || !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else {
+            return
+        }
         resetFinishedBatchIfNeeded()
         guard createPersistentBatch(
             name: name,
             description: description,
             existingRecordingIDs: existingRecordingIDs
         ) else { return }
+        add(urls: urls)
         add(remoteSources: remoteSources)
         startIfNeeded()
         finalizePersistentBatchIfFinished()

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -397,16 +397,18 @@ final class FileTranscriptionBatchService {
         self.playCompletionSound = playCompletionSound
     }
 
-    func beginBatch(urls: [URL]) {
+    @discardableResult
+    func beginBatch(urls: [URL]) -> Bool {
         beginBatch(urls: urls, name: "", description: "", existingRecordingIDs: [])
     }
 
+    @discardableResult
     func beginBatch(
         urls: [URL],
         name: String,
         description: String,
         existingRecordingIDs: [UUID]
-    ) {
+    ) -> Bool {
         beginBatch(
             urls: urls,
             remoteSources: [],
@@ -416,7 +418,8 @@ final class FileTranscriptionBatchService {
         )
     }
 
-    func beginBatch(remoteSources: [YouTubeRemoteMediaSource]) {
+    @discardableResult
+    func beginBatch(remoteSources: [YouTubeRemoteMediaSource]) -> Bool {
         beginBatch(
             remoteSources: remoteSources,
             name: "",
@@ -425,12 +428,13 @@ final class FileTranscriptionBatchService {
         )
     }
 
+    @discardableResult
     func beginBatch(
         remoteSources: [YouTubeRemoteMediaSource],
         name: String,
         description: String,
         existingRecordingIDs: [UUID]
-    ) {
+    ) -> Bool {
         beginBatch(
             urls: [],
             remoteSources: remoteSources,
@@ -440,28 +444,30 @@ final class FileTranscriptionBatchService {
         )
     }
 
+    @discardableResult
     func beginBatch(
         urls: [URL],
         remoteSources: [YouTubeRemoteMediaSource],
         name: String,
         description: String,
         existingRecordingIDs: [UUID]
-    ) {
-        guard !isProcessing else { return }
+    ) -> Bool {
+        guard !isProcessing else { return false }
         guard !urls.isEmpty || !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else {
-            return
+            return false
         }
         resetFinishedBatchIfNeeded()
-        guard currentBatchID == nil else { return }
+        guard currentBatchID == nil else { return false }
         guard createPersistentBatch(
             name: name,
             description: description,
             existingRecordingIDs: existingRecordingIDs
-        ) else { return }
+        ) else { return false }
         add(urls: urls)
         add(remoteSources: remoteSources)
         startIfNeeded()
         finalizePersistentBatchIfFinished()
+        return true
     }
 
     func resume(batch: TranscriptionBatch) {

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -447,6 +447,7 @@ final class FileTranscriptionBatchService {
         description: String,
         existingRecordingIDs: [UUID]
     ) {
+        guard !isProcessing else { return }
         guard !urls.isEmpty || !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else {
             return
         }
@@ -485,7 +486,10 @@ final class FileTranscriptionBatchService {
     }
 
     func add(urls: [URL]) {
-        guard batchPersistence == nil || currentBatchID != nil else { return }
+        if batchPersistence != nil, currentBatchID == nil {
+            beginBatch(urls: urls)
+            return
+        }
         let existingURLs = Set(items.map(\.sourceURL.standardizedFileURL))
         var addedURLs = Set<URL>()
         let initialItemCount = items.count
@@ -516,7 +520,10 @@ final class FileTranscriptionBatchService {
     }
 
     func add(remoteSources: [YouTubeRemoteMediaSource]) {
-        guard batchPersistence == nil || currentBatchID != nil else { return }
+        if batchPersistence != nil, currentBatchID == nil {
+            beginBatch(remoteSources: remoteSources)
+            return
+        }
         let existingIDs = Set(items.compactMap { $0.remoteSource?.mediaID })
         var addedIDs = Set<String>()
         let initialItemCount = items.count

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -73,7 +73,7 @@ struct FileTranscriptionSettingsSnapshot {
     }
 }
 
-struct ImportedMediaIdentity: Equatable {
+struct ImportedMediaIdentity: Codable, Equatable {
     let fileName: String
     let fileSizeBytes: Int64?
 
@@ -84,14 +84,14 @@ struct ImportedMediaIdentity: Equatable {
     }
 }
 
-struct BatchTranscriptionItem: Identifiable, Equatable {
-    enum RemoteArtifactWork: Equatable {
+struct BatchTranscriptionItem: Codable, Identifiable, Equatable {
+    enum RemoteArtifactWork: Codable, Equatable {
         case all
         case captionsOnly
         case transcriptOnly
     }
 
-    enum Status: Equatable {
+    enum Status: Codable, Equatable {
         case queued
         case checkingLink
         case checkingDuplicate
@@ -264,6 +264,8 @@ protocol FileTranscriptionBatchPersisting: AnyObject {
     func createBatch(name: String, description: String, recordingIDs: [UUID]) throws -> UUID
     func addRecordingIDs(_ recordingIDs: [UUID], to batchID: UUID) throws
     func replaceRecordingIDs(_ recordingIDs: [UUID], in batchID: UUID) throws
+    func replaceWorkItems(_ items: [BatchTranscriptionItem], in batchID: UUID) throws
+    func reopenBatch(_ batchID: UUID) throws
     func closeBatch(_ batchID: UUID) throws
 }
 
@@ -278,6 +280,10 @@ extension TranscriptionBatchStorage: FileTranscriptionBatchPersisting {
 
     func closeBatch(_ batchID: UUID) throws {
         try close(batchID: batchID)
+    }
+
+    func reopenBatch(_ batchID: UUID) throws {
+        try reopen(batchID: batchID)
     }
 }
 
@@ -452,6 +458,28 @@ final class FileTranscriptionBatchService {
         finalizePersistentBatchIfFinished()
     }
 
+    func resume(batch: TranscriptionBatch) {
+        guard !isProcessing, let persistedItems = batch.workItems, !persistedItems.isEmpty else {
+            return
+        }
+        do {
+            try batchPersistence?.reopenBatch(batch.id)
+        } catch {
+            batchError = "Could not reopen the transcription batch."
+            return
+        }
+        currentBatchID = batch.id
+        initialRecordingIDs = batch.recordingIDs
+        items = persistedItems.map { item in
+            var item = item
+            if !item.status.isTerminal || item.status == .authorizationPaused {
+                item.status = .failed
+            }
+            return item
+        }
+        retry(ids: Set(items.filter { $0.status != .completed && $0.status != .duplicate }.map(\.id)))
+    }
+
     func add(urls: [URL]) {
         let existingURLs = Set(items.map(\.sourceURL.standardizedFileURL))
         var addedURLs = Set<URL>()
@@ -477,6 +505,7 @@ final class FileTranscriptionBatchService {
         }
 
         if items.count > initialItemCount {
+            persistWorkItems()
             wakeScheduler()
         }
     }
@@ -503,6 +532,7 @@ final class FileTranscriptionBatchService {
         }
 
         if items.count > initialItemCount {
+            persistWorkItems()
             wakeScheduler()
         }
     }
@@ -541,6 +571,7 @@ final class FileTranscriptionBatchService {
         guard let batchPersistence, let currentBatchID else { return }
         do {
             try batchPersistence.addRecordingIDs([recordingID], to: currentBatchID)
+            try batchPersistence.replaceWorkItems(items, in: currentBatchID)
         } catch {
             batchError = "Could not save the transcription batch."
         }
@@ -553,6 +584,7 @@ final class FileTranscriptionBatchService {
               let currentBatchID
         else { return }
         do {
+            try batchPersistence.replaceWorkItems(items, in: currentBatchID)
             try batchPersistence.replaceRecordingIDs(
                 initialRecordingIDs + items.compactMap(\.recordingID),
                 in: currentBatchID
@@ -924,7 +956,9 @@ final class FileTranscriptionBatchService {
                 }
 
                 let acquisition = try await withRemoteAcquisitionPermit {
-                    if items[initialIndex].remoteArtifactWork != .transcriptOnly {
+                    if items[initialIndex].remoteArtifactWork != .transcriptOnly,
+                       items[initialIndex].sourceCaptionArtifacts.isEmpty
+                    {
                         update(itemID) { $0.status = .retrievingCaptions }
                         do {
                             if let caption = try await remoteExtractor.retrieveCaption(
@@ -1282,7 +1316,20 @@ final class FileTranscriptionBatchService {
         _ mutation: (inout BatchTranscriptionItem) -> Void
     ) {
         guard let index = index(of: itemID) else { return }
+        let oldStatus = items[index].status
         mutation(&items[index])
+        if items[index].status != oldStatus {
+            persistWorkItems()
+        }
+    }
+
+    private func persistWorkItems() {
+        guard let batchPersistence, let currentBatchID else { return }
+        do {
+            try batchPersistence.replaceWorkItems(items, in: currentBatchID)
+        } catch {
+            batchError = "Could not save the transcription batch."
+        }
     }
 }
 

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -452,6 +452,7 @@ final class FileTranscriptionBatchService {
             return
         }
         resetFinishedBatchIfNeeded()
+        guard currentBatchID == nil else { return }
         guard createPersistentBatch(
             name: name,
             description: description,

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -1185,7 +1185,7 @@ final class FileTranscriptionBatchService {
                 recordingStore.markCompleted(
                     recordingID: recordingID,
                     transcript: transcript,
-                    provenance: nil
+                    provenance: GeneratedTranscriptProvenance(provider: settings.provider.rawValue)
                 )
             }
             update(itemID) {
@@ -1531,14 +1531,15 @@ private final class LiveFileTranscriptionBatchRecordingStore: FileTranscriptionB
         transcript: GeneratedTranscript,
         provenance: GeneratedTranscriptProvenance?
     ) {
+        let provider = provenance?.provider ?? TranscriptionProvider.cloud.rawValue
         storage.completeTranscription(
             id: recordingID,
             status: .transcribed,
             text: transcript.text,
             segments: transcript.segments.isEmpty ? nil : transcript.segments,
             generatedTranscriptProvenance: provenance,
-            kind: .cloud,
-            provider: provenance?.provider ?? "cloud"
+            kind: provider == TranscriptionProvider.local.rawValue ? .local : .cloud,
+            provider: provider
         )
     }
 

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -465,7 +465,7 @@ final class FileTranscriptionBatchService {
     }
 
     func resume(batch: TranscriptionBatch) {
-        guard !isProcessing, let persistedItems = batch.workItems, !persistedItems.isEmpty else {
+        guard canResume(batch: batch), let persistedItems = batch.workItems else {
             return
         }
         do {
@@ -484,6 +484,12 @@ final class FileTranscriptionBatchService {
             return item
         }
         retry(ids: Set(items.filter { $0.status != .completed && $0.status != .duplicate }.map(\.id)))
+    }
+
+    func canResume(batch: TranscriptionBatch) -> Bool {
+        !isProcessing
+            && (currentBatchID == nil || currentBatchID == batch.id)
+            && !(batch.workItems?.isEmpty ?? true)
     }
 
     func add(urls: [URL]) {

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -259,6 +259,28 @@ extension FileTranscriptionBatchRecordingStoring {
     }
 }
 
+@MainActor
+protocol FileTranscriptionBatchPersisting: AnyObject {
+    func createBatch(name: String, description: String, recordingIDs: [UUID]) throws -> UUID
+    func addRecordingIDs(_ recordingIDs: [UUID], to batchID: UUID) throws
+    func replaceRecordingIDs(_ recordingIDs: [UUID], in batchID: UUID) throws
+    func closeBatch(_ batchID: UUID) throws
+}
+
+extension TranscriptionBatchStorage: FileTranscriptionBatchPersisting {
+    func createBatch(name: String, description: String, recordingIDs: [UUID]) throws -> UUID {
+        try create(
+            name: name,
+            description: description,
+            recordingIDs: recordingIDs
+        ).id
+    }
+
+    func closeBatch(_ batchID: UUID) throws {
+        try close(batchID: batchID)
+    }
+}
+
 @Observable
 @MainActor
 final class FileTranscriptionBatchService {
@@ -273,6 +295,7 @@ final class FileTranscriptionBatchService {
             guard let id = SettingsStorage.shared.selectedChromeProfileID else { return nil }
             return ChromeProfileStore.discover().first(where: { $0.id == id })
         },
+        batchPersistence: TranscriptionBatchStorage.shared,
         settingsSnapshot: { .current() },
         playCompletionSound: {
             guard SettingsStorage.shared.playSoundOnCompletion else { return }
@@ -325,12 +348,15 @@ final class FileTranscriptionBatchService {
     private let preparer: FileTranscriptionBatchPreparing
     private let transcriber: FileTranscriptionBatchTranscribing
     private let recordingStore: FileTranscriptionBatchRecordingStoring
+    private let batchPersistence: FileTranscriptionBatchPersisting?
     private let remoteExtractor: RemoteMediaExtracting?
     private let chromeProfile: @MainActor () -> ChromeProfile?
     private let settingsSnapshot: @MainActor () -> FileTranscriptionSettingsSnapshot
     private let playCompletionSound: @MainActor () -> Void
 
     private var processingTask: Task<Void, Never>?
+    private var currentBatchID: UUID?
+    private var initialRecordingIDs: [UUID] = []
     private var activeSettingsSnapshot: FileTranscriptionSettingsSnapshot?
     private var hasPlayedCompletionSound = false
     private var schedulerContinuation: CheckedContinuation<Void, Never>?
@@ -347,12 +373,14 @@ final class FileTranscriptionBatchService {
         recordingStore: FileTranscriptionBatchRecordingStoring,
         remoteExtractor: RemoteMediaExtracting? = nil,
         chromeProfile: @escaping @MainActor () -> ChromeProfile? = { nil },
+        batchPersistence: FileTranscriptionBatchPersisting? = nil,
         settingsSnapshot: @escaping @MainActor () -> FileTranscriptionSettingsSnapshot,
         playCompletionSound: @escaping @MainActor () -> Void
     ) {
         self.preparer = preparer
         self.transcriber = transcriber
         self.recordingStore = recordingStore
+        self.batchPersistence = batchPersistence
         self.remoteExtractor = remoteExtractor
         self.chromeProfile = chromeProfile
         self.settingsSnapshot = settingsSnapshot
@@ -360,15 +388,52 @@ final class FileTranscriptionBatchService {
     }
 
     func beginBatch(urls: [URL]) {
+        beginBatch(urls: urls, name: "", description: "", existingRecordingIDs: [])
+    }
+
+    func beginBatch(
+        urls: [URL],
+        name: String,
+        description: String,
+        existingRecordingIDs: [UUID]
+    ) {
+        guard !urls.isEmpty || !existingRecordingIDs.isEmpty else { return }
         resetFinishedBatchIfNeeded()
+        guard createPersistentBatch(
+            name: name,
+            description: description,
+            existingRecordingIDs: existingRecordingIDs
+        ) else { return }
         add(urls: urls)
         startIfNeeded()
+        finalizePersistentBatchIfFinished()
     }
 
     func beginBatch(remoteSources: [YouTubeRemoteMediaSource]) {
+        beginBatch(
+            remoteSources: remoteSources,
+            name: "",
+            description: "",
+            existingRecordingIDs: []
+        )
+    }
+
+    func beginBatch(
+        remoteSources: [YouTubeRemoteMediaSource],
+        name: String,
+        description: String,
+        existingRecordingIDs: [UUID]
+    ) {
+        guard !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else { return }
         resetFinishedBatchIfNeeded()
+        guard createPersistentBatch(
+            name: name,
+            description: description,
+            existingRecordingIDs: existingRecordingIDs
+        ) else { return }
         add(remoteSources: remoteSources)
         startIfNeeded()
+        finalizePersistentBatchIfFinished()
     }
 
     func add(urls: [URL]) {
@@ -390,6 +455,7 @@ final class FileTranscriptionBatchService {
                 item.durationSeconds = duplicate.durationSeconds
                 item.transcriptionText = duplicate.transcriptionText
                 item.recordingID = duplicate.recordingID
+                persistRecordingID(duplicate.recordingID)
             }
             items.append(item)
         }
@@ -415,6 +481,7 @@ final class FileTranscriptionBatchService {
                 mediaID: source.mediaID
             ), canReuse(duplicate: duplicate) {
                 apply(duplicate: duplicate, to: &item)
+                persistRecordingID(duplicate.recordingID)
             }
             items.append(item)
         }
@@ -429,6 +496,56 @@ final class FileTranscriptionBatchService {
             items.removeAll()
             activeSettingsSnapshot = nil
             hasPlayedCompletionSound = false
+            currentBatchID = nil
+            initialRecordingIDs = []
+        }
+    }
+
+    private func createPersistentBatch(
+        name: String,
+        description: String,
+        existingRecordingIDs: [UUID]
+    ) -> Bool {
+        initialRecordingIDs = existingRecordingIDs
+        guard let batchPersistence else { return true }
+        do {
+            currentBatchID = try batchPersistence.createBatch(
+                name: name,
+                description: description,
+                recordingIDs: existingRecordingIDs
+            )
+            return true
+        } catch {
+            batchError = "Could not create the transcription batch."
+            return false
+        }
+    }
+
+    private func persistRecordingID(_ recordingID: UUID) {
+        guard let batchPersistence, let currentBatchID else { return }
+        do {
+            try batchPersistence.addRecordingIDs([recordingID], to: currentBatchID)
+        } catch {
+            batchError = "Could not save the transcription batch."
+        }
+    }
+
+    private func finalizePersistentBatchIfFinished() {
+        guard !isProcessing,
+              items.allSatisfy(\.status.isTerminal),
+              let batchPersistence,
+              let currentBatchID
+        else { return }
+        do {
+            try batchPersistence.replaceRecordingIDs(
+                initialRecordingIDs + items.compactMap(\.recordingID),
+                in: currentBatchID
+            )
+            try batchPersistence.closeBatch(currentBatchID)
+            self.currentBatchID = nil
+            initialRecordingIDs = []
+        } catch {
+            batchError = "Could not finish saving the transcription batch."
         }
     }
 
@@ -540,6 +657,7 @@ final class FileTranscriptionBatchService {
             if !Task.isCancelled, items.contains(where: { $0.status == .queued }) {
                 startIfNeeded()
             }
+            finalizePersistentBatchIfFinished()
         }
         guard await preflightRemoteAuthorization() else { return }
 
@@ -785,6 +903,7 @@ final class FileTranscriptionBatchService {
                     durationSeconds: metadata.durationSeconds
                 ), canReuse(duplicate: duplicate) {
                     update(itemID) { apply(duplicate: duplicate, to: &$0) }
+                    persistRecordingID(duplicate.recordingID)
                     return
                 }
 
@@ -849,6 +968,7 @@ final class FileTranscriptionBatchService {
                 )
                 if let recordingID {
                     update(itemID) { $0.recordingID = recordingID }
+                    persistRecordingID(recordingID)
                     recordingStore.markProcessing(recordingID: recordingID)
                 }
             } else if let recordingID {
@@ -956,6 +1076,7 @@ final class FileTranscriptionBatchService {
                 )
                 if let recordingID {
                     update(itemID) { $0.recordingID = recordingID }
+                    persistRecordingID(recordingID)
                     recordingStore.markProcessing(recordingID: recordingID)
                 }
             }

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -1195,6 +1195,7 @@ final class FileTranscriptionBatchService {
             items[index].errorMessage = nil
             items[index].finishedAt = nil
         }
+        persistWorkItems()
         processingTask?.cancel()
         wakeScheduler()
     }

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -305,6 +305,9 @@ final class FileTranscriptionBatchService {
             guard let id = SettingsStorage.shared.selectedChromeProfileID else { return nil }
             return ChromeProfileStore.discover().first(where: { $0.id == id })
         },
+        remoteMediaAuthorized: {
+            SettingsStorage.shared.remoteMediaRightsAcknowledged
+        },
         batchPersistence: TranscriptionBatchStorage.shared,
         settingsSnapshot: { .current() },
         playCompletionSound: {
@@ -361,6 +364,7 @@ final class FileTranscriptionBatchService {
     private let batchPersistence: FileTranscriptionBatchPersisting?
     private let remoteExtractor: RemoteMediaExtracting?
     private let chromeProfile: @MainActor () -> ChromeProfile?
+    private let remoteMediaAuthorized: @MainActor () -> Bool
     private let settingsSnapshot: @MainActor () -> FileTranscriptionSettingsSnapshot
     private let playCompletionSound: @MainActor () -> Void
 
@@ -383,6 +387,7 @@ final class FileTranscriptionBatchService {
         recordingStore: FileTranscriptionBatchRecordingStoring,
         remoteExtractor: RemoteMediaExtracting? = nil,
         chromeProfile: @escaping @MainActor () -> ChromeProfile? = { nil },
+        remoteMediaAuthorized: @escaping @MainActor () -> Bool = { true },
         batchPersistence: FileTranscriptionBatchPersisting? = nil,
         settingsSnapshot: @escaping @MainActor () -> FileTranscriptionSettingsSnapshot,
         playCompletionSound: @escaping @MainActor () -> Void
@@ -393,6 +398,7 @@ final class FileTranscriptionBatchService {
         self.batchPersistence = batchPersistence
         self.remoteExtractor = remoteExtractor
         self.chromeProfile = chromeProfile
+        self.remoteMediaAuthorized = remoteMediaAuthorized
         self.settingsSnapshot = settingsSnapshot
         self.playCompletionSound = playCompletionSound
     }
@@ -463,6 +469,52 @@ final class FileTranscriptionBatchService {
             description: description,
             existingRecordingIDs: existingRecordingIDs
         ) else { return false }
+        add(urls: urls)
+        add(remoteSources: remoteSources)
+        startIfNeeded()
+        finalizePersistentBatchIfFinished()
+        return true
+    }
+
+    @discardableResult
+    func append(
+        to batch: TranscriptionBatch,
+        urls: [URL],
+        remoteSources: [YouTubeRemoteMediaSource],
+        existingRecordingIDs: [UUID]
+    ) -> Bool {
+        guard !isProcessing else { return false }
+        guard !urls.isEmpty || !remoteSources.isEmpty || !existingRecordingIDs.isEmpty else {
+            return false
+        }
+        if !remoteSources.isEmpty {
+            guard remoteMediaAuthorized() else {
+                batchError = "Confirm that you own this content or have permission to transcribe it."
+                return false
+            }
+            guard chromeProfile() != nil else {
+                batchError = "Select a Google Chrome profile to transcribe YouTube URLs."
+                return false
+            }
+        }
+        resetFinishedBatchIfNeeded()
+        guard currentBatchID == nil else { return false }
+
+        do {
+            try batchPersistence?.reopenBatch(batch.id)
+            try batchPersistence?.addRecordingIDs(existingRecordingIDs, to: batch.id)
+        } catch {
+            batchError = "Could not reopen the transcription batch."
+            return false
+        }
+
+        var seenRecordingIDs = Set<UUID>()
+        currentBatchID = batch.id
+        initialRecordingIDs = (batch.recordingIDs + existingRecordingIDs).filter {
+            seenRecordingIDs.insert($0).inserted
+        }
+        items = batch.workItems ?? []
+        batchError = nil
         add(urls: urls)
         add(remoteSources: remoteSources)
         startIfNeeded()

--- a/Diduny/Core/Services/FileTranscriptionBatchService.swift
+++ b/Diduny/Core/Services/FileTranscriptionBatchService.swift
@@ -134,6 +134,8 @@ struct BatchTranscriptionItem: Codable, Identifiable, Equatable {
     var sourceCaptionArtifacts: [TranscriptArtifact] = []
     var captionErrorMessage: String?
     var remoteArtifactWork: RemoteArtifactWork = .all
+    var downloadedAudioURL: URL?
+    var cloudJobID: String?
     var startedAt: Date?
     var finishedAt: Date?
 
@@ -198,6 +200,8 @@ protocol FileTranscriptionBatchTranscribing: AnyObject {
         settings: FileTranscriptionSettingsSnapshot,
         source: String,
         sourceDurationSeconds: TimeInterval?,
+        resumeJobID: String?,
+        onJobSubmitted: @escaping (String) -> Void,
         onUpdate: @escaping (JobProgressUpdate) -> Void
     ) async throws -> GeneratedTranscript
 }
@@ -481,6 +485,7 @@ final class FileTranscriptionBatchService {
     }
 
     func add(urls: [URL]) {
+        guard batchPersistence == nil || currentBatchID != nil else { return }
         let existingURLs = Set(items.map(\.sourceURL.standardizedFileURL))
         var addedURLs = Set<URL>()
         let initialItemCount = items.count
@@ -511,6 +516,7 @@ final class FileTranscriptionBatchService {
     }
 
     func add(remoteSources: [YouTubeRemoteMediaSource]) {
+        guard batchPersistence == nil || currentBatchID != nil else { return }
         let existingIDs = Set(items.compactMap { $0.remoteSource?.mediaID })
         var addedIDs = Set<String>()
         let initialItemCount = items.count
@@ -876,7 +882,11 @@ final class FileTranscriptionBatchService {
         var captionAttemptFailed = false
 
         defer {
-            downloadedAudio?.removeTemporaryFiles()
+            if recordingID != nil {
+                downloadedAudio?.removeTemporaryFiles()
+                update(itemID) { $0.downloadedAudioURL = nil }
+                persistWorkItems()
+            }
             temporaryAudio?.removeTemporaryFile()
         }
 
@@ -955,48 +965,61 @@ final class FileTranscriptionBatchService {
                     return
                 }
 
-                let acquisition = try await withRemoteAcquisitionPermit {
-                    if items[initialIndex].remoteArtifactWork != .transcriptOnly,
-                       items[initialIndex].sourceCaptionArtifacts.isEmpty
-                    {
-                        update(itemID) { $0.status = .retrievingCaptions }
-                        do {
-                            if let caption = try await remoteExtractor.retrieveCaption(
-                                for: source,
-                                metadata: metadata,
-                                profile: profile
-                            ) {
-                                update(itemID) { $0.sourceCaptionArtifacts = [caption] }
-                            }
-                        } catch RemoteMediaExtractorError.authorizationRequired {
-                            throw RemoteMediaExtractorError.authorizationRequired
-                        } catch {
-                            captionAttemptFailed = true
-                            update(itemID) {
-                                $0.captionErrorMessage = "Source captions could not be retrieved."
+                if let checkpointURL = items[initialIndex].downloadedAudioURL,
+                   FileManager.default.fileExists(atPath: checkpointURL.path)
+                {
+                    downloadedAudio = RemoteDownloadedAudio(
+                        fileURL: checkpointURL,
+                        temporaryDirectory: checkpointURL.deletingLastPathComponent()
+                    )
+                } else {
+                    let acquisition = try await withRemoteAcquisitionPermit {
+                        if items[initialIndex].remoteArtifactWork != .transcriptOnly,
+                           items[initialIndex].sourceCaptionArtifacts.isEmpty
+                        {
+                            update(itemID) { $0.status = .retrievingCaptions }
+                            do {
+                                if let caption = try await remoteExtractor.retrieveCaption(
+                                    for: source,
+                                    metadata: metadata,
+                                    profile: profile
+                                ) {
+                                    update(itemID) { $0.sourceCaptionArtifacts = [caption] }
+                                }
+                            } catch RemoteMediaExtractorError.authorizationRequired {
+                                throw RemoteMediaExtractorError.authorizationRequired
+                            } catch {
+                                captionAttemptFailed = true
+                                update(itemID) {
+                                    $0.captionErrorMessage = "Source captions could not be retrieved."
+                                }
                             }
                         }
-                    }
 
-                    update(itemID) {
-                        $0.status = .downloading
-                        $0.progressFraction = nil
-                    }
-                    return try await remoteExtractor.downloadAudio(
-                        for: source,
-                        metadata: metadata,
-                        profile: profile
-                    ) { [weak self] progress in
-                        Task { @MainActor in
-                            self?.update(itemID) {
-                                $0.downloadedBytes = progress.downloadedBytes
-                                $0.totalDownloadBytes = progress.totalBytes
-                                $0.progressFraction = progress.fractionCompleted
+                        update(itemID) {
+                            $0.status = .downloading
+                            $0.progressFraction = nil
+                        }
+                        return try await remoteExtractor.downloadAudio(
+                            for: source,
+                            metadata: metadata,
+                            profile: profile
+                        ) { [weak self] progress in
+                            Task { @MainActor in
+                                self?.update(itemID) {
+                                    $0.downloadedBytes = progress.downloadedBytes
+                                    $0.totalDownloadBytes = progress.totalBytes
+                                    $0.progressFraction = progress.fractionCompleted
+                                }
                             }
                         }
+                    }
+                    downloadedAudio = acquisition
+                    update(itemID) {
+                        $0.downloadedAudioURL = acquisition.fileURL
+                        $0.status = .preparing
                     }
                 }
-                downloadedAudio = acquisition
                 try Task.checkCancellation()
 
                 guard let downloadedAudio else {
@@ -1038,7 +1061,8 @@ final class FileTranscriptionBatchService {
                 audioFileURL: audioURL,
                 settings: settings,
                 source: item(withID: itemID)?.displayName ?? audioURL.lastPathComponent,
-                sourceDurationSeconds: item(withID: itemID)?.durationSeconds
+                sourceDurationSeconds: item(withID: itemID)?.durationSeconds,
+                itemID: itemID
             ) { [weak self] progressUpdate in
                 Task { @MainActor in
                     self?.apply(progressUpdate: progressUpdate, to: itemID)
@@ -1140,7 +1164,8 @@ final class FileTranscriptionBatchService {
                 audioFileURL: audioURL,
                 settings: settings,
                 source: item(withID: itemID)?.displayName ?? audioURL.lastPathComponent,
-                sourceDurationSeconds: item(withID: itemID)?.durationSeconds
+                sourceDurationSeconds: item(withID: itemID)?.durationSeconds,
+                itemID: itemID
             ) { [weak self] progressUpdate in
                 Task { @MainActor in
                     self?.apply(progressUpdate: progressUpdate, to: itemID)
@@ -1205,6 +1230,7 @@ final class FileTranscriptionBatchService {
         settings: FileTranscriptionSettingsSnapshot,
         source: String,
         sourceDurationSeconds: TimeInterval?,
+        itemID: UUID,
         onUpdate: @escaping (JobProgressUpdate) -> Void
     ) async throws -> GeneratedTranscript {
         let permits = settings.provider == .cloud
@@ -1218,6 +1244,11 @@ final class FileTranscriptionBatchService {
                 settings: settings,
                 source: source,
                 sourceDurationSeconds: sourceDurationSeconds,
+                resumeJobID: item(withID: itemID)?.cloudJobID,
+                onJobSubmitted: { [weak self] jobID in
+                    self?.update(itemID) { $0.cloudJobID = jobID }
+                    self?.persistWorkItems()
+                },
                 onUpdate: onUpdate
             )
             await permits.release()
@@ -1355,6 +1386,8 @@ private final class LiveFileTranscriptionBatchTranscriber: FileTranscriptionBatc
         settings: FileTranscriptionSettingsSnapshot,
         source: String,
         sourceDurationSeconds: TimeInterval?,
+        resumeJobID: String?,
+        onJobSubmitted: @escaping (String) -> Void,
         onUpdate: @escaping (JobProgressUpdate) -> Void
     ) async throws -> GeneratedTranscript {
         switch settings.provider {
@@ -1364,11 +1397,20 @@ private final class LiveFileTranscriptionBatchTranscriber: FileTranscriptionBatc
                 config["language_hints"] = settings.languageHints
                 config["language_hints_strict"] = true
             }
-            return try await AsyncTranscriptionJobService().transcribeFileDetailedWithRetry(
+            let service = AsyncTranscriptionJobService()
+            if let resumeJobID {
+                return try await service.resumeFileDetailed(
+                    jobID: resumeJobID,
+                    config: config,
+                    onProgressUpdate: onUpdate
+                )
+            }
+            return try await service.transcribeFileDetailedWithRetry(
                 audioFileURL: audioFileURL,
                 config: config,
                 source: source,
                 sourceDurationSeconds: sourceDurationSeconds,
+                onSubmitted: onJobSubmitted,
                 onProgressUpdate: onUpdate
             )
         case .local:

--- a/Diduny/Core/Services/RecordingQueueService.swift
+++ b/Diduny/Core/Services/RecordingQueueService.swift
@@ -147,6 +147,8 @@ final class RecordingQueueService {
             let transcript: GeneratedTranscript
             let status: Recording.ProcessingStatus
             let translationTargetLanguageCode: String?
+            let historyKind: TranscriptVersion.Kind
+            let sourceLanguageCode: String?
             switch item.action {
             case .transcribe:
                 if provider == .cloud {
@@ -162,6 +164,8 @@ final class RecordingQueueService {
                 }
                 status = .transcribed
                 translationTargetLanguageCode = nil
+                historyKind = provider == .local ? .local : .cloud
+                sourceLanguageCode = nil
             case .transcribeDiarize:
                 if provider == .cloud {
                     transcript = try await transcribeViaJobs(
@@ -176,8 +180,11 @@ final class RecordingQueueService {
                 }
                 status = .transcribed
                 translationTargetLanguageCode = nil
+                historyKind = provider == .local ? .local : .cloud
+                sourceLanguageCode = nil
             case .translate:
                 let audioData = try await loadAudioData(from: audioURL)
+                let pair = SettingsStorage.shared.resolveTranslationLanguagePair()
                 let targetLanguage: String
                 if let explicitTargetLanguage = item.targetLanguage {
                     targetLanguage = explicitTargetLanguage
@@ -188,7 +195,6 @@ final class RecordingQueueService {
                         )
                     )
                 } else {
-                    let pair = SettingsStorage.shared.resolveTranslationLanguagePair()
                     targetLanguage = provider == .local ? "en" : pair.languageB
                     transcript = try await GeneratedTranscript(
                         text: service.translateAndTranscribe(
@@ -199,6 +205,8 @@ final class RecordingQueueService {
                 }
                 status = .translated
                 translationTargetLanguageCode = targetLanguage
+                historyKind = .translation
+                sourceLanguageCode = pair.languageA
             }
 
             guard !Task.isCancelled else {
@@ -218,7 +226,13 @@ final class RecordingQueueService {
                     ? transcript.segments
                     : nil,
                 translationTargetLanguageCode: translationTargetLanguageCode,
-                generatedTranscriptProvenance: provenance
+                generatedTranscriptProvenance: provenance,
+                kind: historyKind,
+                provider: provider.rawValue,
+                modelIdentifier: provider == .local
+                    ? item.whisperModelOverride ?? SettingsStorage.shared.selectedWhisperModel
+                    : nil,
+                sourceLanguageCode: sourceLanguageCode
             )
             currentJobStatus = nil
             Log.app.info("Queue processed recording \(item.id): \(status.rawValue)")

--- a/Diduny/Core/Services/RemoteMediaService.swift
+++ b/Diduny/Core/Services/RemoteMediaService.swift
@@ -218,7 +218,7 @@ enum RemoteMediaExtractorError: LocalizedError, Equatable {
     }
 }
 
-struct RemoteMediaMetadata: Equatable {
+struct RemoteMediaMetadata: Codable, Equatable {
     let source: RemoteMediaSourceMetadata
     let durationSeconds: TimeInterval
     let audioFormatID: String

--- a/Diduny/Core/Services/RemoteMediaService.swift
+++ b/Diduny/Core/Services/RemoteMediaService.swift
@@ -7,6 +7,23 @@ struct RemoteMediaSourceMetadata: Codable, Equatable, Hashable {
     let canonicalURL: URL
     let title: String
     let channelName: String?
+    let description: String?
+
+    init(
+        provider: String,
+        mediaID: String,
+        canonicalURL: URL,
+        title: String,
+        channelName: String?,
+        description: String? = nil
+    ) {
+        self.provider = provider
+        self.mediaID = mediaID
+        self.canonicalURL = canonicalURL
+        self.title = title
+        self.channelName = channelName
+        self.description = description
+    }
 }
 
 struct TranscriptArtifact: Codable, Equatable {
@@ -284,7 +301,8 @@ struct RemoteMediaMetadata: Codable, Equatable {
                 mediaID: payload.id,
                 canonicalURL: expectedSource.canonicalURL,
                 title: payload.title,
-                channelName: payload.channelName
+                channelName: payload.channelName,
+                description: payload.description
             ),
             durationSeconds: payload.duration,
             audioFormatID: compatibleAudio.id,
@@ -316,6 +334,7 @@ private struct YTDLPPayload: Decodable {
     let id: String
     let title: String
     let channelName: String?
+    let description: String?
     let duration: TimeInterval
     let originalLanguage: String?
     let isLive: Bool?
@@ -325,7 +344,7 @@ private struct YTDLPPayload: Decodable {
     let automaticCaptions: [String: [YTDLPCaption]]?
 
     enum CodingKeys: String, CodingKey {
-        case id, title, duration, availability, formats, subtitles
+        case id, title, description, duration, availability, formats, subtitles
         case channelName = "uploader"
         case originalLanguage = "original_language"
         case isLive = "is_live"

--- a/Diduny/Core/Services/RemoteMediaService.swift
+++ b/Diduny/Core/Services/RemoteMediaService.swift
@@ -77,6 +77,12 @@ struct YouTubeRemoteMediaSource: Codable, Equatable, Hashable {
     let mediaID: String
     let canonicalURL: URL
 
+    struct BatchValidation: Equatable {
+        let sources: [YouTubeRemoteMediaSource]
+        let duplicateCount: Int
+        let invalidValues: [String]
+    }
+
     enum ValidationError: LocalizedError, Equatable {
         case malformedURL
         case unsupportedProvider
@@ -145,6 +151,38 @@ struct YouTubeRemoteMediaSource: Codable, Equatable, Hashable {
             let source = try normalize(value)
             return seen.insert(source.mediaID).inserted ? source : nil
         }
+    }
+
+    static func validateBatch(
+        _ rawValue: String,
+        excludingMediaIDs: Set<String> = []
+    ) -> BatchValidation {
+        let values = rawValue
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        var sources: [Self] = []
+        var seen = excludingMediaIDs
+        var duplicateCount = 0
+        var invalidValues: [String] = []
+
+        for value in values {
+            do {
+                let source = try normalize(value)
+                if seen.insert(source.mediaID).inserted {
+                    sources.append(source)
+                } else {
+                    duplicateCount += 1
+                }
+            } catch {
+                invalidValues.append(value)
+            }
+        }
+        return BatchValidation(
+            sources: sources,
+            duplicateCount: duplicateCount,
+            invalidValues: invalidValues
+        )
     }
 
     private static func isValidVideoID(_ value: String) -> Bool {

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -204,45 +204,89 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Delete
 
-    func deleteRecording(_ recording: Recording) {
-        do {
+    @discardableResult
+    func deleteRecording(_ recording: Recording) -> Bool {
+        deleteStoredRecordings(Set([recording.id])) {
             try batchStorage.removeRecordingReferences(Set([recording.id]))
-        } catch {
-            Log.app.error("Failed to remove recording from transcription batches: \(error.localizedDescription)")
-            return
         }
-        let fileURL = recordingsDir.appendingPathComponent(recording.audioFileName)
-        try? fileManager.removeItem(at: fileURL)
-        recordings.removeAll { $0.id == recording.id }
-        saveMetadata()
     }
 
-    func deleteRecordings(_ ids: Set<UUID>) {
-        guard !ids.isEmpty else { return }
-        do {
+    @discardableResult
+    func deleteRecordings(_ ids: Set<UUID>) -> Bool {
+        guard !ids.isEmpty else { return true }
+        return deleteStoredRecordings(ids) {
             try batchStorage.removeRecordingReferences(ids)
-        } catch {
-            Log.app.error("Failed to remove recordings from transcription batches: \(error.localizedDescription)")
-            return
         }
+    }
 
-        for id in ids {
-            if let recording = recordings.first(where: { $0.id == id }) {
-                let fileURL = recordingsDir.appendingPathComponent(recording.audioFileName)
-                try? fileManager.removeItem(at: fileURL)
+    @discardableResult
+    func deleteBatch(_ batch: TranscriptionBatch) -> Bool {
+        deleteStoredRecordings(Set(batch.recordingIDs)) {
+            _ = try batchStorage.delete(batchID: batch.id)
+        }
+    }
+
+    private func deleteStoredRecordings(
+        _ ids: Set<UUID>,
+        updateBatchMetadata: () throws -> Void
+    ) -> Bool {
+        let previousRecordings = recordings
+        let targets = recordings.filter { ids.contains($0.id) }
+        var stagedFiles: [(original: URL, staged: URL)] = []
+
+        func restoreStagedFiles() {
+            for file in stagedFiles.reversed() where fileManager.fileExists(atPath: file.staged.path) {
+                do {
+                    try fileManager.moveItem(at: file.staged, to: file.original)
+                } catch {
+                    Log.app.error("Failed to restore staged recording file: \(error.localizedDescription)")
+                }
             }
         }
-        recordings.removeAll { ids.contains($0.id) }
-        saveMetadata()
-    }
 
-    func deleteBatch(_ batch: TranscriptionBatch) {
         do {
-            let recordingIDs = try batchStorage.delete(batchID: batch.id)
-            deleteRecordings(recordingIDs)
+            for recording in targets {
+                let original = recordingsDir.appendingPathComponent(recording.audioFileName)
+                guard fileManager.fileExists(atPath: original.path) else { continue }
+                let staged = recordingsDir.appendingPathComponent(
+                    ".\(recording.audioFileName).deleting-\(UUID().uuidString)"
+                )
+                try fileManager.moveItem(at: original, to: staged)
+                stagedFiles.append((original, staged))
+            }
         } catch {
-            Log.app.error("Failed to delete transcription batch: \(error.localizedDescription)")
+            restoreStagedFiles()
+            Log.app.error("Failed to stage recording deletion: \(error.localizedDescription)")
+            return false
         }
+
+        recordings.removeAll { ids.contains($0.id) }
+        guard saveMetadataSynchronously() else {
+            recordings = previousRecordings
+            restoreStagedFiles()
+            return false
+        }
+
+        do {
+            try updateBatchMetadata()
+        } catch {
+            recordings = previousRecordings
+            if !saveMetadataSynchronously() {
+                Log.app.error("Failed to restore recordings metadata after batch update failure")
+            }
+            restoreStagedFiles()
+            Log.app.error("Failed to update transcription batches during deletion: \(error.localizedDescription)")
+            return false
+        }
+
+        for file in stagedFiles {
+            do {
+                try fileManager.removeItem(at: file.staged)
+            } catch {
+                Log.app.warning("Failed to clean staged recording file: \(error.localizedDescription)")
+            }
+        }
+        return true
     }
 
     func pruneExpiredRecordings(now: Date = Date()) {
@@ -263,13 +307,19 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Update
 
-    func updateDetails(id: UUID, title: String, description: String) {
-        guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
+    @discardableResult
+    func updateDetails(id: UUID, title: String, description: String) -> Bool {
+        guard let index = recordings.firstIndex(where: { $0.id == id }) else { return false }
+        let previous = recordings[index]
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
         recordings[index].title = trimmedTitle.isEmpty ? nil : trimmedTitle
         recordings[index].description = trimmedDescription.isEmpty ? nil : trimmedDescription
-        saveMetadataSynchronously()
+        guard saveMetadataSynchronously() else {
+            recordings[index] = previous
+            return false
+        }
+        return true
     }
 
     func updateRecording(
@@ -324,6 +374,7 @@ final class RecordingsLibraryStorage {
         sourceLanguageCode: String? = nil
     ) {
         guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
+        let previous = recordings[index]
         let completedAt = Date()
         let version = TranscriptVersion(
             createdAt: completedAt,
@@ -344,7 +395,9 @@ final class RecordingsLibraryStorage {
         recordings[index].transcriptSegments = segments
         recordings[index].translationTargetLanguageCode = translationTargetLanguageCode
         recordings[index].generatedTranscriptProvenance = generatedTranscriptProvenance
-        saveMetadataSynchronously()
+        if !saveMetadataSynchronously() {
+            recordings[index] = previous
+        }
     }
 
     func optimizeStoredRecordingIfNeeded(id: UUID) async -> URL? {

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -537,7 +537,10 @@ final class RecordingsLibraryStorage {
                 remoteSource: recording.remoteSource,
                 sourceCaptionArtifacts: recording.sourceCaptionArtifacts,
                 generatedTranscriptProvenance: recording.generatedTranscriptProvenance,
-                transcriptSegments: recording.transcriptSegments
+                transcriptSegments: recording.transcriptSegments,
+                title: recording.title,
+                description: recording.description,
+                transcriptHistory: recording.transcriptHistory
             )
             saveMetadata()
 

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -11,6 +11,7 @@ final class RecordingsLibraryStorage {
     private let appSupportDir: URL
     private let recordingsDir: URL
     private let metadataURL: URL
+    private let deletionRecoveryURL: URL
     private let batchStorage: TranscriptionBatchStorage
     private let metadataWriteQueue = DispatchQueue(label: "ua.com.rmarinsky.diduny.recordings-metadata")
 
@@ -31,6 +32,7 @@ final class RecordingsLibraryStorage {
 
         try? fm.createDirectory(at: appDir, withIntermediateDirectories: true)
         metadataURL = appDir.appendingPathComponent("recordings_metadata.json")
+        deletionRecoveryURL = appDir.appendingPathComponent("recordings_delete_recovery.json")
 
         Task { @MainActor [weak self] in
             await self?.loadAndPruneAsync()
@@ -234,6 +236,10 @@ final class RecordingsLibraryStorage {
         let targets = recordings.filter { ids.contains($0.id) }
         var stagedFiles: [(original: URL, staged: URL)] = []
 
+        guard Self.writeMetadataSnapshot(previousRecordings, to: deletionRecoveryURL) else {
+            return false
+        }
+
         func restoreStagedFiles() {
             for file in stagedFiles.reversed() where fileManager.fileExists(atPath: file.staged.path) {
                 do {
@@ -256,6 +262,7 @@ final class RecordingsLibraryStorage {
             }
         } catch {
             restoreStagedFiles()
+            try? fileManager.removeItem(at: deletionRecoveryURL)
             Log.app.error("Failed to stage recording deletion: \(error.localizedDescription)")
             return false
         }
@@ -271,7 +278,9 @@ final class RecordingsLibraryStorage {
             try updateBatchMetadata()
         } catch {
             recordings = previousRecordings
-            if !saveMetadataSynchronously() {
+            if saveMetadataSynchronously() {
+                try? fileManager.removeItem(at: deletionRecoveryURL)
+            } else {
                 Log.app.error("Failed to restore recordings metadata after batch update failure")
             }
             restoreStagedFiles()
@@ -286,6 +295,7 @@ final class RecordingsLibraryStorage {
                 Log.app.warning("Failed to clean staged recording file: \(error.localizedDescription)")
             }
         }
+        try? fileManager.removeItem(at: deletionRecoveryURL)
         return true
     }
 
@@ -452,11 +462,24 @@ final class RecordingsLibraryStorage {
 
     private func loadAndPruneAsync() async {
         let url = metadataURL
+        let recoveryURL = deletionRecoveryURL
         let recDir = recordingsDir
         let result = await Task.detached(
             priority: .utility
         ) { () -> (recordings: [Recording], resetInterrupted: Bool)? in
-            guard let data = try? Data(contentsOf: url) else { return nil }
+            let data: Data
+            if let recoveryData = try? Data(contentsOf: recoveryURL) {
+                data = recoveryData
+                do {
+                    try recoveryData.write(to: url, options: .atomic)
+                    try FileManager.default.removeItem(at: recoveryURL)
+                } catch {
+                    Log.app.error("Failed to restore recording deletion recovery: \(error.localizedDescription)")
+                }
+            } else {
+                guard let metadata = try? Data(contentsOf: url) else { return nil }
+                data = metadata
+            }
             do {
                 let decoder = JSONDecoder()
                 decoder.dateDecodingStrategy = .iso8601

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -11,14 +11,19 @@ final class RecordingsLibraryStorage {
     private let appSupportDir: URL
     private let recordingsDir: URL
     private let metadataURL: URL
+    private let batchStorage: TranscriptionBatchStorage
     private let metadataWriteQueue = DispatchQueue(label: "ua.com.rmarinsky.diduny.recordings-metadata")
 
-    private init() {
+    init(
+        baseDirectory: URL? = nil,
+        batchStorage: TranscriptionBatchStorage? = nil
+    ) {
         let fm = FileManager.default
         let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let bundleID = Bundle.main.bundleIdentifier ?? "Diduny"
-        let appDir = appSupport.appendingPathComponent(bundleID)
+        let appDir = baseDirectory ?? appSupport.appendingPathComponent(bundleID)
         appSupportDir = appDir
+        self.batchStorage = batchStorage ?? .shared
 
         let recDir = appDir.appendingPathComponent("Recordings")
         try? fm.createDirectory(at: recDir, withIntermediateDirectories: true)
@@ -200,6 +205,12 @@ final class RecordingsLibraryStorage {
     // MARK: - Delete
 
     func deleteRecording(_ recording: Recording) {
+        do {
+            try batchStorage.removeRecordingReferences(Set([recording.id]))
+        } catch {
+            Log.app.error("Failed to remove recording from transcription batches: \(error.localizedDescription)")
+            return
+        }
         let fileURL = recordingsDir.appendingPathComponent(recording.audioFileName)
         try? fileManager.removeItem(at: fileURL)
         recordings.removeAll { $0.id == recording.id }
@@ -208,6 +219,12 @@ final class RecordingsLibraryStorage {
 
     func deleteRecordings(_ ids: Set<UUID>) {
         guard !ids.isEmpty else { return }
+        do {
+            try batchStorage.removeRecordingReferences(ids)
+        } catch {
+            Log.app.error("Failed to remove recordings from transcription batches: \(error.localizedDescription)")
+            return
+        }
 
         for id in ids {
             if let recording = recordings.first(where: { $0.id == id }) {
@@ -217,6 +234,15 @@ final class RecordingsLibraryStorage {
         }
         recordings.removeAll { ids.contains($0.id) }
         saveMetadata()
+    }
+
+    func deleteBatch(_ batch: TranscriptionBatch) {
+        do {
+            let recordingIDs = try batchStorage.delete(batchID: batch.id)
+            deleteRecordings(recordingIDs)
+        } catch {
+            Log.app.error("Failed to delete transcription batch: \(error.localizedDescription)")
+        }
     }
 
     func pruneExpiredRecordings(now: Date = Date()) {

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -263,6 +263,15 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Update
 
+    func updateDetails(id: UUID, title: String, description: String) {
+        guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        recordings[index].title = trimmedTitle.isEmpty ? nil : trimmedTitle
+        recordings[index].description = trimmedDescription.isEmpty ? nil : trimmedDescription
+        saveMetadataSynchronously()
+    }
+
     func updateRecording(
         id: UUID,
         status: Recording.ProcessingStatus,
@@ -308,20 +317,33 @@ final class RecordingsLibraryStorage {
         text: String,
         segments: [TimedTranscriptSegment]?,
         translationTargetLanguageCode: String? = nil,
-        generatedTranscriptProvenance: GeneratedTranscriptProvenance? = nil
+        generatedTranscriptProvenance: GeneratedTranscriptProvenance? = nil,
+        kind: TranscriptVersion.Kind,
+        provider: String? = nil,
+        modelIdentifier: String? = nil,
+        sourceLanguageCode: String? = nil
     ) {
         guard let index = recordings.firstIndex(where: { $0.id == id }) else { return }
+        let completedAt = Date()
+        let version = TranscriptVersion(
+            createdAt: completedAt,
+            kind: kind,
+            provider: provider,
+            modelIdentifier: modelIdentifier,
+            sourceLanguageCode: sourceLanguageCode,
+            targetLanguageCode: translationTargetLanguageCode,
+            text: text,
+            segments: segments,
+            provenance: generatedTranscriptProvenance
+        )
+        recordings[index].transcriptHistory = recordings[index].resolvedTranscriptHistory + [version]
         recordings[index].status = status
         recordings[index].transcriptionText = text
         recordings[index].errorMessage = nil
-        recordings[index].processedAt = Date()
+        recordings[index].processedAt = completedAt
         recordings[index].transcriptSegments = segments
-        if let translationTargetLanguageCode {
-            recordings[index].translationTargetLanguageCode = translationTargetLanguageCode
-        }
-        if let generatedTranscriptProvenance {
-            recordings[index].generatedTranscriptProvenance = generatedTranscriptProvenance
-        }
+        recordings[index].translationTargetLanguageCode = translationTargetLanguageCode
+        recordings[index].generatedTranscriptProvenance = generatedTranscriptProvenance
         saveMetadataSynchronously()
     }
 

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+struct RecordingDeletionStagedFile: Codable, Equatable {
+    let originalPath: String
+    let stagedPath: String
+}
+
+struct RecordingDeletionRecovery: Codable, Equatable {
+    let recordings: [Recording]
+    let stagedFiles: [RecordingDeletionStagedFile]
+}
+
 @Observable
 @MainActor
 final class RecordingsLibraryStorage {
@@ -234,16 +244,32 @@ final class RecordingsLibraryStorage {
     ) -> Bool {
         let previousRecordings = recordings
         let targets = recordings.filter { ids.contains($0.id) }
-        var stagedFiles: [(original: URL, staged: URL)] = []
+        let stagedFiles = targets.compactMap { recording -> RecordingDeletionStagedFile? in
+            let original = recordingsDir.appendingPathComponent(recording.audioFileName)
+            guard fileManager.fileExists(atPath: original.path) else { return nil }
+            return RecordingDeletionStagedFile(
+                originalPath: original.path,
+                stagedPath: recordingsDir.appendingPathComponent(
+                    ".\(recording.audioFileName).deleting-\(UUID().uuidString)"
+                ).path
+            )
+        }
+        let recovery = RecordingDeletionRecovery(
+            recordings: previousRecordings,
+            stagedFiles: stagedFiles
+        )
 
-        guard Self.writeMetadataSnapshot(previousRecordings, to: deletionRecoveryURL) else {
+        guard Self.writeDeletionRecovery(recovery, to: deletionRecoveryURL) else {
             return false
         }
 
         func restoreStagedFiles() {
-            for file in stagedFiles.reversed() where fileManager.fileExists(atPath: file.staged.path) {
+            for file in stagedFiles.reversed() where fileManager.fileExists(atPath: file.stagedPath) {
                 do {
-                    try fileManager.moveItem(at: file.staged, to: file.original)
+                    try fileManager.moveItem(
+                        at: URL(fileURLWithPath: file.stagedPath),
+                        to: URL(fileURLWithPath: file.originalPath)
+                    )
                 } catch {
                     Log.app.error("Failed to restore staged recording file: \(error.localizedDescription)")
                 }
@@ -251,14 +277,11 @@ final class RecordingsLibraryStorage {
         }
 
         do {
-            for recording in targets {
-                let original = recordingsDir.appendingPathComponent(recording.audioFileName)
-                guard fileManager.fileExists(atPath: original.path) else { continue }
-                let staged = recordingsDir.appendingPathComponent(
-                    ".\(recording.audioFileName).deleting-\(UUID().uuidString)"
+            for file in stagedFiles {
+                try fileManager.moveItem(
+                    at: URL(fileURLWithPath: file.originalPath),
+                    to: URL(fileURLWithPath: file.stagedPath)
                 )
-                try fileManager.moveItem(at: original, to: staged)
-                stagedFiles.append((original, staged))
             }
         } catch {
             restoreStagedFiles()
@@ -290,7 +313,7 @@ final class RecordingsLibraryStorage {
 
         for file in stagedFiles {
             do {
-                try fileManager.removeItem(at: file.staged)
+                try fileManager.removeItem(at: URL(fileURLWithPath: file.stagedPath))
             } catch {
                 Log.app.warning("Failed to clean staged recording file: \(error.localizedDescription)")
             }
@@ -468,10 +491,30 @@ final class RecordingsLibraryStorage {
             priority: .utility
         ) { () -> (recordings: [Recording], resetInterrupted: Bool)? in
             let data: Data
-            if let recoveryData = try? Data(contentsOf: recoveryURL) {
-                data = recoveryData
+            if let recoveryData = try? Data(contentsOf: recoveryURL),
+               let recovery = try? Self.decodeDeletionRecovery(recoveryData)
+            {
+                for file in recovery.stagedFiles {
+                    let original = URL(fileURLWithPath: file.originalPath)
+                    let staged = URL(fileURLWithPath: file.stagedPath)
+                    if FileManager.default.fileExists(atPath: staged.path),
+                       !FileManager.default.fileExists(atPath: original.path)
+                    {
+                        try? FileManager.default.moveItem(at: staged, to: original)
+                    }
+                }
+                guard recovery.stagedFiles.allSatisfy({
+                    FileManager.default.fileExists(atPath: $0.originalPath)
+                }) else {
+                    Log.app.error("Recording deletion recovery still has missing media files")
+                    return nil
+                }
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                guard let restoredData = try? encoder.encode(recovery.recordings) else { return nil }
+                data = restoredData
                 do {
-                    try recoveryData.write(to: url, options: .atomic)
+                    try restoredData.write(to: url, options: .atomic)
                     try FileManager.default.removeItem(at: recoveryURL)
                 } catch {
                     Log.app.error("Failed to restore recording deletion recovery: \(error.localizedDescription)")
@@ -555,6 +598,27 @@ final class RecordingsLibraryStorage {
             Log.app.error("Failed to save recordings metadata: \(error.localizedDescription)")
             return false
         }
+    }
+
+    private nonisolated static func writeDeletionRecovery(
+        _ recovery: RecordingDeletionRecovery,
+        to url: URL
+    ) -> Bool {
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            try encoder.encode(recovery).write(to: url, options: .atomic)
+            return true
+        } catch {
+            Log.app.error("Failed to save recording deletion recovery: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private nonisolated static func decodeDeletionRecovery(_ data: Data) throws -> RecordingDeletionRecovery {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(RecordingDeletionRecovery.self, from: data)
     }
 
     private func shouldSaveRecording(type: Recording.RecordingType) -> Bool {

--- a/Diduny/Core/Storage/RecordingsLibraryStorage.swift
+++ b/Diduny/Core/Storage/RecordingsLibraryStorage.swift
@@ -44,9 +44,7 @@ final class RecordingsLibraryStorage {
         metadataURL = appDir.appendingPathComponent("recordings_metadata.json")
         deletionRecoveryURL = appDir.appendingPathComponent("recordings_delete_recovery.json")
 
-        Task { @MainActor [weak self] in
-            await self?.loadAndPruneAsync()
-        }
+        loadAndPrune()
     }
 
     // MARK: - Save (from Data — voice/translation)
@@ -483,13 +481,11 @@ final class RecordingsLibraryStorage {
 
     // MARK: - Persistence
 
-    private func loadAndPruneAsync() async {
+    private func loadAndPrune() {
         let url = metadataURL
         let recoveryURL = deletionRecoveryURL
         let recDir = recordingsDir
-        let result = await Task.detached(
-            priority: .utility
-        ) { () -> (recordings: [Recording], resetInterrupted: Bool)? in
+        let result: (recordings: [Recording], resetInterrupted: Bool)? = {
             let data: Data
             if let recoveryData = try? Data(contentsOf: recoveryURL),
                let recovery = try? Self.decodeDeletionRecovery(recoveryData)
@@ -540,17 +536,9 @@ final class RecordingsLibraryStorage {
                 Log.app.error("Failed to load recordings metadata: \(error.localizedDescription)")
                 return nil
             }
-        }.value
+        }()
         if let result {
-            if recordings.isEmpty {
-                recordings = result.recordings
-            } else {
-                // A save landed while we were loading from disk. Don't clobber the
-                // freshly inserted in-memory entries — merge the disk snapshot in,
-                // keeping in-memory (newer) records on id conflicts.
-                let existingIDs = Set(recordings.map(\.id))
-                recordings.append(contentsOf: result.recordings.filter { !existingIDs.contains($0.id) })
-            }
+            recordings = result.recordings
             if result.resetInterrupted {
                 saveMetadata()
             }

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -74,7 +74,8 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
 
     func markdown(recordings: [Recording]) -> String {
         let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
-        let recordingsMarkdown = recordingIDs.compactMap { id -> String? in
+        let workItemRecordingIDs = Set((workItems ?? []).compactMap(\.recordingID))
+        let recordingsMarkdown = recordingIDs.filter { !workItemRecordingIDs.contains($0) }.compactMap { id -> String? in
             guard let recording = byID[id] else { return nil }
             let title = recording.remoteSource?.title
                 ?? recording.sourceFileName
@@ -83,11 +84,18 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                 ?? "[Transcript unavailable — \(recording.status.displayName)]"
             return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
         }
-        let unresolvedMarkdown = (workItems ?? []).compactMap { item -> String? in
-            guard item.recordingID == nil else { return nil }
+        let workItemsMarkdown = (workItems ?? []).compactMap { item -> String? in
+            if let recordingID = item.recordingID, let recording = byID[recordingID] {
+                let title = recording.remoteSource?.title
+                    ?? recording.sourceFileName
+                    ?? recording.libraryDisplayName
+                let body = recording.displayTranscriptText
+                    ?? "[Transcript unavailable — \(recording.status.displayName)]"
+                return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
+            }
             return "# \(item.displayName)\n\nSource: \(item.sourceURL.absoluteString)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
         }
-        return (recordingsMarkdown + unresolvedMarkdown).joined(separator: "\n\n")
+        return (recordingsMarkdown + workItemsMarkdown).joined(separator: "\n\n")
     }
 }
 
@@ -207,6 +215,9 @@ final class TranscriptionBatchStorage {
         guard !ids.isEmpty else { return }
         for index in batches.indices {
             batches[index].recordingIDs.removeAll(where: ids.contains)
+            batches[index].workItems?.removeAll { item in
+                item.recordingID.map(ids.contains) == true
+            }
         }
         try save()
     }
@@ -220,6 +231,14 @@ final class TranscriptionBatchStorage {
         batches.removeAll { $0.id == batchID }
         for index in batches.indices {
             batches[index].recordingIDs.removeAll(where: affected.contains)
+            batches[index].workItems?.removeAll { item in
+                item.recordingID.map(affected.contains) == true
+            }
+        }
+        for item in batch.workItems ?? [] {
+            if let url = item.downloadedAudioURL {
+                try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+            }
         }
         try save()
         return affected

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -191,8 +191,16 @@ final class TranscriptionBatchStorage {
         )
         metadataURL = baseDirectory.appendingPathComponent("transcription_batches.json")
         loadErrorMessage = nil
-        guard let data = try? Data(contentsOf: metadataURL) else {
+        guard FileManager.default.fileExists(atPath: metadataURL.path) else {
             batches = []
+            return
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: metadataURL)
+        } catch {
+            batches = []
+            loadErrorMessage = "Diduny couldn't read batches. The original data remains at \(metadataURL.path)."
             return
         }
         let decoder = JSONDecoder()
@@ -301,6 +309,7 @@ final class TranscriptionBatchStorage {
         let removedItems = batches.flatMap { batch in
             (batch.workItems ?? []).filter { $0.recordingID.map(ids.contains) == true }
         }
+        try removedItems.forEach(removeDownloadedArtifact)
         try mutateAndSave {
             for index in batches.indices {
                 batches[index].recordingIDs.removeAll(where: ids.contains)
@@ -309,7 +318,6 @@ final class TranscriptionBatchStorage {
                 }
             }
         }
-        removedItems.forEach(removeDownloadedArtifact)
     }
 
     @discardableResult
@@ -323,6 +331,7 @@ final class TranscriptionBatchStorage {
                 candidate.id == batchID || item.recordingID.map(affected.contains) == true
             }
         }
+        try removedItems.forEach(removeDownloadedArtifact)
         try mutateAndSave {
             batches.removeAll { $0.id == batchID }
             for index in batches.indices {
@@ -332,17 +341,21 @@ final class TranscriptionBatchStorage {
                 }
             }
         }
-        removedItems.forEach(removeDownloadedArtifact)
         return affected
     }
 
-    private func removeDownloadedArtifact(_ item: BatchTranscriptionItem) {
+    private func removeDownloadedArtifact(_ item: BatchTranscriptionItem) throws {
         guard let url = item.downloadedAudioURL?.standardizedFileURL else { return }
         let fileManager = FileManager.default
-        try? fileManager.removeItem(at: url)
+        let temporaryRoot = fileManager.temporaryDirectory.standardizedFileURL.path + "/"
+        guard url.path.hasPrefix(temporaryRoot) else {
+            throw CocoaError(.fileWriteNoPermission, userInfo: [NSFilePathErrorKey: url.path])
+        }
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
 
         let parent = url.deletingLastPathComponent()
-        let temporaryRoot = fileManager.temporaryDirectory.standardizedFileURL.path + "/"
         guard parent.path.hasPrefix(temporaryRoot),
               (try? fileManager.contentsOfDirectory(atPath: parent.path).isEmpty) == true
         else { return }

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -227,8 +227,9 @@ final class TranscriptionBatchStorage {
             createdAt: createdAt,
             recordingIDs: unique(recordingIDs)
         )
-        batches.insert(batch, at: 0)
-        try save()
+        try mutateAndSave {
+            batches.insert(batch, at: 0)
+        }
         return batch
     }
 
@@ -237,11 +238,12 @@ final class TranscriptionBatchStorage {
             throw StorageError.batchNotFound
         }
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        batches[index].name = trimmedName.isEmpty
-            ? Self.defaultName(for: batches[index].createdAt)
-            : trimmedName
-        batches[index].description = description.trimmingCharacters(in: .whitespacesAndNewlines)
-        try save()
+        try mutateAndSave {
+            batches[index].name = trimmedName.isEmpty
+                ? Self.defaultName(for: batches[index].createdAt)
+                : trimmedName
+            batches[index].description = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 
     func addRecordingIDs(_ recordingIDs: [UUID], to batchID: UUID) throws {
@@ -251,54 +253,63 @@ final class TranscriptionBatchStorage {
         guard !batches[index].isProcessingClosed else {
             throw StorageError.membershipClosed
         }
-        batches[index].recordingIDs = unique(batches[index].recordingIDs + recordingIDs)
-        try save()
+        let ids = unique(batches[index].recordingIDs + recordingIDs)
+        try mutateAndSave {
+            batches[index].recordingIDs = ids
+        }
     }
 
     func replaceRecordingIDs(_ recordingIDs: [UUID], in batchID: UUID) throws {
         guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
             throw StorageError.batchNotFound
         }
-        batches[index].recordingIDs = unique(recordingIDs)
-        try save()
+        let ids = unique(recordingIDs)
+        try mutateAndSave {
+            batches[index].recordingIDs = ids
+        }
     }
 
     func replaceWorkItems(_ items: [BatchTranscriptionItem], in batchID: UUID) throws {
         guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
             throw StorageError.batchNotFound
         }
-        batches[index].workItems = items
-        try save()
+        try mutateAndSave {
+            batches[index].workItems = items
+        }
     }
 
     func reopen(batchID: UUID) throws {
         guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
             throw StorageError.batchNotFound
         }
-        batches[index].isProcessingClosed = false
-        try save()
+        try mutateAndSave {
+            batches[index].isProcessingClosed = false
+        }
     }
 
     func close(batchID: UUID) throws {
         guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
             throw StorageError.batchNotFound
         }
-        batches[index].isProcessingClosed = true
-        try save()
+        try mutateAndSave {
+            batches[index].isProcessingClosed = true
+        }
     }
 
     func removeRecordingReferences(_ ids: Set<UUID>) throws {
         guard !ids.isEmpty else { return }
-        for index in batches.indices {
-            batches[index].workItems?.filter { item in
-                item.recordingID.map(ids.contains) == true
-            }.forEach(removeDownloadedArtifact)
-            batches[index].recordingIDs.removeAll(where: ids.contains)
-            batches[index].workItems?.removeAll { item in
-                item.recordingID.map(ids.contains) == true
+        let removedItems = batches.flatMap { batch in
+            (batch.workItems ?? []).filter { $0.recordingID.map(ids.contains) == true }
+        }
+        try mutateAndSave {
+            for index in batches.indices {
+                batches[index].recordingIDs.removeAll(where: ids.contains)
+                batches[index].workItems?.removeAll { item in
+                    item.recordingID.map(ids.contains) == true
+                }
             }
         }
-        try save()
+        removedItems.forEach(removeDownloadedArtifact)
     }
 
     @discardableResult
@@ -307,18 +318,21 @@ final class TranscriptionBatchStorage {
             throw StorageError.batchNotFound
         }
         let affected = Set(batch.recordingIDs)
-        batch.workItems?.forEach(removeDownloadedArtifact)
-        batches.removeAll { $0.id == batchID }
-        for index in batches.indices {
-            batches[index].workItems?.filter { item in
-                item.recordingID.map(affected.contains) == true
-            }.forEach(removeDownloadedArtifact)
-            batches[index].recordingIDs.removeAll(where: affected.contains)
-            batches[index].workItems?.removeAll { item in
-                item.recordingID.map(affected.contains) == true
+        let removedItems = batches.flatMap { candidate in
+            (candidate.workItems ?? []).filter { item in
+                candidate.id == batchID || item.recordingID.map(affected.contains) == true
             }
         }
-        try save()
+        try mutateAndSave {
+            batches.removeAll { $0.id == batchID }
+            for index in batches.indices {
+                batches[index].recordingIDs.removeAll(where: affected.contains)
+                batches[index].workItems?.removeAll { item in
+                    item.recordingID.map(affected.contains) == true
+                }
+            }
+        }
+        removedItems.forEach(removeDownloadedArtifact)
         return affected
     }
 
@@ -340,6 +354,17 @@ final class TranscriptionBatchStorage {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(batches).write(to: metadataURL, options: .atomic)
+    }
+
+    private func mutateAndSave(_ mutation: () -> Void) throws {
+        let previous = batches
+        mutation()
+        do {
+            try save()
+        } catch {
+            batches = previous
+            throw error
+        }
     }
 
     private func unique(_ ids: [UUID]) -> [UUID] {

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -93,7 +93,8 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                     ?? "[Transcript unavailable — \(recording.status.displayName)]"
                 return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
             }
-            return "# \(item.displayName)\n\nSource: \(item.sourceURL.absoluteString)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
+            let source = item.remoteSource == nil ? "File Transcription" : "YouTube"
+            return "# \(item.displayName)\n\nSource: \(source)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
         }
         return (recordingsMarkdown + workItemsMarkdown).joined(separator: "\n\n")
     }

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -67,14 +67,14 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                     recording.remoteSource?.description,
                     recording.remoteSource?.canonicalURL.absoluteString,
                     recording.libraryDisplayName,
-                    recording.transcriptionText,
+                    recording.transcriptionText
                 ].compactMap { $0 }.contains {
                     $0.localizedCaseInsensitiveContains(normalized)
                 }
                 || memberIDs.contains(recording.id)
-                    && recording.resolvedTranscriptHistory.contains {
-                        $0.text.localizedCaseInsensitiveContains(normalized)
-                    }
+                && recording.resolvedTranscriptHistory.contains {
+                    $0.text.localizedCaseInsensitiveContains(normalized)
+                }
         } || workItems?.contains {
             $0.displayName.localizedCaseInsensitiveContains(normalized)
                 || ($0.errorMessage?.localizedCaseInsensitiveContains(normalized) ?? false)
@@ -84,10 +84,11 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
     func markdown(recordings: [Recording]) -> String {
         let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
         let workItemRecordingIDs = Set((workItems ?? []).compactMap(\.recordingID))
-        let recordingsMarkdown = recordingIDs.filter { !workItemRecordingIDs.contains($0) }.compactMap { id -> String? in
-            guard let recording = byID[id] else { return nil }
-            return recordingMarkdown(recording)
-        }
+        let recordingsMarkdown = recordingIDs.filter { !workItemRecordingIDs.contains($0) }
+            .compactMap { id -> String? in
+                guard let recording = byID[id] else { return nil }
+                return recordingMarkdown(recording)
+            }
         let workItemsMarkdown = (workItems ?? []).compactMap { item -> String? in
             if let recordingID = item.recordingID, let recording = byID[recordingID] {
                 return recordingMarkdown(recording)
@@ -112,7 +113,7 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         var metadata = [
             "Type: \(recording.libraryDisplayName)",
             "Duration: \(duration)",
-            "Date: \(recording.createdAt.formatted(.iso8601))",
+            "Date: \(recording.createdAt.formatted(.iso8601))"
         ]
         if let description = recording.description, !description.isEmpty {
             metadata.append("Description: \(description)")
@@ -147,9 +148,18 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
 @Observable
 @MainActor
 final class TranscriptionBatchStorage {
-    enum StorageError: Error {
+    enum StorageError: LocalizedError {
         case batchNotFound
         case membershipClosed
+        case unreadableMetadata
+
+        var errorDescription: String? {
+            switch self {
+            case .batchNotFound: "Batch not found."
+            case .membershipClosed: "Completed batch membership cannot be changed."
+            case .unreadableMetadata: "Batch data could not be loaded, so it was left unchanged."
+            }
+        }
     }
 
     static let shared: TranscriptionBatchStorage = {
@@ -158,12 +168,16 @@ final class TranscriptionBatchStorage {
             in: .userDomainMask
         ).first!
         let bundleID = Bundle.main.bundleIdentifier ?? "Diduny"
-        return try! TranscriptionBatchStorage(
-            baseDirectory: appSupport.appendingPathComponent(bundleID)
-        )
+        let baseDirectory = appSupport.appendingPathComponent(bundleID)
+        do {
+            return try TranscriptionBatchStorage(baseDirectory: baseDirectory)
+        } catch {
+            return TranscriptionBatchStorage(unavailableAt: baseDirectory, error: error)
+        }
     }()
 
     private(set) var batches: [TranscriptionBatch]
+    private(set) var loadErrorMessage: String?
     private let metadataURL: URL
 
     init(baseDirectory: URL) throws {
@@ -172,14 +186,27 @@ final class TranscriptionBatchStorage {
             withIntermediateDirectories: true
         )
         metadataURL = baseDirectory.appendingPathComponent("transcription_batches.json")
+        loadErrorMessage = nil
         guard let data = try? Data(contentsOf: metadataURL) else {
             batches = []
             return
         }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        batches = try decoder.decode([TranscriptionBatch].self, from: data)
+        do {
+            batches = try decoder.decode([TranscriptionBatch].self, from: data)
+        } catch {
+            batches = []
+            loadErrorMessage = "Diduny couldn't load batches. The original data remains at \(metadataURL.path)."
+            return
+        }
         batches.sort { $0.createdAt > $1.createdAt }
+    }
+
+    private init(unavailableAt baseDirectory: URL, error: Error) {
+        metadataURL = baseDirectory.appendingPathComponent("transcription_batches.json")
+        batches = []
+        loadErrorMessage = "Diduny couldn't access batch storage: \(error.localizedDescription)"
     }
 
     @discardableResult
@@ -305,6 +332,7 @@ final class TranscriptionBatchStorage {
     }
 
     private func save() throws {
+        guard loadErrorMessage == nil else { throw StorageError.unreadableMetadata }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(batches).write(to: metadataURL, options: .atomic)

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -309,13 +309,20 @@ final class TranscriptionBatchStorage {
         let removedItems = batches.flatMap { batch in
             (batch.workItems ?? []).filter { $0.recordingID.map(ids.contains) == true }
         }
-        try removedItems.forEach(removeDownloadedArtifact)
+        try removedItems.forEach(validateDownloadedArtifact)
         try mutateAndSave {
             for index in batches.indices {
                 batches[index].recordingIDs.removeAll(where: ids.contains)
                 batches[index].workItems?.removeAll { item in
                     item.recordingID.map(ids.contains) == true
                 }
+            }
+        }
+        for item in removedItems {
+            do {
+                try removeDownloadedArtifact(item)
+            } catch {
+                Log.app.error("Failed to clean downloaded batch artifact: \(error.localizedDescription)")
             }
         }
     }
@@ -331,7 +338,7 @@ final class TranscriptionBatchStorage {
                 candidate.id == batchID || item.recordingID.map(affected.contains) == true
             }
         }
-        try removedItems.forEach(removeDownloadedArtifact)
+        try removedItems.forEach(validateDownloadedArtifact)
         try mutateAndSave {
             batches.removeAll { $0.id == batchID }
             for index in batches.indices {
@@ -341,16 +348,29 @@ final class TranscriptionBatchStorage {
                 }
             }
         }
+        for item in removedItems {
+            do {
+                try removeDownloadedArtifact(item)
+            } catch {
+                Log.app.error("Failed to clean downloaded batch artifact: \(error.localizedDescription)")
+            }
+        }
         return affected
     }
 
-    private func removeDownloadedArtifact(_ item: BatchTranscriptionItem) throws {
+    private func validateDownloadedArtifact(_ item: BatchTranscriptionItem) throws {
         guard let url = item.downloadedAudioURL?.standardizedFileURL else { return }
-        let fileManager = FileManager.default
-        let temporaryRoot = fileManager.temporaryDirectory.standardizedFileURL.path + "/"
+        let temporaryRoot = FileManager.default.temporaryDirectory.standardizedFileURL.path + "/"
         guard url.path.hasPrefix(temporaryRoot) else {
             throw CocoaError(.fileWriteNoPermission, userInfo: [NSFilePathErrorKey: url.path])
         }
+    }
+
+    private func removeDownloadedArtifact(_ item: BatchTranscriptionItem) throws {
+        try validateDownloadedArtifact(item)
+        guard let url = item.downloadedAudioURL?.standardizedFileURL else { return }
+        let fileManager = FileManager.default
+        let temporaryRoot = fileManager.temporaryDirectory.standardizedFileURL.path + "/"
         if fileManager.fileExists(atPath: url.path) {
             try fileManager.removeItem(at: url)
         }

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -47,6 +47,10 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         } ? .completed : .completedWithIssues
     }
 
+    var retryableWorkItems: [BatchTranscriptionItem] {
+        (workItems ?? []).filter { $0.status != .completed && $0.status != .duplicate }
+    }
+
     func matches(_ query: String, recordings: [Recording]) -> Bool {
         let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return true }

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+enum TranscriptionBatchStatus: String, Codable {
+    case processing = "Processing"
+    case completed = "Completed"
+    case completedWithIssues = "Completed with Issues"
+}
+
+struct TranscriptionBatch: Codable, Equatable, Identifiable {
+    let id: UUID
+    var name: String
+    var description: String
+    let createdAt: Date
+    var isProcessingClosed: Bool
+    var recordingIDs: [UUID]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        description: String = "",
+        createdAt: Date = Date(),
+        isProcessingClosed: Bool = false,
+        recordingIDs: [UUID] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.createdAt = createdAt
+        self.isProcessingClosed = isProcessingClosed
+        self.recordingIDs = recordingIDs
+    }
+
+    func status(in recordings: [Recording]) -> TranscriptionBatchStatus {
+        guard isProcessingClosed else { return .processing }
+        let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
+        return recordingIDs.allSatisfy { id in
+            guard let recording = byID[id] else { return false }
+            return recording.status == .transcribed || recording.status == .translated
+        } ? .completed : .completedWithIssues
+    }
+
+    func matches(_ query: String, recordings: [Recording]) -> Bool {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return true }
+        if name.localizedCaseInsensitiveContains(normalized)
+            || description.localizedCaseInsensitiveContains(normalized)
+        {
+            return true
+        }
+        let memberIDs = Set(recordingIDs)
+        return recordings.contains { recording in
+            memberIDs.contains(recording.id)
+                && [
+                    recording.sourceFileName,
+                    recording.remoteSource?.title,
+                    recording.libraryDisplayName,
+                    recording.transcriptionText,
+                ].compactMap { $0 }.contains {
+                    $0.localizedCaseInsensitiveContains(normalized)
+                }
+        }
+    }
+
+    func markdown(recordings: [Recording]) -> String {
+        let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
+        return recordingIDs.compactMap { id -> String? in
+            guard let recording = byID[id] else { return nil }
+            let title = recording.remoteSource?.title
+                ?? recording.sourceFileName
+                ?? recording.libraryDisplayName
+            let body = recording.displayTranscriptText
+                ?? "[Transcript unavailable — \(recording.status.displayName)]"
+            return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
+        }.joined(separator: "\n\n")
+    }
+}
+
+@Observable
+@MainActor
+final class TranscriptionBatchStorage {
+    enum StorageError: Error {
+        case batchNotFound
+        case membershipClosed
+    }
+
+    static let shared: TranscriptionBatchStorage = {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        let bundleID = Bundle.main.bundleIdentifier ?? "Diduny"
+        return try! TranscriptionBatchStorage(
+            baseDirectory: appSupport.appendingPathComponent(bundleID)
+        )
+    }()
+
+    private(set) var batches: [TranscriptionBatch]
+    private let metadataURL: URL
+
+    init(baseDirectory: URL) throws {
+        try FileManager.default.createDirectory(
+            at: baseDirectory,
+            withIntermediateDirectories: true
+        )
+        metadataURL = baseDirectory.appendingPathComponent("transcription_batches.json")
+        guard let data = try? Data(contentsOf: metadataURL) else {
+            batches = []
+            return
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        batches = try decoder.decode([TranscriptionBatch].self, from: data)
+        batches.sort { $0.createdAt > $1.createdAt }
+    }
+
+    @discardableResult
+    func create(
+        name: String,
+        description: String = "",
+        recordingIDs: [UUID],
+        createdAt: Date = Date()
+    ) throws -> TranscriptionBatch {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let batch = TranscriptionBatch(
+            name: trimmedName.isEmpty ? Self.defaultName(for: createdAt) : trimmedName,
+            description: description.trimmingCharacters(in: .whitespacesAndNewlines),
+            createdAt: createdAt,
+            recordingIDs: unique(recordingIDs)
+        )
+        batches.insert(batch, at: 0)
+        try save()
+        return batch
+    }
+
+    func update(batchID: UUID, name: String, description: String) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        batches[index].name = trimmedName.isEmpty
+            ? Self.defaultName(for: batches[index].createdAt)
+            : trimmedName
+        batches[index].description = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        try save()
+    }
+
+    func addRecordingIDs(_ recordingIDs: [UUID], to batchID: UUID) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        guard !batches[index].isProcessingClosed else {
+            throw StorageError.membershipClosed
+        }
+        batches[index].recordingIDs = unique(batches[index].recordingIDs + recordingIDs)
+        try save()
+    }
+
+    func close(batchID: UUID) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        batches[index].isProcessingClosed = true
+        try save()
+    }
+
+    func removeRecordingReferences(_ ids: Set<UUID>) throws {
+        guard !ids.isEmpty else { return }
+        for index in batches.indices {
+            batches[index].recordingIDs.removeAll(where: ids.contains)
+        }
+        try save()
+    }
+
+    @discardableResult
+    func delete(batchID: UUID) throws -> Set<UUID> {
+        guard let batch = batches.first(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        let affected = Set(batch.recordingIDs)
+        batches.removeAll { $0.id == batchID }
+        for index in batches.indices {
+            batches[index].recordingIDs.removeAll(where: affected.contains)
+        }
+        try save()
+        return affected
+    }
+
+    private func save() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(batches).write(to: metadataURL, options: .atomic)
+    }
+
+    private func unique(_ ids: [UUID]) -> [UUID] {
+        var seen = Set<UUID>()
+        return ids.filter { seen.insert($0).inserted }
+    }
+
+    private static func defaultName(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.dateFormat = "MMM d, yyyy, HH:mm"
+        return "Batch — \(formatter.string(from: date))"
+    }
+}

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -59,13 +59,21 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         return recordings.contains { recording in
             memberIDs.contains(recording.id)
                 && [
+                    recording.title,
+                    recording.description,
                     recording.sourceFileName,
                     recording.remoteSource?.title,
+                    recording.remoteSource?.channelName,
+                    recording.remoteSource?.canonicalURL.absoluteString,
                     recording.libraryDisplayName,
                     recording.transcriptionText,
                 ].compactMap { $0 }.contains {
                     $0.localizedCaseInsensitiveContains(normalized)
                 }
+                || memberIDs.contains(recording.id)
+                    && recording.resolvedTranscriptHistory.contains {
+                        $0.text.localizedCaseInsensitiveContains(normalized)
+                    }
         } || workItems?.contains {
             $0.displayName.localizedCaseInsensitiveContains(normalized)
                 || ($0.errorMessage?.localizedCaseInsensitiveContains(normalized) ?? false)
@@ -77,26 +85,61 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         let workItemRecordingIDs = Set((workItems ?? []).compactMap(\.recordingID))
         let recordingsMarkdown = recordingIDs.filter { !workItemRecordingIDs.contains($0) }.compactMap { id -> String? in
             guard let recording = byID[id] else { return nil }
-            let title = recording.remoteSource?.title
-                ?? recording.sourceFileName
-                ?? recording.libraryDisplayName
-            let body = recording.displayTranscriptText
-                ?? "[Transcript unavailable — \(recording.status.displayName)]"
-            return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
+            return recordingMarkdown(recording)
         }
         let workItemsMarkdown = (workItems ?? []).compactMap { item -> String? in
             if let recordingID = item.recordingID, let recording = byID[recordingID] {
-                let title = recording.remoteSource?.title
-                    ?? recording.sourceFileName
-                    ?? recording.libraryDisplayName
-                let body = recording.displayTranscriptText
-                    ?? "[Transcript unavailable — \(recording.status.displayName)]"
-                return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
+                return recordingMarkdown(recording)
             }
             let source = item.remoteSource == nil ? "File Transcription" : "YouTube"
-            return "# \(item.displayName)\n\nSource: \(source)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
+            return "## \(item.displayName)\n\nType: \(source)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
         }
-        return (recordingsMarkdown + workItemsMarkdown).joined(separator: "\n\n")
+        var header = "# \(name)"
+        if !description.isEmpty { header += "\n\n\(description)" }
+        header += "\n\nCreated: \(createdAt.formatted(.iso8601))"
+        return ([header] + recordingsMarkdown + workItemsMarkdown).joined(separator: "\n\n")
+    }
+
+    private func recordingMarkdown(_ recording: Recording) -> String {
+        let totalSeconds = max(0, Int(recording.durationSeconds.rounded()))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        let duration = hours > 0
+            ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
+            : String(format: "%d:%02d", minutes, seconds)
+        var metadata = [
+            "Type: \(recording.libraryDisplayName)",
+            "Duration: \(duration)",
+            "Date: \(recording.createdAt.formatted(.iso8601))",
+        ]
+        if let description = recording.description, !description.isEmpty {
+            metadata.append("Description: \(description)")
+        }
+        if let sourceURL = recording.remoteSource?.canonicalURL.absoluteString {
+            metadata.append("Source URL: \(sourceURL)")
+        }
+        let versions = recording.resolvedTranscriptHistory
+        let history = versions.isEmpty
+            ? "[Transcript unavailable — \(recording.status.displayName)]"
+            : versions.map { version in
+                var heading = switch version.kind {
+                case .cloud: "Cloud"
+                case .local: "Local"
+                case .translation: "Translation"
+                }
+                if version.kind == .translation,
+                   let source = version.sourceLanguageCode,
+                   let target = version.targetLanguageCode
+                {
+                    heading += " · \(source) → \(target)"
+                }
+                var details = ["Processed: \(version.createdAt.formatted(.iso8601))"]
+                if let provider = version.provider { details.append("Provider: \(provider)") }
+                if let model = version.modelIdentifier { details.append("Model: \(model)") }
+                return "### \(heading)\n\n\(details.joined(separator: "\n"))\n\n\(version.text)"
+            }.joined(separator: "\n\n")
+        return "## \(recording.displayTitle)\n\n\(metadata.joined(separator: "\n"))\n\n\(history)"
     }
 }
 
@@ -215,6 +258,9 @@ final class TranscriptionBatchStorage {
     func removeRecordingReferences(_ ids: Set<UUID>) throws {
         guard !ids.isEmpty else { return }
         for index in batches.indices {
+            batches[index].workItems?.filter { item in
+                item.recordingID.map(ids.contains) == true
+            }.forEach(removeDownloadedArtifact)
             batches[index].recordingIDs.removeAll(where: ids.contains)
             batches[index].workItems?.removeAll { item in
                 item.recordingID.map(ids.contains) == true
@@ -229,20 +275,32 @@ final class TranscriptionBatchStorage {
             throw StorageError.batchNotFound
         }
         let affected = Set(batch.recordingIDs)
+        batch.workItems?.forEach(removeDownloadedArtifact)
         batches.removeAll { $0.id == batchID }
         for index in batches.indices {
+            batches[index].workItems?.filter { item in
+                item.recordingID.map(affected.contains) == true
+            }.forEach(removeDownloadedArtifact)
             batches[index].recordingIDs.removeAll(where: affected.contains)
             batches[index].workItems?.removeAll { item in
                 item.recordingID.map(affected.contains) == true
             }
         }
-        for item in batch.workItems ?? [] {
-            if let url = item.downloadedAudioURL {
-                try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
-            }
-        }
         try save()
         return affected
+    }
+
+    private func removeDownloadedArtifact(_ item: BatchTranscriptionItem) {
+        guard let url = item.downloadedAudioURL?.standardizedFileURL else { return }
+        let fileManager = FileManager.default
+        try? fileManager.removeItem(at: url)
+
+        let parent = url.deletingLastPathComponent()
+        let temporaryRoot = fileManager.temporaryDirectory.standardizedFileURL.path + "/"
+        guard parent.path.hasPrefix(temporaryRoot),
+              (try? fileManager.contentsOfDirectory(atPath: parent.path).isEmpty) == true
+        else { return }
+        try? fileManager.removeItem(at: parent)
     }
 
     private func save() throws {

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -155,6 +155,14 @@ final class TranscriptionBatchStorage {
         try save()
     }
 
+    func replaceRecordingIDs(_ recordingIDs: [UUID], in batchID: UUID) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        batches[index].recordingIDs = unique(recordingIDs)
+        try save()
+    }
+
     func close(batchID: UUID) throws {
         guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
             throw StorageError.batchNotFound

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -13,6 +13,7 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
     let createdAt: Date
     var isProcessingClosed: Bool
     var recordingIDs: [UUID]
+    var workItems: [BatchTranscriptionItem]?
 
     init(
         id: UUID = UUID(),
@@ -20,7 +21,8 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         description: String = "",
         createdAt: Date = Date(),
         isProcessingClosed: Bool = false,
-        recordingIDs: [UUID] = []
+        recordingIDs: [UUID] = [],
+        workItems: [BatchTranscriptionItem]? = nil
     ) {
         self.id = id
         self.name = name
@@ -28,10 +30,16 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
         self.createdAt = createdAt
         self.isProcessingClosed = isProcessingClosed
         self.recordingIDs = recordingIDs
+        self.workItems = workItems
     }
 
     func status(in recordings: [Recording]) -> TranscriptionBatchStatus {
         guard isProcessingClosed else { return .processing }
+        if workItems?.contains(where: {
+            $0.status != .completed && $0.status != .duplicate
+        }) == true {
+            return .completedWithIssues
+        }
         let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
         return recordingIDs.allSatisfy { id in
             guard let recording = byID[id] else { return false }
@@ -58,12 +66,15 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                 ].compactMap { $0 }.contains {
                     $0.localizedCaseInsensitiveContains(normalized)
                 }
-        }
+        } || workItems?.contains {
+            $0.displayName.localizedCaseInsensitiveContains(normalized)
+                || ($0.errorMessage?.localizedCaseInsensitiveContains(normalized) ?? false)
+        } == true
     }
 
     func markdown(recordings: [Recording]) -> String {
         let byID = Dictionary(uniqueKeysWithValues: recordings.map { ($0.id, $0) })
-        return recordingIDs.compactMap { id -> String? in
+        let recordingsMarkdown = recordingIDs.compactMap { id -> String? in
             guard let recording = byID[id] else { return nil }
             let title = recording.remoteSource?.title
                 ?? recording.sourceFileName
@@ -71,7 +82,12 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
             let body = recording.displayTranscriptText
                 ?? "[Transcript unavailable — \(recording.status.displayName)]"
             return "# \(title)\n\nSource: \(recording.libraryDisplayName)\n\n\(body)"
-        }.joined(separator: "\n\n")
+        }
+        let unresolvedMarkdown = (workItems ?? []).compactMap { item -> String? in
+            guard item.recordingID == nil else { return nil }
+            return "# \(item.displayName)\n\nSource: \(item.sourceURL.absoluteString)\n\n[Transcript unavailable — \(item.errorMessage ?? "Not completed")]"
+        }
+        return (recordingsMarkdown + unresolvedMarkdown).joined(separator: "\n\n")
     }
 }
 
@@ -160,6 +176,22 @@ final class TranscriptionBatchStorage {
             throw StorageError.batchNotFound
         }
         batches[index].recordingIDs = unique(recordingIDs)
+        try save()
+    }
+
+    func replaceWorkItems(_ items: [BatchTranscriptionItem], in batchID: UUID) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        batches[index].workItems = items
+        try save()
+    }
+
+    func reopen(batchID: UUID) throws {
+        guard let index = batches.firstIndex(where: { $0.id == batchID }) else {
+            throw StorageError.batchNotFound
+        }
+        batches[index].isProcessingClosed = false
         try save()
     }
 

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -64,6 +64,7 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                     recording.sourceFileName,
                     recording.remoteSource?.title,
                     recording.remoteSource?.channelName,
+                    recording.remoteSource?.description,
                     recording.remoteSource?.canonicalURL.absoluteString,
                     recording.libraryDisplayName,
                     recording.transcriptionText,

--- a/Diduny/Features/Main/MainSection.swift
+++ b/Diduny/Features/Main/MainSection.swift
@@ -3,7 +3,6 @@ import SwiftUI
 enum MainSection: String, Hashable {
     case overview
     case recordings
-    case batches
     case typingTest
     case meetings
 
@@ -17,7 +16,6 @@ enum MainSection: String, Hashable {
         switch self {
         case .overview: "Overview"
         case .recordings: "Recordings"
-        case .batches: "Batches"
         case .typingTest: "Typing Test"
         case .meetings: "Meetings"
         case .general: "General"
@@ -32,7 +30,6 @@ enum MainSection: String, Hashable {
         switch self {
         case .overview: "square.grid.2x2"
         case .recordings: "waveform"
-        case .batches: "square.stack.3d.up"
         case .typingTest: "keyboard"
         case .meetings: "calendar"
         case .general: "gear"

--- a/Diduny/Features/Main/MainSection.swift
+++ b/Diduny/Features/Main/MainSection.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum MainSection: String, Hashable {
     case overview
     case recordings
+    case batches
     case typingTest
     case meetings
 
@@ -16,6 +17,7 @@ enum MainSection: String, Hashable {
         switch self {
         case .overview: "Overview"
         case .recordings: "Recordings"
+        case .batches: "Batches"
         case .typingTest: "Typing Test"
         case .meetings: "Meetings"
         case .general: "General"
@@ -30,6 +32,7 @@ enum MainSection: String, Hashable {
         switch self {
         case .overview: "square.grid.2x2"
         case .recordings: "waveform"
+        case .batches: "square.stack.3d.up"
         case .typingTest: "keyboard"
         case .meetings: "calendar"
         case .general: "gear"

--- a/Diduny/Features/Main/MainWindowController.swift
+++ b/Diduny/Features/Main/MainWindowController.swift
@@ -6,9 +6,11 @@ import SwiftUI
 @MainActor
 final class MainWindowController {
     static let shared = MainWindowController()
+    static let batchComposerActionTitle = "Batch Files and URLs…"
 
     var requestedSection: MainSection?
     var requestedRecordingID: UUID?
+    var requestedBatchComposer = false
 
     private var window: NSWindow?
     private var windowDelegate: MainWindowDelegate?
@@ -46,6 +48,11 @@ final class MainWindowController {
     func showRecording(id: UUID) {
         requestedRecordingID = id
         showWindow(section: .recordings)
+    }
+
+    func requestBatchComposer() {
+        requestedBatchComposer = true
+        requestedSection = .recordings
     }
 
     func closeWindow() {

--- a/Diduny/Features/Main/MainWindowView.swift
+++ b/Diduny/Features/Main/MainWindowView.swift
@@ -65,6 +65,8 @@ struct MainWindowView: View {
         case .recordings:
             RecordingsLibraryView()
                 .environment(audioDeviceManager)
+        case .batches:
+            TranscriptionBatchesView()
         case .typingTest:
             TypingTestView()
         case .meetings:

--- a/Diduny/Features/Main/MainWindowView.swift
+++ b/Diduny/Features/Main/MainWindowView.swift
@@ -65,8 +65,6 @@ struct MainWindowView: View {
         case .recordings:
             RecordingsLibraryView()
                 .environment(audioDeviceManager)
-        case .batches:
-            TranscriptionBatchesView()
         case .typingTest:
             TypingTestView()
         case .meetings:

--- a/Diduny/Features/Main/SidebarView.swift
+++ b/Diduny/Features/Main/SidebarView.swift
@@ -117,9 +117,12 @@ struct SidebarView: View {
             }
             .focusable(false)
             .accessibilityLabel(Text(section.label))
-            .accessibilityValue(Text(section.isBetaDisabled ? "Beta, unavailable" : selectedSection == section ? "Selected" : ""))
+            .accessibilityValue(Text(section
+                    .isBetaDisabled ? "Beta, unavailable" : selectedSection == section ? "Selected" : ""))
             .accessibilityIdentifier("Sidebar \(section.label)")
-            .help(section.isBetaDisabled ? "Meetings is in beta. Meeting recordings are available in Recordings." : section.label)
+            .help(section
+                .isBetaDisabled ? "Meetings is in beta. Meeting recordings are available in Recordings." : section
+                .label)
     }
 }
 

--- a/Diduny/Features/Main/SidebarView.swift
+++ b/Diduny/Features/Main/SidebarView.swift
@@ -6,7 +6,7 @@ struct SidebarView: View {
 
     let topInset: CGFloat
 
-    private let mainItems: [MainSection] = [.overview, .recordings, .typingTest, .meetings]
+    private let mainItems: [MainSection] = [.overview, .recordings, .batches, .typingTest, .meetings]
     private let settingsItems: [MainSection] = [.general, .audioDictation, .models, .shortcuts, .account]
 
     init(selectedSection: Binding<MainSection>, topInset: CGFloat = 34) {

--- a/Diduny/Features/Main/SidebarView.swift
+++ b/Diduny/Features/Main/SidebarView.swift
@@ -6,7 +6,7 @@ struct SidebarView: View {
 
     let topInset: CGFloat
 
-    private let mainItems: [MainSection] = [.overview, .recordings, .batches, .typingTest, .meetings]
+    private let mainItems: [MainSection] = [.overview, .recordings, .typingTest, .meetings]
     private let settingsItems: [MainSection] = [.general, .audioDictation, .models, .shortcuts, .account]
 
     init(selectedSection: Binding<MainSection>, topInset: CGFloat = 34) {

--- a/Diduny/Features/MenuBar/MenuBarContentView.swift
+++ b/Diduny/Features/MenuBar/MenuBarContentView.swift
@@ -35,8 +35,7 @@ struct MenuBarContentView: View {
     var onToggleTranslationRecording: @MainActor () -> Void
     var onToggleMeetingRecording: @MainActor () -> Void
     var onToggleMeetingTranslationRecording: @MainActor () -> Void
-    var onTranscribeFiles: @MainActor () -> Void
-    var onTranscribeURL: @MainActor () -> Void
+    var onBatchFilesAndURLs: @MainActor () -> Void
     var onOpenMainWindow: @MainActor (MainSection) -> Void
     var onCheckForUpdates: @MainActor () -> Void
 
@@ -123,12 +122,8 @@ struct MenuBarContentView: View {
                 onOpenMainWindow(.overview)
             }
 
-            Button(transcribeFilesTitle, action: onTranscribeFiles)
-                .disabled(appState.recordingState == .processing)
-
-            Button("Transcribe URL…", action: onTranscribeURL)
-                .keyboardShortcut("u", modifiers: [.command, .shift])
-                .disabled(appState.recordingState == .processing)
+            Button(MainWindowController.batchComposerActionTitle, action: onBatchFilesAndURLs)
+                .keyboardShortcut("b", modifiers: [.command, .shift])
 
             Button("Recordings") {
                 onOpenMainWindow(.recordings)
@@ -179,12 +174,6 @@ struct MenuBarContentView: View {
         case .error:
             "Dictation"
         }
-    }
-
-    private var transcribeFilesTitle: String {
-        let batch = FileTranscriptionBatchService.shared
-        guard batch.isProcessing else { return "Transcribe Files…" }
-        return "Transcription Batch (\(batch.finishedCount)/\(batch.items.count))…"
     }
 
     private func isInProgress(_ state: RecordingState) -> Bool {

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -3,9 +3,10 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct RecordingDetailView: View {
-    @Environment(\.dismiss) private var dismiss
-
     let recording: Recording
+    let parentBatchName: String?
+    let onBack: (() -> Void)?
+    let onClose: () -> Void
 
     @State private var playbackService = AudioPlaybackService.shared
     @State private var queueService = RecordingQueueService.shared
@@ -15,6 +16,23 @@ struct RecordingDetailView: View {
     @State private var showRetranscriptionConfirmation = false
     @State private var requestedRetranscriptionProvider: TranscriptionProvider = .cloud
     @State private var requestedWhisperModel: String?
+    @State private var title: String
+    @State private var description: String
+    @State private var showDeleteConfirmation = false
+
+    init(
+        recording: Recording,
+        parentBatchName: String? = nil,
+        onBack: (() -> Void)? = nil,
+        onClose: @escaping () -> Void = {}
+    ) {
+        self.recording = recording
+        self.parentBatchName = parentBatchName
+        self.onBack = onBack
+        self.onClose = onClose
+        _title = State(initialValue: recording.title ?? recording.displayTitle)
+        _description = State(initialValue: recording.description ?? recording.remoteSource?.description ?? "")
+    }
 
     private var currentRecording: Recording {
         storage.recordings.first(where: { $0.id == recording.id }) ?? recording
@@ -32,6 +50,10 @@ struct RecordingDetailView: View {
     private var otherLanguages: [SupportedLanguage] {
         let favCodes = Set(SettingsStorage.shared.favoriteLanguages)
         return SupportedLanguage.allLanguages.filter { !favCodes.contains($0.code) }
+    }
+
+    private var translationPair: TranslationLanguagePair {
+        SettingsStorage.shared.resolveTranslationLanguagePair()
     }
 
     private var queueStatusText: String? {
@@ -65,6 +87,11 @@ struct RecordingDetailView: View {
 
             Divider()
 
+            detailsSection
+                .padding(12)
+
+            Divider()
+
             // Playback
             playbackSection
                 .padding(12)
@@ -81,17 +108,29 @@ struct RecordingDetailView: View {
                 .padding(12)
         }
         .onExitCommand {
-            dismiss()
+            onClose()
         }
         .alert("Transcribe Again?", isPresented: $showRetranscriptionConfirmation) {
-            Button("Replace Generated Transcript", role: .destructive) {
+            Button("Transcribe Again") {
                 enqueueRequestedRetranscription()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
-                "This replaces the generated transcript in this recording. Source captions and YouTube identity stay unchanged."
+                "This adds a new transcript version. Earlier transcripts, source captions, and YouTube identity stay available."
             )
+        }
+        .alert("Delete Recording and Files?", isPresented: $showDeleteConfirmation) {
+            Button("Delete Recording", role: .destructive) {
+                if playbackService.playingRecordingId == currentRecording.id {
+                    playbackService.stop()
+                }
+                storage.deleteRecording(currentRecording)
+                onClose()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently deletes the recording, stored media, transcript history, translations, and every batch reference.")
         }
     }
 
@@ -99,12 +138,20 @@ struct RecordingDetailView: View {
 
     private var header: some View {
         HStack(spacing: 10) {
+            if let onBack {
+                Button(action: onBack) {
+                    Label("Back to \(parentBatchName ?? "Batch")", systemImage: "chevron.left")
+                }
+                .buttonStyle(.plain)
+                .help("Back to \(parentBatchName ?? "Batch")")
+            }
+
             Image(systemName: currentRecording.libraryIconName)
                 .font(.title2)
                 .foregroundColor(iconColor)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(currentRecording.libraryDisplayName)
+                Text(currentRecording.displayTitle)
                     .font(.headline)
 
                 HStack(spacing: 8) {
@@ -143,11 +190,45 @@ struct RecordingDetailView: View {
                     )
 
                 Button("Close") {
-                    dismiss()
+                    onClose()
                 }
                 .keyboardShortcut(.cancelAction)
                 .controlSize(.small)
                 .accessibilityIdentifier("Close recording detail")
+            }
+        }
+    }
+
+    private var detailsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("DETAILS")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextField("Recording title", text: $title)
+            TextField("Description", text: $description, axis: .vertical)
+                .lineLimit(2 ... 4)
+            if let remoteSource = currentRecording.remoteSource {
+                HStack(spacing: 6) {
+                    Link(destination: remoteSource.canonicalURL) {
+                        Label("Open YouTube Source", systemImage: "link")
+                    }
+                    .lineLimit(1)
+                    if let channel = remoteSource.channelName {
+                        Text("· \(channel)").foregroundStyle(.secondary).lineLimit(1)
+                    }
+                }
+                .font(.caption)
+            }
+            HStack {
+                Spacer()
+                Button("Save Details") {
+                    storage.updateDetails(
+                        id: currentRecording.id,
+                        title: title,
+                        description: description
+                    )
+                }
+                .controlSize(.small)
             }
         }
     }
@@ -167,38 +248,33 @@ struct RecordingDetailView: View {
     private var transcriptionSection: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                Group {
-                    if currentRecording.status == .processing {
-                        HStack {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text(queueStatusText ?? "Processing...")
-                                .foregroundColor(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else if let text = currentRecording.displayTranscriptText {
-                        VStack(alignment: .leading, spacing: 8) {
-                            if currentRecording.isYouTubeVideo,
-                               currentRecording.transcriptSegments?.isEmpty ?? true
-                            {
-                                Text("Timestamps were not stored for this transcript. Transcribe Again to add them.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                            Text(text)
-                                .textSelection(.enabled)
-                                .font(.body)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    } else if currentRecording.status == .failed {
-                        Text(currentRecording.errorMessage ?? "Transcription failed")
-                            .foregroundColor(.red)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else {
-                        Text("No transcription yet")
-                            .foregroundColor(.secondary)
-                            .italic()
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                Text("TRANSCRIPT HISTORY")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                if currentRecording.status == .processing {
+                    HStack {
+                        ProgressView().controlSize(.small)
+                        Text(queueStatusText ?? "Processing...").foregroundStyle(.secondary)
+                    }
+                } else if currentRecording.status == .failed {
+                    Label(
+                        currentRecording.errorMessage ?? "Transcription failed",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.red)
+                }
+
+                let versions = currentRecording.resolvedTranscriptHistory.sorted {
+                    $0.createdAt > $1.createdAt
+                }
+                if versions.isEmpty {
+                    Text("No transcription yet")
+                        .foregroundStyle(.secondary)
+                        .italic()
+                } else {
+                    ForEach(versions) { version in
+                        transcriptCard(version)
                     }
                 }
 
@@ -247,6 +323,51 @@ struct RecordingDetailView: View {
         .frame(maxHeight: .infinity)
     }
 
+    private func transcriptCard(_ version: TranscriptVersion) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(transcriptVersionTitle(version)).font(.headline)
+                    Text(version.createdAt.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button {
+                    ClipboardService.shared.copy(text: version.text, behavior: .raw)
+                } label: {
+                    Label("Copy Transcript", systemImage: "doc.on.doc")
+                }
+                .controlSize(.small)
+            }
+            Text(transcriptVersionText(version))
+                .textSelection(.enabled)
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func transcriptVersionTitle(_ version: TranscriptVersion) -> String {
+        switch version.kind {
+        case .cloud:
+            return "Cloud Transcript"
+        case .local:
+            return version.modelIdentifier.map { "Local Transcript · \($0)" } ?? "Local Transcript"
+        case .translation:
+            if let source = version.sourceLanguageCode, let target = version.targetLanguageCode {
+                return "Translation · \(source.uppercased()) → \(target.uppercased())"
+            }
+            return "Translation"
+        }
+    }
+
+    private func transcriptVersionText(_ version: TranscriptVersion) -> String {
+        guard let segments = version.segments, !segments.isEmpty else { return version.text }
+        return segments.map { "[\($0.timestampLabel)] \($0.text)" }.joined(separator: "\n\n")
+    }
+
     // MARK: - Actions
 
     private func exportCaption(_ artifact: TranscriptArtifact) {
@@ -268,20 +389,10 @@ struct RecordingDetailView: View {
             // Local (Whisper) section
             localActionsSection
 
-            // Copy text button
-            if let text = currentRecording.displayTranscriptText {
-                Divider()
-                HStack {
-                    Spacer()
-                    Button("Copy Text") {
-                        ClipboardService.shared.copy(
-                            text: text,
-                            behavior: currentRecording.remoteSource == nil
-                                ? currentRecording.type.clipboardCopyBehavior
-                                : .raw
-                        )
-                    }
-                }
+            Divider()
+
+            Button("Delete Recording", role: .destructive) {
+                showDeleteConfirmation = true
             }
         }
     }
@@ -295,7 +406,11 @@ struct RecordingDetailView: View {
                 .foregroundColor(Color("BrandAccentDeep"))
 
             VStack(alignment: .leading, spacing: 6) {
-                Button(currentRecording.remoteSource == nil ? "Transcribe" : "Transcribe Again…") {
+                Button(
+                    currentRecording.resolvedTranscriptHistory.isEmpty
+                        ? "Transcribe in Cloud"
+                        : "Transcribe Again in Cloud…"
+                ) {
                     requestRetranscription(provider: .cloud)
                 }
                 .disabled(currentRecording.status == .processing)
@@ -311,48 +426,33 @@ struct RecordingDetailView: View {
                     .disabled(currentRecording.status == .processing)
                 }
 
-                HStack(spacing: 6) {
-                    Text("Translate:")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 4) {
-                            ForEach(favoriteLanguages) { lang in
-                                Button(lang.code.uppercased()) {
-                                    queueService.enqueue(
-                                        [currentRecording.id],
-                                        action: .translate,
-                                        providerOverride: .cloud,
-                                        targetLanguage: lang.code
-                                    )
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                                .disabled(currentRecording.status == .processing)
-                                .help(lang.name)
-                            }
-
-                            if !otherLanguages.isEmpty {
-                                Menu("...") {
-                                    ForEach(otherLanguages) { lang in
-                                        Button(lang.name) {
-                                            queueService.enqueue(
-                                                [currentRecording.id],
-                                                action: .translate,
-                                                providerOverride: .cloud,
-                                                targetLanguage: lang.code
-                                            )
-                                        }
-                                    }
-                                }
-                                .menuStyle(.borderlessButton)
-                                .controlSize(.small)
-                                .disabled(currentRecording.status == .processing)
-                            }
-                        }
+                Menu {
+                    ForEach(favoriteLanguages) { lang in
+                        Button(lang.name) { translate(to: lang.code) }
                     }
+                    if !favoriteLanguages.isEmpty && !otherLanguages.isEmpty { Divider() }
+                    ForEach(otherLanguages) { lang in
+                        Button(lang.name) { translate(to: lang.code) }
+                    }
+                } label: {
+                    HStack {
+                        Text(
+                            "Translate: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "Choose Language")"
+                        )
+                        Spacer()
+                        Image(systemName: "chevron.down")
+                            .font(.caption2)
+                    }
+                    .frame(maxWidth: .infinity)
                 }
+                .menuStyle(.borderlessButton)
+                .disabled(currentRecording.status == .processing)
+
+                Text(
+                    "Translation direction: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "choose a language")"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
         }
     }
@@ -396,6 +496,15 @@ struct RecordingDetailView: View {
     }
 
     // MARK: - Helpers
+
+    private func translate(to languageCode: String) {
+        queueService.enqueue(
+            [currentRecording.id],
+            action: .translate,
+            providerOverride: .cloud,
+            targetLanguage: languageCode
+        )
+    }
 
     private func requestRetranscription(
         provider: TranscriptionProvider,

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -130,7 +130,9 @@ struct RecordingDetailView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This permanently deletes the recording, stored media, transcript history, translations, and every batch reference.")
+            Text(
+                "This permanently deletes the recording, stored media, transcript history, translations, and every batch reference."
+            )
         }
     }
 
@@ -430,7 +432,7 @@ struct RecordingDetailView: View {
                     ForEach(favoriteLanguages) { lang in
                         Button(lang.name) { translate(to: lang.code) }
                     }
-                    if !favoriteLanguages.isEmpty && !otherLanguages.isEmpty { Divider() }
+                    if !favoriteLanguages.isEmpty, !otherLanguages.isEmpty { Divider() }
                     ForEach(otherLanguages) { lang in
                         Button(lang.name) { translate(to: lang.code) }
                     }

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -19,6 +19,7 @@ struct RecordingDetailView: View {
     @State private var title: String
     @State private var description: String
     @State private var showDeleteConfirmation = false
+    @State private var operationErrorMessage: String?
 
     init(
         recording: Recording,
@@ -125,14 +126,28 @@ struct RecordingDetailView: View {
                 if playbackService.playingRecordingId == currentRecording.id {
                     playbackService.stop()
                 }
-                storage.deleteRecording(currentRecording)
-                onClose()
+                if storage.deleteRecording(currentRecording) {
+                    onClose()
+                } else {
+                    operationErrorMessage = "The recording and its files were left unchanged."
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(
                 "This permanently deletes the recording, stored media, transcript history, translations, and every batch reference."
             )
+        }
+        .alert(
+            "Recording Change Failed",
+            isPresented: Binding(
+                get: { operationErrorMessage != nil },
+                set: { if !$0 { operationErrorMessage = nil } }
+            )
+        ) {
+            Button("OK") { operationErrorMessage = nil }
+        } message: {
+            Text(operationErrorMessage ?? "Unknown error")
         }
     }
 
@@ -224,11 +239,13 @@ struct RecordingDetailView: View {
             HStack {
                 Spacer()
                 Button("Save Details") {
-                    storage.updateDetails(
+                    if !storage.updateDetails(
                         id: currentRecording.id,
                         title: title,
                         description: description
-                    )
+                    ) {
+                        operationErrorMessage = "The title and description were left unchanged."
+                    }
                 }
                 .controlSize(.small)
             }

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -82,31 +82,35 @@ struct RecordingDetailView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Header
             header
-                .padding(12)
+                .padding(16)
 
             Divider()
 
-            detailsSection
-                .padding(12)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    detailsSection
+                        .padding(16)
 
-            Divider()
+                    if currentRecording.remoteSource != nil {
+                        Divider()
+                        youtubeSourceSection
+                            .padding(16)
+                    }
 
-            // Playback
-            playbackSection
-                .padding(12)
+                    Divider()
+                    playbackAndProcessingSection
+                        .padding(16)
 
-            Divider()
+                    Divider()
+                    transcriptionSection
+                        .padding(16)
 
-            // Transcription text
-            transcriptionSection
-
-            Divider()
-
-            // Actions
-            actionsSection
-                .padding(12)
+                    Divider()
+                    deleteSection
+                        .padding(16)
+                }
+            }
         }
         .onExitCommand {
             onClose()
@@ -154,63 +158,49 @@ struct RecordingDetailView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(spacing: 10) {
+        VStack(alignment: .leading, spacing: 12) {
             if let onBack {
                 Button(action: onBack) {
-                    Label("Back to \(parentBatchName ?? "Batch")", systemImage: "chevron.left")
+                    Label("Back to Batch", systemImage: "chevron.left")
                 }
                 .buttonStyle(.plain)
                 .help("Back to \(parentBatchName ?? "Batch")")
             }
 
-            Image(systemName: currentRecording.libraryIconName)
-                .font(.title2)
-                .foregroundColor(iconColor)
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: currentRecording.libraryIconName)
+                    .font(.title2)
+                    .foregroundColor(iconColor)
+                    .frame(width: 28, height: 28)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(currentRecording.displayTitle)
-                    .font(.headline)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(currentRecording.displayTitle)
+                        .font(.headline)
+                        .lineLimit(2)
 
-                HStack(spacing: 8) {
-                    Text(formattedDate)
+                    Text("\(currentRecording.libraryDisplayName) · \(formattedDuration) · \(formattedDate)")
                         .font(.caption)
                         .foregroundColor(.secondary)
+                        .lineLimit(2)
 
-                    Text(formattedDuration)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    Text(formattedSize)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if let sourceDevice = currentRecording.sourceDevice {
+                        Text(deviceSummary(sourceDevice))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
                 }
 
-                if let sourceDevice = currentRecording.sourceDevice {
-                    Text(deviceSummary(sourceDevice))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
-            }
+                Spacer(minLength: 8)
 
-            Spacer()
-
-            HStack(spacing: 8) {
-                Text("Esc")
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 3)
-                    .background(
-                        Color(.quaternaryLabelColor).opacity(0.12),
-                        in: RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    )
-
-                Button("Close") {
+                Button {
                     onClose()
+                } label: {
+                    Image(systemName: "xmark")
                 }
+                .buttonStyle(.plain)
                 .keyboardShortcut(.cancelAction)
-                .controlSize(.small)
+                .help("Close (Esc)")
                 .accessibilityIdentifier("Close recording detail")
             }
         }
@@ -224,18 +214,6 @@ struct RecordingDetailView: View {
             TextField("Recording title", text: $title)
             TextField("Description", text: $description, axis: .vertical)
                 .lineLimit(2 ... 4)
-            if let remoteSource = currentRecording.remoteSource {
-                HStack(spacing: 6) {
-                    Link(destination: remoteSource.canonicalURL) {
-                        Label("Open YouTube Source", systemImage: "link")
-                    }
-                    .lineLimit(1)
-                    if let channel = remoteSource.channelName {
-                        Text("· \(channel)").foregroundStyle(.secondary).lineLimit(1)
-                    }
-                }
-                .font(.caption)
-            }
             HStack {
                 Spacer()
                 Button("Save Details") {
@@ -252,7 +230,35 @@ struct RecordingDetailView: View {
         }
     }
 
-    // MARK: - Playback
+    private var youtubeSourceSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("YOUTUBE SOURCE")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if let remoteSource = currentRecording.remoteSource {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(remoteSource.title)
+                        .font(.callout.weight(.medium))
+                        .lineLimit(2)
+                    Link(remoteSource.canonicalURL.absoluteString, destination: remoteSource.canonicalURL)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let channel = remoteSource.channelName {
+                        Text(channel)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+    }
+
+    // MARK: - Playback and processing
 
     private var playbackSection: some View {
         AudioPlaybackControlView(
@@ -262,84 +268,114 @@ struct RecordingDetailView: View {
         )
     }
 
+    private var playbackAndProcessingSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("PLAYBACK")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            playbackSection
+                .padding(12)
+                .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+
+            HStack(spacing: 8) {
+                localTranscriptionButton
+                cloudTranscriptionButton
+            }
+
+            translationMenu
+        }
+    }
+
     // MARK: - Transcription
 
     private var transcriptionSection: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
                 Text("TRANSCRIPT HISTORY")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-
-                if currentRecording.status == .processing {
-                    HStack {
-                        ProgressView().controlSize(.small)
-                        Text(queueStatusText ?? "Processing...").foregroundStyle(.secondary)
-                    }
-                } else if currentRecording.status == .failed {
-                    Label(
-                        currentRecording.errorMessage ?? "Transcription failed",
-                        systemImage: "exclamationmark.triangle.fill"
+                Spacer()
+                Text("\(currentRecording.resolvedTranscriptHistory.count) versions")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(
+                        Color(.quaternaryLabelColor).opacity(0.12),
+                        in: Capsule()
                     )
-                    .foregroundStyle(.red)
-                }
+            }
 
-                let versions = currentRecording.resolvedTranscriptHistory.sorted {
-                    $0.createdAt > $1.createdAt
+            if currentRecording.status == .processing {
+                HStack {
+                    ProgressView().controlSize(.small)
+                    Text(queueStatusText ?? "Processing...").foregroundStyle(.secondary)
                 }
-                if versions.isEmpty {
-                    Text("No transcription yet")
-                        .foregroundStyle(.secondary)
-                        .italic()
-                } else {
-                    ForEach(versions) { version in
-                        transcriptCard(version)
-                    }
-                }
+            } else if currentRecording.status == .failed {
+                Label(
+                    currentRecording.errorMessage ?? "Transcription failed",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .foregroundStyle(.red)
+            }
 
-                if let artifacts = currentRecording.sourceCaptionArtifacts,
-                   !artifacts.isEmpty
-                {
-                    Divider()
-                    ForEach(Array(artifacts.enumerated()), id: \.offset) { _, artifact in
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack {
-                                Label(
-                                    artifact.provenance == .youtubeAuthored
-                                        ? "YouTube Captions · Authored"
-                                        : "YouTube Captions · Automatic",
-                                    systemImage: "captions.bubble"
-                                )
-                                .font(.headline)
-                                Spacer()
-                                Button("Export…") {
-                                    exportCaption(artifact)
-                                }
-                                .controlSize(.small)
-                                Button("Copy Captions") {
-                                    ClipboardService.shared.copy(
-                                        text: artifact.text,
-                                        behavior: .raw
-                                    )
-                                }
-                                .controlSize(.small)
+            let versions = currentRecording.resolvedTranscriptHistory.sorted {
+                $0.createdAt > $1.createdAt
+            }
+            if versions.isEmpty {
+                Text("No transcription yet")
+                    .foregroundStyle(.secondary)
+                    .italic()
+            } else {
+                ForEach(versions) { version in
+                    transcriptCard(version)
+                }
+            }
+
+            if let artifacts = currentRecording.sourceCaptionArtifacts,
+               !artifacts.isEmpty
+            {
+                Divider()
+                ForEach(Array(artifacts.enumerated()), id: \.offset) { _, artifact in
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Label(
+                                artifact.provenance == .youtubeAuthored
+                                    ? "YouTube Captions · Authored"
+                                    : "YouTube Captions · Automatic",
+                                systemImage: "captions.bubble"
+                            )
+                            .font(.headline)
+                            Spacer()
+                            Button("Export…") {
+                                exportCaption(artifact)
                             }
+                            .controlSize(.small)
+                            Button("Copy Captions") {
+                                ClipboardService.shared.copy(
+                                    text: artifact.text,
+                                    behavior: .raw
+                                )
+                            }
+                            .controlSize(.small)
+                        }
+                        ScrollView {
                             Text(artifact.text)
                                 .textSelection(.enabled)
                                 .font(.body)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .padding(12)
-                        .background(
-                            Color(.textBackgroundColor),
-                            in: RoundedRectangle(cornerRadius: 8)
-                        )
+                        .frame(maxHeight: 190)
                     }
+                    .padding(12)
+                    .background(
+                        Color(.textBackgroundColor),
+                        in: RoundedRectangle(cornerRadius: 8)
+                    )
                 }
             }
-            .padding(12)
         }
-        .frame(maxHeight: .infinity)
     }
 
     private func transcriptCard(_ version: TranscriptVersion) -> some View {
@@ -359,10 +395,13 @@ struct RecordingDetailView: View {
                 }
                 .controlSize(.small)
             }
-            Text(transcriptVersionText(version))
-                .textSelection(.enabled)
-                .font(.body)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            ScrollView {
+                Text(transcriptVersionText(version))
+                    .textSelection(.enabled)
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 190)
         }
         .padding(12)
         .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
@@ -387,7 +426,7 @@ struct RecordingDetailView: View {
         return segments.map { "[\($0.timestampLabel)] \($0.text)" }.joined(separator: "\n\n")
     }
 
-    // MARK: - Actions
+    // MARK: - Processing actions
 
     private func exportCaption(_ artifact: TranscriptArtifact) {
         let panel = NSSavePanel()
@@ -398,43 +437,13 @@ struct RecordingDetailView: View {
         try? artifact.text.write(to: url, atomically: true, encoding: .utf8)
     }
 
-    private var actionsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // Cloud section
-            cloudActionsSection
-
-            Divider()
-
-            // Local (Whisper) section
-            localActionsSection
-
-            Divider()
-
-            Button("Delete Recording", role: .destructive) {
-                showDeleteConfirmation = true
-            }
-        }
-    }
-
-    // MARK: - Cloud Actions
-
-    private var cloudActionsSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label("Cloud", systemImage: "cloud.fill")
-                .font(.caption)
-                .foregroundColor(Color("BrandAccentDeep"))
-
-            VStack(alignment: .leading, spacing: 6) {
-                Button(
-                    currentRecording.resolvedTranscriptHistory.isEmpty
-                        ? "Transcribe in Cloud"
-                        : "Transcribe Again in Cloud…"
-                ) {
-                    requestRetranscription(provider: .cloud)
-                }
-                .disabled(currentRecording.status == .processing)
-
-                if supportsSpeakerLabels {
+    private var cloudTranscriptionButton: some View {
+        Group {
+            if supportsSpeakerLabels {
+                Menu {
+                    Button("Standard Transcription") {
+                        requestRetranscription(provider: .cloud)
+                    }
                     Button("Transcribe with Speakers") {
                         queueService.enqueue(
                             [currentRecording.id],
@@ -442,76 +451,98 @@ struct RecordingDetailView: View {
                             providerOverride: .cloud
                         )
                     }
-                    .disabled(currentRecording.status == .processing)
-                }
-
-                Menu {
-                    ForEach(favoriteLanguages) { lang in
-                        Button(lang.name) { translate(to: lang.code) }
-                    }
-                    if !favoriteLanguages.isEmpty, !otherLanguages.isEmpty { Divider() }
-                    ForEach(otherLanguages) { lang in
-                        Button(lang.name) { translate(to: lang.code) }
-                    }
                 } label: {
-                    HStack {
-                        Text(
-                            "Translate: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "Choose Language")"
-                        )
-                        Spacer()
-                        Image(systemName: "chevron.down")
-                            .font(.caption2)
-                    }
-                    .frame(maxWidth: .infinity)
+                    Label("Transcribe in Cloud", systemImage: "cloud")
+                        .frame(maxWidth: .infinity)
                 }
-                .menuStyle(.borderlessButton)
-                .disabled(currentRecording.status == .processing)
+            } else {
+                Button {
+                    requestRetranscription(provider: .cloud)
+                } label: {
+                    Label("Transcribe in Cloud", systemImage: "cloud")
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .buttonStyle(.bordered)
+        .disabled(currentRecording.status == .processing)
+        .frame(maxWidth: .infinity)
+    }
 
-                Text(
-                    "Translation direction: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "choose a language")"
-                )
-                .font(.caption)
+    private var localTranscriptionButton: some View {
+        Button {
+            let modelName = selectedWhisperModel.isEmpty
+                ? downloadedWhisperModels.first?.name
+                : selectedWhisperModel
+            requestRetranscription(provider: .local, whisperModel: modelName)
+        } label: {
+            Label("Transcribe Locally", systemImage: "waveform")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .disabled(currentRecording.status == .processing || downloadedWhisperModels.isEmpty)
+        .frame(maxWidth: .infinity)
+        .help(
+            downloadedWhisperModels.isEmpty
+                ? "Download a Whisper model in Settings first."
+                : "Uses \(selectedLocalModelName)."
+        )
+    }
+
+    private var translationMenu: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Menu {
+                ForEach(favoriteLanguages) { lang in
+                    Button(lang.name) { translate(to: lang.code) }
+                }
+                if !favoriteLanguages.isEmpty, !otherLanguages.isEmpty { Divider() }
+                ForEach(otherLanguages) { lang in
+                    Button(lang.name) { translate(to: lang.code) }
+                }
+            } label: {
+                HStack {
+                    Text(
+                        "Translate: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "Choose Language")"
+                    )
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.caption2)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .menuStyle(.borderlessButton)
+            .disabled(currentRecording.status == .processing)
+
+            Text(
+                "Translation direction: \(translationPair.languageA.uppercased()) → \(currentRecording.translationTargetLanguageCode?.uppercased() ?? "choose a language")"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var deleteSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("DELETE RECORDING")
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
+            Text(
+                "This permanently deletes the recording, all source media and generated files, every transcript and translation version, and removes it from attached batches."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            Button("Delete Recording…", role: .destructive) {
+                showDeleteConfirmation = true
             }
         }
     }
 
-    // MARK: - Local Actions
-
-    private var localActionsSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label("Local (Whisper.cpp)", systemImage: "desktopcomputer")
-                .font(.caption)
-                .foregroundColor(.green)
-
-            if !downloadedWhisperModels.isEmpty {
-                HStack(spacing: 8) {
-                    Picker("Model:", selection: $selectedWhisperModel) {
-                        ForEach(downloadedWhisperModels) { model in
-                            Text(model.displayName).tag(model.name)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .frame(maxWidth: 200)
-
-                    Button(currentRecording.remoteSource == nil ? "Transcribe Locally" : "Transcribe Again Locally…") {
-                        let modelName = selectedWhisperModel.isEmpty ? downloadedWhisperModels.first?
-                            .name : selectedWhisperModel
-                        requestRetranscription(provider: .local, whisperModel: modelName)
-                    }
-                    .disabled(currentRecording.status == .processing)
-                }
-
-                Text("Use this when you want offline processing with the selected Whisper model.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            } else {
-                Text("Only Whisper-compatible local models are supported right now. Download one in Settings.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .italic()
-            }
-        }
+    private var selectedLocalModelName: String {
+        downloadedWhisperModels
+            .first(where: { $0.name == selectedWhisperModel })?
+            .displayName
+            ?? downloadedWhisperModels.first?.displayName
+            ?? "the selected local model"
     }
 
     // MARK: - Helpers
@@ -569,10 +600,6 @@ struct RecordingDetailView: View {
         let minutes = Int(currentRecording.durationSeconds) / 60
         let seconds = Int(currentRecording.durationSeconds) % 60
         return String(format: "%d:%02d", minutes, seconds)
-    }
-
-    private var formattedSize: String {
-        ByteCountFormatter.string(fromByteCount: currentRecording.fileSizeBytes, countStyle: .file)
     }
 
     private func deviceSummary(_ sourceDevice: RecordingDeviceInfo) -> String {

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -137,7 +137,8 @@ struct RecordingsLibraryView: View {
             set: { if !$0 { inspectorSelection = nil } }
         )) {
             inspectorContent
-                .frame(minWidth: 380, idealWidth: 430, minHeight: 500)
+                .inspectorColumnWidth(min: 380, ideal: 430, max: 500)
+                .frame(minHeight: 500)
         }
         .sheet(isPresented: $showBatchComposer) {
             NewTranscriptionBatchSheet(recordings: storage.recordings)

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -154,13 +154,13 @@ struct RecordingsLibraryView: View {
         }
         .alert("Delete Recording", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
-                if let r = recordingToDelete {
-                    if playbackService.playingRecordingId == r.id {
+                if let recording = recordingToDelete {
+                    if playbackService.playingRecordingId == recording.id {
                         playbackService.stop()
                     }
-                    if storage.deleteRecording(r) {
-                        selectedRecordingIds.remove(r.id)
-                        if case let .recording(id, _) = inspectorSelection, id == r.id {
+                    if storage.deleteRecording(recording) {
+                        selectedRecordingIds.remove(recording.id)
+                        if case let .recording(id, _) = inspectorSelection, id == recording.id {
                             inspectorSelection = nil
                         }
                     } else {

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -18,6 +18,7 @@ struct RecordingsLibraryView: View {
         case all = "All"
         case meetings = "Meetings"
         case voiceNotes = "Voice notes"
+        case hasTranslation = "Has Translation"
         case files = "Files"
         case youtube = "YouTube"
 
@@ -29,6 +30,10 @@ struct RecordingsLibraryView: View {
                 recording.type.isMeetingLike
             case .voiceNotes:
                 recording.type == .voice || recording.type == .translation
+            case .hasTranslation:
+                recording.translationTargetLanguageCode != nil
+                    || recording.type == .translation
+                    || recording.type == .meetingTranslation
             case .files:
                 recording.type == .fileTranscription && !recording.isYouTubeVideo
             case .youtube:

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -29,6 +29,7 @@ struct RecordingsLibraryView: View {
     @State private var isSelectionMode = false
     @State private var selectedRecordingIds = Set<UUID>()
     @State private var recordingToRetranscribe: Recording?
+    @State private var batchLoadErrorMessage: String?
 
     enum RecordingTypeFilter: String, CaseIterable {
         case all = "All"
@@ -39,7 +40,9 @@ struct RecordingsLibraryView: View {
         case youtube = "YouTube"
         case batches = "Batches"
 
-        var showsBatches: Bool { self == .batches }
+        var showsBatches: Bool {
+            self == .batches
+        }
 
         func matches(_ recording: Recording) -> Bool {
             switch self {
@@ -139,6 +142,7 @@ struct RecordingsLibraryView: View {
             NewTranscriptionBatchSheet(recordings: storage.recordings)
         }
         .onAppear {
+            batchLoadErrorMessage = batchStorage.loadErrorMessage
             openRequestedRecordingIfAvailable()
         }
         .onChange(of: MainWindowController.shared.requestedRecordingID) {
@@ -191,6 +195,17 @@ struct RecordingsLibraryView: View {
             }
         } message: {
             Text("This adds a new transcript version. Earlier transcripts and source captions stay available.")
+        }
+        .alert(
+            "Batches Couldn't Be Loaded",
+            isPresented: Binding(
+                get: { batchLoadErrorMessage != nil },
+                set: { if !$0 { batchLoadErrorMessage = nil } }
+            )
+        ) {
+            Button("OK") { batchLoadErrorMessage = nil }
+        } message: {
+            Text(batchLoadErrorMessage ?? "Unknown error")
         }
     }
 
@@ -288,7 +303,7 @@ struct RecordingsLibraryView: View {
                 Spacer()
             }
 
-            if isSelectionMode && !filter.showsBatches {
+            if isSelectionMode, !filter.showsBatches {
                 bulkSelectionBar
             }
         }

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -1,12 +1,28 @@
 import SwiftUI
 
+enum RecordingsInspectorSelection: Equatable {
+    case recording(UUID, parentBatchID: UUID?)
+    case batch(UUID)
+
+    var parentBatchID: UUID? {
+        guard case let .recording(_, parentBatchID) = self else { return nil }
+        return parentBatchID
+    }
+
+    var backDestination: Self? {
+        parentBatchID.map(Self.batch)
+    }
+}
+
 struct RecordingsLibraryView: View {
     @State private var storage = RecordingsLibraryStorage.shared
+    @State private var batchStorage = TranscriptionBatchStorage.shared
     @State private var queueService = RecordingQueueService.shared
     @State private var playbackService = AudioPlaybackService.shared
     @State private var searchText = ""
     @State private var filter: RecordingTypeFilter = .all
-    @State private var selectedRecording: Recording? = nil
+    @State private var inspectorSelection: RecordingsInspectorSelection?
+    @State private var showBatchComposer = false
     @State private var showDeleteConfirmation = false
     @State private var showBulkDeleteConfirmation = false
     @State private var recordingToDelete: Recording? = nil
@@ -21,6 +37,9 @@ struct RecordingsLibraryView: View {
         case hasTranslation = "Has Translation"
         case files = "Files"
         case youtube = "YouTube"
+        case batches = "Batches"
+
+        var showsBatches: Bool { self == .batches }
 
         func matches(_ recording: Recording) -> Bool {
             switch self {
@@ -38,6 +57,8 @@ struct RecordingsLibraryView: View {
                 recording.type == .fileTranscription && !recording.isYouTubeVideo
             case .youtube:
                 recording.isYouTubeVideo
+            case .batches:
+                false
             }
         }
     }
@@ -47,11 +68,18 @@ struct RecordingsLibraryView: View {
             guard filter.matches(recording) else { return false }
             guard !searchText.isEmpty else { return true }
             let query = searchText.lowercased()
-            return recording.libraryDisplayName.lowercased().contains(query)
+            return recording.displayTitle.lowercased().contains(query)
+                || recording.libraryDisplayName.lowercased().contains(query)
+                || (recording.description?.lowercased().contains(query) ?? false)
                 || (recording.sourceFileName?.lowercased().contains(query) ?? false)
                 || (recording.remoteSource?.channelName?.lowercased().contains(query) ?? false)
-                || (recording.transcriptionText?.lowercased().contains(query) ?? false)
+                || (recording.remoteSource?.description?.lowercased().contains(query) ?? false)
+                || recording.resolvedTranscriptHistory.contains { $0.text.lowercased().contains(query) }
         }
+    }
+
+    private var filteredBatches: [TranscriptionBatch] {
+        batchStorage.batches.filter { $0.matches(searchText, recordings: storage.recordings) }
     }
 
     private var favoriteLanguages: [SupportedLanguage] {
@@ -79,7 +107,17 @@ struct RecordingsLibraryView: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 16)
 
-            if storage.recordings.isEmpty {
+            if filter.showsBatches {
+                if batchStorage.batches.isEmpty {
+                    batchesEmptyState
+                } else if filteredBatches.isEmpty {
+                    noResultsState
+                } else {
+                    batchesCard
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 24)
+                }
+            } else if storage.recordings.isEmpty {
                 emptyState
             } else if filteredRecordings.isEmpty {
                 noResultsState
@@ -90,9 +128,15 @@ struct RecordingsLibraryView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .sheet(item: $selectedRecording) { recording in
-            RecordingDetailView(recording: recording)
-                .frame(minWidth: 640, idealWidth: 700, minHeight: 500)
+        .inspector(isPresented: Binding(
+            get: { inspectorSelection != nil },
+            set: { if !$0 { inspectorSelection = nil } }
+        )) {
+            inspectorContent
+                .frame(minWidth: 380, idealWidth: 430, minHeight: 500)
+        }
+        .sheet(isPresented: $showBatchComposer) {
+            NewTranscriptionBatchSheet(recordings: storage.recordings)
         }
         .onAppear {
             openRequestedRecordingIfAvailable()
@@ -111,7 +155,9 @@ struct RecordingsLibraryView: View {
                     }
                     storage.deleteRecording(r)
                     selectedRecordingIds.remove(r.id)
-                    if selectedRecording?.id == r.id { selectedRecording = nil }
+                    if case let .recording(id, _) = inspectorSelection, id == r.id {
+                        inspectorSelection = nil
+                    }
                 }
                 recordingToDelete = nil
             }
@@ -134,7 +180,7 @@ struct RecordingsLibraryView: View {
                 set: { if !$0 { recordingToRetranscribe = nil } }
             )
         ) {
-            Button("Replace Generated Transcript", role: .destructive) {
+            Button("Transcribe Again") {
                 if let recordingToRetranscribe {
                     queueService.enqueue([recordingToRetranscribe.id], action: .transcribe)
                 }
@@ -144,7 +190,7 @@ struct RecordingsLibraryView: View {
                 recordingToRetranscribe = nil
             }
         } message: {
-            Text("This replaces the generated transcript. Source captions and YouTube identity stay unchanged.")
+            Text("This adds a new transcript version. Earlier transcripts and source captions stay available.")
         }
     }
 
@@ -155,6 +201,15 @@ struct RecordingsLibraryView: View {
             Text("Recordings")
                 .font(.title2.bold())
             Spacer()
+            if filter.showsBatches {
+                Button {
+                    showBatchComposer = true
+                } label: {
+                    Label("New Batch", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
             Button {
                 BatchTranscriptionWindowController.shared.selectFilesForNewBatch()
             } label: {
@@ -176,25 +231,27 @@ struct RecordingsLibraryView: View {
             .keyboardShortcut("u", modifiers: [.command, .shift])
             .help("Transcribe YouTube URLs (⇧⌘U)")
 
-            Button {
-                toggleSelectionMode()
-            } label: {
-                Label(
-                    isSelectionMode ? "Done" : "Select",
-                    systemImage: isSelectionMode ? "checkmark.circle" : "checklist"
-                )
+            if !filter.showsBatches {
+                Button {
+                    toggleSelectionMode()
+                } label: {
+                    Label(
+                        isSelectionMode ? "Done" : "Select",
+                        systemImage: isSelectionMode ? "checkmark.circle" : "checklist"
+                    )
+                }
+                .labelStyle(.titleAndIcon)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(storage.recordings.isEmpty)
+                .accessibilityIdentifier("Toggle recording selection")
             }
-            .labelStyle(.titleAndIcon)
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .disabled(storage.recordings.isEmpty)
-            .accessibilityIdentifier("Toggle recording selection")
 
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(.secondary)
                     .font(.system(size: 13))
-                TextField("Search transcripts", text: $searchText)
+                TextField(filter.showsBatches ? "Search batches" : "Search transcripts", text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 13))
                     .frame(width: 160)
@@ -231,7 +288,7 @@ struct RecordingsLibraryView: View {
                 Spacer()
             }
 
-            if isSelectionMode {
+            if isSelectionMode && !filter.showsBatches {
                 bulkSelectionBar
             }
         }
@@ -279,7 +336,7 @@ struct RecordingsLibraryView: View {
                             if isSelectionMode {
                                 toggleSelection(for: recording)
                             } else {
-                                selectedRecording = recording
+                                inspectorSelection = .recording(recording.id, parentBatchID: nil)
                             }
                         },
                         onTranscribe: { transcribe(recording) },
@@ -304,13 +361,87 @@ struct RecordingsLibraryView: View {
         )
     }
 
+    private var batchesCard: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(filteredBatches.enumerated()), id: \.element.id) { index, batch in
+                    Button {
+                        inspectorSelection = .batch(batch.id)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "square.stack.3d.up.fill")
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 32, height: 32)
+                                .background(Color.accentColor.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(batch.name).font(.headline).foregroundStyle(.primary)
+                                Text(batch.description.isEmpty ? "No description" : batch.description)
+                                    .lineLimit(1)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            VStack(alignment: .trailing, spacing: 3) {
+                                Text("\(batch.recordingIDs.count) recordings")
+                                Text(batch.status(in: storage.recordings).rawValue)
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    if index < filteredBatches.count - 1 { Divider().padding(.horizontal, 16) }
+                }
+            }
+        }
+        .background(Color(.windowBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private var inspectorContent: some View {
+        switch inspectorSelection {
+        case let .recording(id, parentBatchID):
+            if let recording = storage.recordings.first(where: { $0.id == id }) {
+                RecordingDetailView(
+                    recording: recording,
+                    parentBatchName: parentBatchID.flatMap { id in
+                        batchStorage.batches.first(where: { $0.id == id })?.name
+                    },
+                    onBack: parentBatchID == nil ? nil : {
+                        inspectorSelection = inspectorSelection?.backDestination
+                    },
+                    onClose: { inspectorSelection = nil }
+                )
+            }
+        case let .batch(id):
+            if let batch = batchStorage.batches.first(where: { $0.id == id }) {
+                TranscriptionBatchInspectorView(
+                    batch: batch,
+                    onOpenRecording: { recordingID in
+                        inspectorSelection = .recording(recordingID, parentBatchID: id)
+                    },
+                    onClose: { inspectorSelection = nil }
+                )
+            }
+        case nil:
+            EmptyView()
+        }
+    }
+
     private func openRequestedRecordingIfAvailable() {
         let controller = MainWindowController.shared
         guard let id = controller.requestedRecordingID,
               let recording = storage.recordings.first(where: { $0.id == id })
         else { return }
 
-        selectedRecording = recording
+        inspectorSelection = .recording(recording.id, parentBatchID: nil)
         controller.requestedRecordingID = nil
     }
 
@@ -406,8 +537,8 @@ struct RecordingsLibraryView: View {
         if let playingId = playbackService.playingRecordingId, ids.contains(playingId) {
             playbackService.stop()
         }
-        if let selectedRecording, ids.contains(selectedRecording.id) {
-            self.selectedRecording = nil
+        if case let .recording(id, _) = inspectorSelection, ids.contains(id) {
+            inspectorSelection = nil
         }
         storage.deleteRecordings(ids)
         cancelSelection()
@@ -443,6 +574,15 @@ struct RecordingsLibraryView: View {
                 .foregroundColor(.secondary)
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var batchesEmptyState: some View {
+        ContentUnavailableView(
+            "No Batches Yet",
+            systemImage: "square.stack.3d.up",
+            description: Text("Create a batch to group related recordings and transcripts.")
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -30,6 +30,7 @@ struct RecordingsLibraryView: View {
     @State private var selectedRecordingIds = Set<UUID>()
     @State private var recordingToRetranscribe: Recording?
     @State private var batchLoadErrorMessage: String?
+    @State private var deletionErrorMessage: String?
 
     enum RecordingTypeFilter: String, CaseIterable {
         case all = "All"
@@ -157,10 +158,13 @@ struct RecordingsLibraryView: View {
                     if playbackService.playingRecordingId == r.id {
                         playbackService.stop()
                     }
-                    storage.deleteRecording(r)
-                    selectedRecordingIds.remove(r.id)
-                    if case let .recording(id, _) = inspectorSelection, id == r.id {
-                        inspectorSelection = nil
+                    if storage.deleteRecording(r) {
+                        selectedRecordingIds.remove(r.id)
+                        if case let .recording(id, _) = inspectorSelection, id == r.id {
+                            inspectorSelection = nil
+                        }
+                    } else {
+                        deletionErrorMessage = "The recording and its files were left unchanged."
                     }
                 }
                 recordingToDelete = nil
@@ -206,6 +210,17 @@ struct RecordingsLibraryView: View {
             Button("OK") { batchLoadErrorMessage = nil }
         } message: {
             Text(batchLoadErrorMessage ?? "Unknown error")
+        }
+        .alert(
+            "Couldn't Delete Recording",
+            isPresented: Binding(
+                get: { deletionErrorMessage != nil },
+                set: { if !$0 { deletionErrorMessage = nil } }
+            )
+        ) {
+            Button("OK") { deletionErrorMessage = nil }
+        } message: {
+            Text(deletionErrorMessage ?? "Unknown error")
         }
     }
 
@@ -555,8 +570,11 @@ struct RecordingsLibraryView: View {
         if case let .recording(id, _) = inspectorSelection, ids.contains(id) {
             inspectorSelection = nil
         }
-        storage.deleteRecordings(ids)
-        cancelSelection()
+        if storage.deleteRecordings(ids) {
+            cancelSelection()
+        } else {
+            deletionErrorMessage = "The selected recordings and their files were left unchanged."
+        }
     }
 
     // MARK: - Empty States

--- a/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingsLibraryView.swift
@@ -145,12 +145,16 @@ struct RecordingsLibraryView: View {
         .onAppear {
             batchLoadErrorMessage = batchStorage.loadErrorMessage
             openRequestedRecordingIfAvailable()
+            openRequestedBatchComposerIfAvailable()
         }
         .onChange(of: MainWindowController.shared.requestedRecordingID) {
             openRequestedRecordingIfAvailable()
         }
         .onChange(of: storage.recordings) {
             openRequestedRecordingIfAvailable()
+        }
+        .onChange(of: MainWindowController.shared.requestedBatchComposer) {
+            openRequestedBatchComposerIfAvailable()
         }
         .alert("Delete Recording", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
@@ -231,35 +235,16 @@ struct RecordingsLibraryView: View {
             Text("Recordings")
                 .font(.title2.bold())
             Spacer()
-            if filter.showsBatches {
-                Button {
-                    showBatchComposer = true
-                } label: {
-                    Label("New Batch", systemImage: "plus")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
             Button {
-                BatchTranscriptionWindowController.shared.selectFilesForNewBatch()
+                showBatchComposer = true
             } label: {
-                Label("Transcribe Files…", systemImage: "waveform.badge.plus")
+                Label(MainWindowController.batchComposerActionTitle, systemImage: "square.stack.3d.up")
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
-            .keyboardShortcut("o", modifiers: [.command, .shift])
-            .help("Select audio or video files to transcribe (⇧⌘O)")
-            .accessibilityIdentifier("Transcribe files")
-
-            Button {
-                BatchTranscriptionWindowController.shared.selectYouTubeURLsForNewBatch()
-            } label: {
-                Label("Transcribe YouTube URLs…", systemImage: "play.rectangle.on.rectangle")
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .keyboardShortcut("u", modifiers: [.command, .shift])
-            .help("Transcribe YouTube URLs (⇧⌘U)")
+            .keyboardShortcut("b", modifiers: [.command, .shift])
+            .help("Create a batch from files, URLs, or existing recordings (⇧⌘B)")
+            .accessibilityIdentifier("Batch files and URLs")
 
             if !filter.showsBatches {
                 Button {
@@ -303,6 +288,13 @@ struct RecordingsLibraryView: View {
                 in: RoundedRectangle(cornerRadius: 8, style: .continuous)
             )
         }
+    }
+
+    private func openRequestedBatchComposerIfAvailable() {
+        let controller = MainWindowController.shared
+        guard controller.requestedBatchComposer else { return }
+        controller.requestedBatchComposer = false
+        showBatchComposer = true
     }
 
     // MARK: - Filter Chips

--- a/Diduny/Features/Transcription/BatchTranscriptionWindowController.swift
+++ b/Diduny/Features/Transcription/BatchTranscriptionWindowController.swift
@@ -16,12 +16,6 @@ final class BatchTranscriptionWindowController {
 
     private init() {}
 
-    func selectFilesForNewBatch() {
-        guard let urls = ImportedMediaPicker.selectFiles(), !urls.isEmpty else { return }
-        FileTranscriptionBatchService.shared.beginBatch(urls: urls)
-        showWindow()
-    }
-
     func addFiles() {
         guard let urls = ImportedMediaPicker.selectFiles(), !urls.isEmpty else { return }
         let service = FileTranscriptionBatchService.shared
@@ -30,12 +24,8 @@ final class BatchTranscriptionWindowController {
         showWindow()
     }
 
-    func selectYouTubeURLsForNewBatch() {
-        presentYouTubeURLImporter(startsNewBatch: true)
-    }
-
     func addYouTubeURLs() {
-        presentYouTubeURLImporter(startsNewBatch: false)
+        presentYouTubeURLImporter()
     }
 
     func openYouTubeInSelectedChrome() {
@@ -111,7 +101,7 @@ final class BatchTranscriptionWindowController {
         self.window = window
     }
 
-    private func presentYouTubeURLImporter(startsNewBatch: Bool) {
+    private func presentYouTubeURLImporter() {
         showWindow()
         guard urlImportWindow == nil, let window else { return }
 
@@ -121,12 +111,8 @@ final class BatchTranscriptionWindowController {
                 SettingsStorage.shared.selectedChromeProfileID = profileID
                 SettingsStorage.shared.remoteMediaRightsAcknowledged = true
                 let service = FileTranscriptionBatchService.shared
-                if startsNewBatch {
-                    service.beginBatch(remoteSources: sources)
-                } else {
-                    service.add(remoteSources: sources)
-                    service.startIfNeeded()
-                }
+                service.add(remoteSources: sources)
+                service.startIfNeeded()
                 self?.dismissYouTubeURLImporter()
             }
         )

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -10,6 +10,7 @@ struct TranscriptionBatchInspectorView: View {
     @State private var name: String
     @State private var description: String
     @State private var showDeleteConfirmation = false
+    @State private var saveErrorMessage: String?
 
     init(
         batch: TranscriptionBatch,
@@ -63,11 +64,15 @@ struct TranscriptionBatchInspectorView: View {
                             .foregroundStyle(.secondary)
                             Spacer()
                             Button("Save Details") {
-                                try? batches.update(
-                                    batchID: currentBatch.id,
-                                    name: name,
-                                    description: description
-                                )
+                                do {
+                                    try batches.update(
+                                        batchID: currentBatch.id,
+                                        name: name,
+                                        description: description
+                                    )
+                                } catch {
+                                    saveErrorMessage = error.localizedDescription
+                                }
                             }
                             .controlSize(.small)
                         }
@@ -159,6 +164,17 @@ struct TranscriptionBatchInspectorView: View {
                 "This permanently deletes all \(currentBatch.recordingIDs.count) linked recordings and removes shared references from every other batch."
             )
         }
+        .alert(
+            "Couldn't Save Batch",
+            isPresented: Binding(
+                get: { saveErrorMessage != nil },
+                set: { if !$0 { saveErrorMessage = nil } }
+            )
+        ) {
+            Button("OK") { saveErrorMessage = nil }
+        } message: {
+            Text(saveErrorMessage ?? "Unknown error")
+        }
     }
 }
 
@@ -217,7 +233,7 @@ struct NewTranscriptionBatchSheet: View {
 
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        if files.isEmpty && urlLines.isEmpty && selectedRecordingIDs.isEmpty && !showRecordingPicker {
+                        if files.isEmpty, urlLines.isEmpty, selectedRecordingIDs.isEmpty, !showRecordingPicker {
                             Text("Add files, YouTube URLs, or existing recordings.")
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity, alignment: .center)
@@ -248,18 +264,18 @@ struct NewTranscriptionBatchSheet: View {
                                 .padding(.horizontal, 10)
                                 .padding(.bottom, 6)
                             ForEach(recordings.filter { !selectedRecordingIDs.contains($0.id) }) { recording in
-                            Toggle(isOn: Binding(
-                                get: { selectedRecordingIDs.contains(recording.id) },
-                                set: { selected in
-                                    if selected { selectedRecordingIDs.insert(recording.id) }
-                                    else { selectedRecordingIDs.remove(recording.id) }
+                                Toggle(isOn: Binding(
+                                    get: { selectedRecordingIDs.contains(recording.id) },
+                                    set: { selected in
+                                        if selected { selectedRecordingIDs.insert(recording.id) }
+                                        else { selectedRecordingIDs.remove(recording.id) }
+                                    }
+                                )) {
+                                    Text(recording.displayTitle).lineLimit(1)
                                 }
-                            )) {
-                                Text(recording.displayTitle).lineLimit(1)
-                            }
-                            .toggleStyle(.checkbox)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 5)
+                                .toggleStyle(.checkbox)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 5)
                             }
                         }
                     }

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -7,6 +7,7 @@ struct TranscriptionBatchInspectorView: View {
 
     @State private var batches = TranscriptionBatchStorage.shared
     @State private var recordings = RecordingsLibraryStorage.shared
+    @State private var batchService = FileTranscriptionBatchService.shared
     @State private var name: String
     @State private var description: String
     @State private var showDeleteConfirmation = false
@@ -31,6 +32,10 @@ struct TranscriptionBatchInspectorView: View {
     private var members: [Recording] {
         let byID = Dictionary(uniqueKeysWithValues: recordings.recordings.map { ($0.id, $0) })
         return currentBatch.recordingIDs.compactMap { byID[$0] }
+    }
+
+    private var unattachedWorkItems: [BatchTranscriptionItem] {
+        (currentBatch.workItems ?? []).filter { $0.recordingID == nil }
     }
 
     var body: some View {
@@ -86,6 +91,13 @@ struct TranscriptionBatchInspectorView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                             Spacer()
+                            if !currentBatch.retryableWorkItems.isEmpty {
+                                Button("Retry Failed (\(currentBatch.retryableWorkItems.count))") {
+                                    batchService.resume(batch: currentBatch)
+                                }
+                                .controlSize(.small)
+                                .disabled(batchService.isProcessing)
+                            }
                             Button {
                                 ClipboardService.shared.copy(
                                     text: currentBatch.markdown(recordings: recordings.recordings),
@@ -98,7 +110,7 @@ struct TranscriptionBatchInspectorView: View {
                         }
 
                         if members.isEmpty {
-                            Text("No attached recordings")
+                            Text(unattachedWorkItems.isEmpty ? "No attached recordings" : "No completed recordings yet")
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding(.vertical, 24)
@@ -140,6 +152,27 @@ struct TranscriptionBatchInspectorView: View {
                                     in: RoundedRectangle(cornerRadius: 8)
                                 )
                             }
+                        }
+
+                        ForEach(unattachedWorkItems) { item in
+                            HStack(spacing: 10) {
+                                Image(systemName: "exclamationmark.circle")
+                                    .foregroundStyle(.red)
+                                    .frame(width: 24)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(item.displayName).lineLimit(1)
+                                    Text(item.errorMessage ?? "Ready to retry")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding(10)
+                            .background(
+                                Color(.quaternaryLabelColor).opacity(0.08),
+                                in: RoundedRectangle(cornerRadius: 8)
+                            )
                         }
                     }
 

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -154,6 +154,15 @@ struct TranscriptionBatchesView: View {
                         $0.localizedCaseInsensitiveContains(memberQuery)
                     }
             }
+        let unresolvedItems = (batch.workItems ?? []).filter { item in
+            item.recordingID == nil
+                && (memberQuery.isEmpty
+                    || item.displayName.localizedCaseInsensitiveContains(memberQuery)
+                    || (item.errorMessage?.localizedCaseInsensitiveContains(memberQuery) ?? false))
+        }
+        let canRetry = batch.workItems?.contains {
+            $0.status != .completed && $0.status != .duplicate
+        } == true
 
         return VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .top) {
@@ -167,6 +176,12 @@ struct TranscriptionBatchesView: View {
                 Spacer()
                 Button("Delete", role: .destructive) { deletingBatch = batch }
                 Button("Edit") { editingBatch = batch }
+                if canRetry {
+                    Button("Retry Failed") {
+                        FileTranscriptionBatchService.shared.resume(batch: batch)
+                        BatchTranscriptionWindowController.shared.showWindow()
+                    }
+                }
                 Button {
                     ClipboardService.shared.copy(
                         text: batch.markdown(recordings: recordings.recordings),
@@ -190,7 +205,7 @@ struct TranscriptionBatchesView: View {
 
             searchField("Search members", text: $memberQuery)
 
-            if members.isEmpty {
+            if members.isEmpty && unresolvedItems.isEmpty {
                 ContentUnavailableView(
                     memberQuery.isEmpty ? "No Recordings" : "No Results",
                     systemImage: memberQuery.isEmpty ? "waveform" : "magnifyingglass"
@@ -199,6 +214,22 @@ struct TranscriptionBatchesView: View {
             } else {
                 ScrollView {
                     LazyVStack(spacing: 0) {
+                        ForEach(unresolvedItems) { item in
+                            HStack(spacing: 12) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(.orange)
+                                    .frame(width: 28)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(item.displayName).font(.headline)
+                                    Text(item.errorMessage ?? "Not completed")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                            }
+                            .padding(16)
+                            Divider()
+                        }
                         ForEach(Array(members.enumerated()), id: \.element.id) { index, recording in
                             HStack(spacing: 12) {
                                 Image(systemName: recording.libraryIconName)

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -188,8 +188,11 @@ struct TranscriptionBatchInspectorView: View {
         }
         .alert("Delete Batch and Recordings?", isPresented: $showDeleteConfirmation) {
             Button("Delete Batch and \(currentBatch.recordingIDs.count) Recordings", role: .destructive) {
-                recordings.deleteBatch(currentBatch)
-                onClose()
+                if recordings.deleteBatch(currentBatch) {
+                    onClose()
+                } else {
+                    saveErrorMessage = "The batch and its recordings were left unchanged."
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -198,7 +201,7 @@ struct TranscriptionBatchInspectorView: View {
             )
         }
         .alert(
-            "Couldn't Save Batch",
+            "Batch Change Failed",
             isPresented: Binding(
                 get: { saveErrorMessage != nil },
                 set: { if !$0 { saveErrorMessage = nil } }

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -1,0 +1,379 @@
+import SwiftUI
+
+struct TranscriptionBatchesView: View {
+    @State private var batches = TranscriptionBatchStorage.shared
+    @State private var recordings = RecordingsLibraryStorage.shared
+    @State private var selectedBatchID: UUID?
+    @State private var query = ""
+    @State private var memberQuery = ""
+    @State private var showComposer = false
+    @State private var editingBatch: TranscriptionBatch?
+    @State private var deletingBatch: TranscriptionBatch?
+
+    private var selectedBatch: TranscriptionBatch? {
+        batches.batches.first(where: { $0.id == selectedBatchID })
+    }
+
+    private var filteredBatches: [TranscriptionBatch] {
+        batches.batches.filter { $0.matches(query, recordings: recordings.recordings) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let selectedBatch {
+                detail(selectedBatch)
+            } else {
+                batchList
+            }
+        }
+        .sheet(isPresented: $showComposer) {
+            NewTranscriptionBatchSheet(recordings: recordings.recordings)
+        }
+        .sheet(item: $editingBatch) { batch in
+            TranscriptionBatchEditor(batch: batch) { name, description in
+                try? batches.update(batchID: batch.id, name: name, description: description)
+            }
+        }
+        .alert(
+            "Delete Batch and Recordings?",
+            isPresented: Binding(
+                get: { deletingBatch != nil },
+                set: { if !$0 { deletingBatch = nil } }
+            ),
+            presenting: deletingBatch
+        ) { batch in
+            Button("Delete Batch and \(batch.recordingIDs.count) Recordings", role: .destructive) {
+                recordings.deleteBatch(batch)
+                selectedBatchID = nil
+                deletingBatch = nil
+            }
+            Button("Cancel", role: .cancel) { deletingBatch = nil }
+        } message: { batch in
+            Text(
+                "This permanently deletes all \(batch.recordingIDs.count) linked recordings from Library. Shared recordings will also disappear from every other batch."
+            )
+        }
+    }
+
+    private var batchList: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Batches").font(.title2.bold())
+                    Text("Durable groups of files, URLs, and Library recordings.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                searchField("Search batches", text: $query)
+                Button {
+                    showComposer = true
+                } label: {
+                    Label("New Batch", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+
+            if batches.batches.isEmpty {
+                ContentUnavailableView(
+                    "No Batches Yet",
+                    systemImage: "square.stack.3d.up",
+                    description: Text("Create a batch to keep grouped transcription results.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if filteredBatches.isEmpty {
+                ContentUnavailableView.search(text: query)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(filteredBatches.enumerated()), id: \.element.id) { index, batch in
+                            Button {
+                                selectedBatchID = batch.id
+                            } label: {
+                                batchRow(batch)
+                            }
+                            .buttonStyle(.plain)
+                            if index < filteredBatches.count - 1 { Divider() }
+                        }
+                    }
+                }
+                .background(Color(.windowBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
+                }
+            }
+        }
+        .padding(24)
+    }
+
+    private func batchRow(_ batch: TranscriptionBatch) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: "square.stack.3d.up.fill")
+                .font(.title3)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Color.accentColor.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(batch.name).font(.headline)
+                if !batch.description.isEmpty {
+                    Text(batch.description).lineLimit(1).foregroundStyle(.secondary)
+                }
+                Text("\(batch.recordingIDs.count) recordings · \(batch.status(in: recordings.recordings).rawValue)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(batch.createdAt.formatted(date: .abbreviated, time: .shortened))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Image(systemName: "chevron.right").foregroundStyle(.tertiary)
+        }
+        .padding(16)
+        .contentShape(Rectangle())
+    }
+
+    private func detail(_ batch: TranscriptionBatch) -> some View {
+        let memberIDs = Set(batch.recordingIDs)
+        let members = recordings.recordings
+            .filter { memberIDs.contains($0.id) }
+            .sorted {
+                (batch.recordingIDs.firstIndex(of: $0.id) ?? .max)
+                    < (batch.recordingIDs.firstIndex(of: $1.id) ?? .max)
+            }
+            .filter { recording in
+                memberQuery.isEmpty
+                    || [
+                        recording.sourceFileName,
+                        recording.remoteSource?.title,
+                        recording.transcriptionText,
+                    ].compactMap { $0 }.contains {
+                        $0.localizedCaseInsensitiveContains(memberQuery)
+                    }
+            }
+
+        return VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                Button {
+                    selectedBatchID = nil
+                    memberQuery = ""
+                } label: {
+                    Label("All Batches", systemImage: "chevron.left")
+                }
+                .buttonStyle(.plain)
+                Spacer()
+                Button("Delete", role: .destructive) { deletingBatch = batch }
+                Button("Edit") { editingBatch = batch }
+                Button {
+                    ClipboardService.shared.copy(
+                        text: batch.markdown(recordings: recordings.recordings),
+                        behavior: .raw
+                    )
+                } label: {
+                    Label("Copy Markdown", systemImage: "doc.on.doc")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(batch.name).font(.title2.bold())
+                if !batch.description.isEmpty { Text(batch.description).foregroundStyle(.secondary) }
+                Text(
+                    "\(batch.status(in: recordings.recordings).rawValue) · \(batch.recordingIDs.count) recordings · Created \(batch.createdAt.formatted(date: .abbreviated, time: .shortened))"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            searchField("Search members", text: $memberQuery)
+
+            if members.isEmpty {
+                ContentUnavailableView(
+                    memberQuery.isEmpty ? "No Recordings" : "No Results",
+                    systemImage: memberQuery.isEmpty ? "waveform" : "magnifyingglass"
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(Array(members.enumerated()), id: \.element.id) { index, recording in
+                            HStack(spacing: 12) {
+                                Image(systemName: recording.libraryIconName)
+                                    .foregroundStyle(recording.libraryBrandColor)
+                                    .frame(width: 28)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(recording.remoteSource?.title ?? recording.sourceFileName ?? recording.libraryDisplayName)
+                                        .font(.headline)
+                                    Text("\(recording.libraryDisplayName) · \(recording.status.displayName)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    if let preview = recording.transcriptionText {
+                                        Text(preview).lineLimit(2).foregroundStyle(.secondary)
+                                    }
+                                }
+                                Spacer()
+                            }
+                            .padding(16)
+                            if index < members.count - 1 { Divider() }
+                        }
+                    }
+                }
+                .background(Color(.windowBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
+                }
+            }
+        }
+        .padding(24)
+    }
+
+    private func searchField(_ prompt: String, text: Binding<String>) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+            TextField(prompt, text: text).textFieldStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(width: 220)
+        .background(Color(.quaternaryLabelColor).opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private struct TranscriptionBatchEditor: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var description: String
+    let onSave: (String, String) -> Void
+
+    init(batch: TranscriptionBatch, onSave: @escaping (String, String) -> Void) {
+        _name = State(initialValue: batch.name)
+        _description = State(initialValue: batch.description)
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Edit Batch").font(.title2.bold())
+            TextField("Batch name", text: $name)
+            TextField("Description", text: $description, axis: .vertical)
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Save") {
+                    onSave(name, description)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(24)
+        .frame(width: 480)
+    }
+}
+
+private struct NewTranscriptionBatchSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let recordings: [Recording]
+    @State private var name = ""
+    @State private var description = ""
+    @State private var files: [URL] = []
+    @State private var urlText = ""
+    @State private var selectedRecordingIDs = Set<UUID>()
+    @State private var validationError: String?
+
+    private var canCreate: Bool {
+        !files.isEmpty || !urlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || !selectedRecordingIDs.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("New Transcription Batch").font(.title2.bold())
+            TextField("Batch name (optional)", text: $name)
+            TextField("Description (optional)", text: $description, axis: .vertical)
+
+            GroupBox("Files") {
+                HStack {
+                    Text(files.isEmpty ? "No files selected" : "\(files.count) files selected")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Choose Files…") {
+                        files = ImportedMediaPicker.selectFiles() ?? files
+                    }
+                }
+                .padding(6)
+            }
+
+            GroupBox("YouTube URLs") {
+                TextEditor(text: $urlText)
+                    .font(.body.monospaced())
+                    .frame(height: 64)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 5).strokeBorder(Color(.separatorColor))
+                    }
+                    .padding(6)
+            }
+
+            GroupBox("Library") {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(recordings) { recording in
+                            Toggle(isOn: Binding(
+                                get: { selectedRecordingIDs.contains(recording.id) },
+                                set: { selected in
+                                    if selected { selectedRecordingIDs.insert(recording.id) }
+                                    else { selectedRecordingIDs.remove(recording.id) }
+                                }
+                            )) {
+                                Text(recording.remoteSource?.title ?? recording.sourceFileName ?? recording.libraryDisplayName)
+                            }
+                            .toggleStyle(.checkbox)
+                        }
+                    }
+                    .padding(6)
+                }
+                .frame(height: 150)
+            }
+
+            if let validationError {
+                Text(validationError).font(.caption).foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button("Create and Transcribe") { createBatch() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canCreate)
+            }
+        }
+        .padding(24)
+        .frame(width: 620, height: 600)
+    }
+
+    private func createBatch() {
+        do {
+            let remoteSources = try YouTubeRemoteMediaSource.normalizeBatch(urlText)
+            FileTranscriptionBatchService.shared.beginBatch(
+                urls: files,
+                remoteSources: remoteSources,
+                name: name,
+                description: description,
+                existingRecordingIDs: recordings
+                    .filter { selectedRecordingIDs.contains($0.id) }
+                    .map(\.id)
+            )
+            if !files.isEmpty || !remoteSources.isEmpty {
+                BatchTranscriptionWindowController.shared.showWindow()
+            }
+            dismiss()
+        } catch {
+            validationError = error.localizedDescription
+        }
+    }
+}

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -1,9 +1,16 @@
 import SwiftUI
 
+private enum BatchSourceEditor {
+    case youtube
+    case recordings
+}
+
 struct TranscriptionBatchInspectorView: View {
     let batch: TranscriptionBatch
     let onOpenRecording: (UUID) -> Void
     let onClose: () -> Void
+    private let chromeProfiles: [ChromeProfile]
+    private let showsYouTubeAuthorizationControls: Bool
 
     @State private var batches = TranscriptionBatchStorage.shared
     @State private var recordings = RecordingsLibraryStorage.shared
@@ -12,6 +19,12 @@ struct TranscriptionBatchInspectorView: View {
     @State private var description: String
     @State private var showDeleteConfirmation = false
     @State private var saveErrorMessage: String?
+    @State private var sourceEditor: BatchSourceEditor?
+    @State private var youtubeURLText = ""
+    @State private var selectedRecordingIDs = Set<UUID>()
+    @State private var selectedChromeProfileID: String
+    @State private var rightsAcknowledged: Bool
+    @FocusState private var isYouTubeURLInputFocused: Bool
 
     init(
         batch: TranscriptionBatch,
@@ -21,8 +34,20 @@ struct TranscriptionBatchInspectorView: View {
         self.batch = batch
         self.onOpenRecording = onOpenRecording
         self.onClose = onClose
+        let profiles = ChromeProfileStore.discover()
+        let settings = SettingsStorage.shared
+        let storedProfileID = settings.selectedChromeProfileID
+        self.chromeProfiles = profiles
+        self.showsYouTubeAuthorizationControls = !settings.remoteMediaRightsAcknowledged
+            || !profiles.contains(where: { $0.id == storedProfileID })
         _name = State(initialValue: batch.name)
         _description = State(initialValue: batch.description)
+        _selectedChromeProfileID = State(
+            initialValue: profiles.contains(where: { $0.id == storedProfileID })
+                ? storedProfileID ?? ""
+                : profiles.first?.id ?? ""
+        )
+        _rightsAcknowledged = State(initialValue: settings.remoteMediaRightsAcknowledged)
     }
 
     private var currentBatch: TranscriptionBatch {
@@ -36,6 +61,35 @@ struct TranscriptionBatchInspectorView: View {
 
     private var unattachedWorkItems: [BatchTranscriptionItem] {
         (currentBatch.workItems ?? []).filter { $0.recordingID == nil }
+    }
+
+    private var youtubeURLValidation: YouTubeRemoteMediaSource.BatchValidation {
+        YouTubeRemoteMediaSource.validateBatch(
+            youtubeURLText,
+            excludingMediaIDs: existingYouTubeMediaIDs
+        )
+    }
+
+    private var existingYouTubeMediaIDs: Set<String> {
+        Set(
+            (currentBatch.workItems ?? []).compactMap { $0.remoteSource?.mediaID }
+                + members.compactMap { recording in
+                    guard recording.remoteSource?.provider == YouTubeRemoteMediaSource.provider else {
+                        return nil
+                    }
+                    return recording.remoteSource?.mediaID
+                }
+        )
+    }
+
+    private var canAuthorizeYouTube: Bool {
+        rightsAcknowledged
+            && chromeProfiles.contains(where: { $0.id == selectedChromeProfileID })
+    }
+
+    private var availableRecordings: [Recording] {
+        let attachedIDs = Set(currentBatch.recordingIDs)
+        return recordings.recordings.filter { !attachedIDs.contains($0.id) }
     }
 
     var body: some View {
@@ -104,10 +158,32 @@ struct TranscriptionBatchInspectorView: View {
                                     behavior: .raw
                                 )
                             } label: {
-                                Label("Copy All Transcriptions", systemImage: "doc.on.doc")
+                                Label("Copy All", systemImage: "doc.on.doc")
                             }
                             .controlSize(.small)
+                            .help("Copy All Transcriptions")
+                            Menu {
+                                Button("Choose Files…", systemImage: "doc.badge.plus") {
+                                    addFiles()
+                                }
+                                Button("Paste YouTube URLs…", systemImage: "link") {
+                                    sourceEditor = .youtube
+                                    selectedRecordingIDs.removeAll()
+                                    isYouTubeURLInputFocused = true
+                                }
+                                Button("Add from Recordings…", systemImage: "waveform") {
+                                    sourceEditor = .recordings
+                                    selectedRecordingIDs.removeAll()
+                                }
+                            } label: {
+                                Label("Add", systemImage: "plus")
+                            }
+                            .menuStyle(.borderlessButton)
+                            .fixedSize()
+                            .disabled(batchService.isProcessing)
                         }
+
+                        sourceEditorContent
 
                         if members.isEmpty {
                             Text(unattachedWorkItems.isEmpty ? "No attached recordings" : "No completed recordings yet")
@@ -211,6 +287,190 @@ struct TranscriptionBatchInspectorView: View {
         } message: {
             Text(saveErrorMessage ?? "Unknown error")
         }
+    }
+
+    @ViewBuilder
+    private var sourceEditorContent: some View {
+        if sourceEditor == .youtube {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Add YouTube URLs").font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Button {
+                        sourceEditor = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close YouTube URL editor")
+                }
+                Text("Paste one video URL per line. Duplicates are ignored.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $youtubeURLText)
+                    .font(.body.monospaced())
+                    .focused($isYouTubeURLInputFocused)
+                    .accessibilityLabel("YouTube URLs to add")
+                    .frame(height: 112)
+                    .padding(6)
+                    .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 6))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
+                    }
+                if showsYouTubeAuthorizationControls {
+                    if chromeProfiles.isEmpty {
+                        Text("No Google Chrome profiles were found. Open Chrome once, then try again.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else {
+                        Picker("Chrome profile", selection: $selectedChromeProfileID) {
+                            ForEach(chromeProfiles) { profile in
+                                Text(profile.name).tag(profile.id)
+                            }
+                        }
+                        .controlSize(.small)
+                    }
+                    if !SettingsStorage.shared.remoteMediaRightsAcknowledged {
+                        Toggle(
+                            "I own this content or have permission to transcribe it.",
+                            isOn: $rightsAcknowledged
+                        )
+                        .toggleStyle(.checkbox)
+                        .font(.caption)
+                    }
+                }
+                HStack(spacing: 10) {
+                    Text("\(youtubeURLValidation.sources.count) valid")
+                        .foregroundStyle(.green)
+                    if youtubeURLValidation.duplicateCount > 0 {
+                        Text("\(youtubeURLValidation.duplicateCount) duplicate\(youtubeURLValidation.duplicateCount == 1 ? "" : "s")")
+                    }
+                    if !youtubeURLValidation.invalidValues.isEmpty {
+                        Text("\(youtubeURLValidation.invalidValues.count) invalid")
+                            .foregroundStyle(.red)
+                    }
+                    Spacer()
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                HStack {
+                    Spacer()
+                    Button("Paste") {
+                        youtubeURLText = NSPasteboard.general.string(forType: .string) ?? youtubeURLText
+                    }
+                    Button("Add \(youtubeURLValidation.sources.count) URL\(youtubeURLValidation.sources.count == 1 ? "" : "s")") {
+                        addYouTubeURLs()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(youtubeURLValidation.sources.isEmpty || !canAuthorizeYouTube)
+                }
+            }
+            .padding(10)
+            .background(
+                Color(.quaternaryLabelColor).opacity(0.08),
+                in: RoundedRectangle(cornerRadius: 8)
+            )
+        } else if sourceEditor == .recordings {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Add from Recordings").font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Button {
+                        sourceEditor = nil
+                        selectedRecordingIDs.removeAll()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close recording picker")
+                }
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(availableRecordings) { recording in
+                            Toggle(isOn: Binding(
+                                get: { selectedRecordingIDs.contains(recording.id) },
+                                set: { selected in
+                                    if selected { selectedRecordingIDs.insert(recording.id) }
+                                    else { selectedRecordingIDs.remove(recording.id) }
+                                }
+                            )) {
+                                Text(recording.displayTitle).lineLimit(1)
+                            }
+                            .toggleStyle(.checkbox)
+                        }
+                    }
+                }
+                .frame(maxHeight: 180)
+                HStack {
+                    Spacer()
+                    Button("Add \(selectedRecordingIDs.count) Recording\(selectedRecordingIDs.count == 1 ? "" : "s")") {
+                        addExistingRecordings()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(selectedRecordingIDs.isEmpty)
+                }
+            }
+            .padding(10)
+            .background(
+                Color(.quaternaryLabelColor).opacity(0.08),
+                in: RoundedRectangle(cornerRadius: 8)
+            )
+        }
+    }
+
+    private func addFiles() {
+        guard let files = ImportedMediaPicker.selectFiles(), !files.isEmpty else { return }
+        append(urls: files, remoteSources: [], existingRecordingIDs: [])
+    }
+
+    private func addYouTubeURLs() {
+        let validation = youtubeURLValidation
+        guard !validation.sources.isEmpty, canAuthorizeYouTube else { return }
+        SettingsStorage.shared.selectedChromeProfileID = selectedChromeProfileID
+        SettingsStorage.shared.remoteMediaRightsAcknowledged = true
+        guard append(urls: [], remoteSources: validation.sources, existingRecordingIDs: []) else {
+            return
+        }
+        youtubeURLText = validation.invalidValues.joined(separator: "\n")
+        if validation.invalidValues.isEmpty {
+            sourceEditor = nil
+        }
+    }
+
+    private func addExistingRecordings() {
+        guard append(
+            urls: [],
+            remoteSources: [],
+            existingRecordingIDs: availableRecordings
+                .filter { selectedRecordingIDs.contains($0.id) }
+                .map(\.id)
+        ) else { return }
+        selectedRecordingIDs.removeAll()
+        sourceEditor = nil
+    }
+
+    @discardableResult
+    private func append(
+        urls: [URL],
+        remoteSources: [YouTubeRemoteMediaSource],
+        existingRecordingIDs: [UUID]
+    ) -> Bool {
+        let accepted = batchService.append(
+            to: currentBatch,
+            urls: urls,
+            remoteSources: remoteSources,
+            existingRecordingIDs: existingRecordingIDs
+        )
+        guard accepted else {
+            saveErrorMessage = batchService.batchError
+                ?? "Another transcription batch is active. Finish it before updating this batch."
+            return false
+        }
+        if !urls.isEmpty || !remoteSources.isEmpty {
+            BatchTranscriptionWindowController.shared.showWindow()
+        }
+        return true
     }
 }
 

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -258,6 +258,7 @@ struct NewTranscriptionBatchSheet: View {
                 TextEditor(text: $urlText)
                     .font(.body.monospaced())
                     .focused($isYouTubeURLInputFocused)
+                    .accessibilityLabel("YouTube URLs")
                     .frame(height: 64)
                     .padding(6)
                     .overlay {

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -363,7 +363,8 @@ struct NewTranscriptionBatchSheet: View {
     private func createBatch() {
         do {
             let remoteSources = try YouTubeRemoteMediaSource.normalizeBatch(urlText)
-            FileTranscriptionBatchService.shared.beginBatch(
+            let batchService = FileTranscriptionBatchService.shared
+            let accepted = batchService.beginBatch(
                 urls: files,
                 remoteSources: remoteSources,
                 name: name,
@@ -372,6 +373,11 @@ struct NewTranscriptionBatchSheet: View {
                     .filter { selectedRecordingIDs.contains($0.id) }
                     .map(\.id)
             )
+            guard accepted else {
+                validationError = batchService.batchError
+                    ?? "Another transcription batch is active. Finish or retry it before creating a new batch."
+                return
+            }
             if !files.isEmpty || !remoteSources.isEmpty {
                 BatchTranscriptionWindowController.shared.showWindow()
             }

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -223,8 +223,8 @@ struct NewTranscriptionBatchSheet: View {
     @State private var urlText = ""
     @State private var selectedRecordingIDs = Set<UUID>()
     @State private var validationError: String?
-    @State private var showURLField = false
     @State private var showRecordingPicker = false
+    @FocusState private var isYouTubeURLInputFocused: Bool
 
     private var canCreate: Bool {
         !files.isEmpty || !urlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -243,7 +243,7 @@ struct NewTranscriptionBatchSheet: View {
                     files.append(contentsOf: ImportedMediaPicker.selectFiles() ?? [])
                 }
                 Button("Add YouTube URLs", systemImage: "link") {
-                    showURLField.toggle()
+                    isYouTubeURLInputFocused = true
                 }
                 Button("Add from Recordings", systemImage: "waveform") {
                     showRecordingPicker.toggle()
@@ -251,9 +251,13 @@ struct NewTranscriptionBatchSheet: View {
             }
             .controlSize(.small)
 
-            if showURLField {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("YOUTUBE URLS")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
                 TextEditor(text: $urlText)
                     .font(.body.monospaced())
+                    .focused($isYouTubeURLInputFocused)
                     .frame(height: 64)
                     .padding(6)
                     .overlay {

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -1,314 +1,168 @@
 import SwiftUI
 
-struct TranscriptionBatchesView: View {
+struct TranscriptionBatchInspectorView: View {
+    let batch: TranscriptionBatch
+    let onOpenRecording: (UUID) -> Void
+    let onClose: () -> Void
+
     @State private var batches = TranscriptionBatchStorage.shared
     @State private var recordings = RecordingsLibraryStorage.shared
-    @State private var selectedBatchID: UUID?
-    @State private var query = ""
-    @State private var memberQuery = ""
-    @State private var showComposer = false
-    @State private var editingBatch: TranscriptionBatch?
-    @State private var deletingBatch: TranscriptionBatch?
+    @State private var name: String
+    @State private var description: String
+    @State private var showDeleteConfirmation = false
 
-    private var selectedBatch: TranscriptionBatch? {
-        batches.batches.first(where: { $0.id == selectedBatchID })
+    init(
+        batch: TranscriptionBatch,
+        onOpenRecording: @escaping (UUID) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.batch = batch
+        self.onOpenRecording = onOpenRecording
+        self.onClose = onClose
+        _name = State(initialValue: batch.name)
+        _description = State(initialValue: batch.description)
     }
 
-    private var filteredBatches: [TranscriptionBatch] {
-        batches.batches.filter { $0.matches(query, recordings: recordings.recordings) }
+    private var currentBatch: TranscriptionBatch {
+        batches.batches.first(where: { $0.id == batch.id }) ?? batch
+    }
+
+    private var members: [Recording] {
+        let byID = Dictionary(uniqueKeysWithValues: recordings.recordings.map { ($0.id, $0) })
+        return currentBatch.recordingIDs.compactMap { byID[$0] }
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let selectedBatch {
-                detail(selectedBatch)
-            } else {
-                batchList
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Batch").font(.caption).foregroundStyle(.secondary)
+                    Text(currentBatch.name).font(.headline).lineLimit(1)
+                }
+                Spacer()
+                Button("Close", action: onClose)
+                    .controlSize(.small)
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(16)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("DETAILS").font(.caption.weight(.semibold)).foregroundStyle(.secondary)
+                        TextField("Batch title", text: $name)
+                        TextField("Description", text: $description, axis: .vertical)
+                            .lineLimit(2 ... 5)
+                        HStack {
+                            Text(
+                                "\(currentBatch.status(in: recordings.recordings).rawValue) · \(members.count) recordings · \(currentBatch.createdAt.formatted(date: .abbreviated, time: .shortened))"
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            Spacer()
+                            Button("Save Details") {
+                                try? batches.update(
+                                    batchID: currentBatch.id,
+                                    name: name,
+                                    description: description
+                                )
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("ATTACHED RECORDINGS")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Button {
+                                ClipboardService.shared.copy(
+                                    text: currentBatch.markdown(recordings: recordings.recordings),
+                                    behavior: .raw
+                                )
+                            } label: {
+                                Label("Copy All Transcriptions", systemImage: "doc.on.doc")
+                            }
+                            .controlSize(.small)
+                        }
+
+                        if members.isEmpty {
+                            Text("No attached recordings")
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.vertical, 24)
+                        } else {
+                            ForEach(members) { recording in
+                                HStack(spacing: 10) {
+                                    Image(systemName: recording.libraryIconName)
+                                        .foregroundStyle(recording.libraryBrandColor)
+                                        .frame(width: 24)
+                                    Button {
+                                        onOpenRecording(recording.id)
+                                    } label: {
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(recording.displayTitle).lineLimit(1)
+                                            Text("\(recording.libraryDisplayName) · \(recording.status.displayName)")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                    }
+                                    .buttonStyle(.plain)
+                                    if let latest = recording.resolvedTranscriptHistory.last {
+                                        Button("Copy") {
+                                            ClipboardService.shared.copy(text: latest.text, behavior: .raw)
+                                        }
+                                        .controlSize(.small)
+                                    }
+                                    Button {
+                                        onOpenRecording(recording.id)
+                                    } label: {
+                                        Image(systemName: "chevron.right")
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Open \(recording.displayTitle)")
+                                }
+                                .padding(10)
+                                .background(
+                                    Color(.quaternaryLabelColor).opacity(0.08),
+                                    in: RoundedRectangle(cornerRadius: 8)
+                                )
+                            }
+                        }
+                    }
+
+                    Divider()
+
+                    Button("Delete Batch and \(currentBatch.recordingIDs.count) Recordings", role: .destructive) {
+                        showDeleteConfirmation = true
+                    }
+                    .disabled(!currentBatch.isProcessingClosed)
+                }
+                .padding(16)
             }
         }
-        .sheet(isPresented: $showComposer) {
-            NewTranscriptionBatchSheet(recordings: recordings.recordings)
-        }
-        .sheet(item: $editingBatch) { batch in
-            TranscriptionBatchEditor(batch: batch) { name, description in
-                try? batches.update(batchID: batch.id, name: name, description: description)
+        .alert("Delete Batch and Recordings?", isPresented: $showDeleteConfirmation) {
+            Button("Delete Batch and \(currentBatch.recordingIDs.count) Recordings", role: .destructive) {
+                recordings.deleteBatch(currentBatch)
+                onClose()
             }
-        }
-        .alert(
-            "Delete Batch and Recordings?",
-            isPresented: Binding(
-                get: { deletingBatch != nil },
-                set: { if !$0 { deletingBatch = nil } }
-            ),
-            presenting: deletingBatch
-        ) { batch in
-            Button("Delete Batch and \(batch.recordingIDs.count) Recordings", role: .destructive) {
-                recordings.deleteBatch(batch)
-                selectedBatchID = nil
-                deletingBatch = nil
-            }
-            Button("Cancel", role: .cancel) { deletingBatch = nil }
-        } message: { batch in
+            Button("Cancel", role: .cancel) {}
+        } message: {
             Text(
-                "This permanently deletes all \(batch.recordingIDs.count) linked recordings from Library. Shared recordings will also disappear from every other batch."
+                "This permanently deletes all \(currentBatch.recordingIDs.count) linked recordings and removes shared references from every other batch."
             )
         }
     }
-
-    private var batchList: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Batches").font(.title2.bold())
-                    Text("Durable groups of files, URLs, and Library recordings.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                searchField("Search batches", text: $query)
-                Button {
-                    showComposer = true
-                } label: {
-                    Label("New Batch", systemImage: "plus")
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            }
-
-            if batches.batches.isEmpty {
-                ContentUnavailableView(
-                    "No Batches Yet",
-                    systemImage: "square.stack.3d.up",
-                    description: Text("Create a batch to keep grouped transcription results.")
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if filteredBatches.isEmpty {
-                ContentUnavailableView.search(text: query)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(Array(filteredBatches.enumerated()), id: \.element.id) { index, batch in
-                            Button {
-                                selectedBatchID = batch.id
-                            } label: {
-                                batchRow(batch)
-                            }
-                            .buttonStyle(.plain)
-                            if index < filteredBatches.count - 1 { Divider() }
-                        }
-                    }
-                }
-                .background(Color(.windowBackgroundColor))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
-                }
-            }
-        }
-        .padding(24)
-    }
-
-    private func batchRow(_ batch: TranscriptionBatch) -> some View {
-        HStack(spacing: 14) {
-            Image(systemName: "square.stack.3d.up.fill")
-                .font(.title3)
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 34, height: 34)
-                .background(Color.accentColor.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
-            VStack(alignment: .leading, spacing: 4) {
-                Text(batch.name).font(.headline)
-                if !batch.description.isEmpty {
-                    Text(batch.description).lineLimit(1).foregroundStyle(.secondary)
-                }
-                Text("\(batch.recordingIDs.count) recordings · \(batch.status(in: recordings.recordings).rawValue)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer()
-            Text(batch.createdAt.formatted(date: .abbreviated, time: .shortened))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Image(systemName: "chevron.right").foregroundStyle(.tertiary)
-        }
-        .padding(16)
-        .contentShape(Rectangle())
-    }
-
-    private func detail(_ batch: TranscriptionBatch) -> some View {
-        let memberIDs = Set(batch.recordingIDs)
-        let members = recordings.recordings
-            .filter { memberIDs.contains($0.id) }
-            .sorted {
-                (batch.recordingIDs.firstIndex(of: $0.id) ?? .max)
-                    < (batch.recordingIDs.firstIndex(of: $1.id) ?? .max)
-            }
-            .filter { recording in
-                memberQuery.isEmpty
-                    || [
-                        recording.sourceFileName,
-                        recording.remoteSource?.title,
-                        recording.transcriptionText,
-                    ].compactMap { $0 }.contains {
-                        $0.localizedCaseInsensitiveContains(memberQuery)
-                    }
-            }
-        let unresolvedItems = (batch.workItems ?? []).filter { item in
-            item.recordingID == nil
-                && (memberQuery.isEmpty
-                    || item.displayName.localizedCaseInsensitiveContains(memberQuery)
-                    || (item.errorMessage?.localizedCaseInsensitiveContains(memberQuery) ?? false))
-        }
-        let canRetry = batch.workItems?.contains {
-            $0.status != .completed && $0.status != .duplicate
-        } == true
-
-        return VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top) {
-                Button {
-                    selectedBatchID = nil
-                    memberQuery = ""
-                } label: {
-                    Label("All Batches", systemImage: "chevron.left")
-                }
-                .buttonStyle(.plain)
-                Spacer()
-                Button("Delete", role: .destructive) { deletingBatch = batch }
-                    .disabled(!batch.isProcessingClosed)
-                Button("Edit") { editingBatch = batch }
-                if canRetry {
-                    Button("Retry Failed") {
-                        FileTranscriptionBatchService.shared.resume(batch: batch)
-                        BatchTranscriptionWindowController.shared.showWindow()
-                    }
-                }
-                Button {
-                    ClipboardService.shared.copy(
-                        text: batch.markdown(recordings: recordings.recordings),
-                        behavior: .raw
-                    )
-                } label: {
-                    Label("Copy Markdown", systemImage: "doc.on.doc")
-                }
-                .buttonStyle(.borderedProminent)
-            }
-
-            VStack(alignment: .leading, spacing: 5) {
-                Text(batch.name).font(.title2.bold())
-                if !batch.description.isEmpty { Text(batch.description).foregroundStyle(.secondary) }
-                Text(
-                    "\(batch.status(in: recordings.recordings).rawValue) · \(batch.recordingIDs.count) recordings · Created \(batch.createdAt.formatted(date: .abbreviated, time: .shortened))"
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            searchField("Search members", text: $memberQuery)
-
-            if members.isEmpty && unresolvedItems.isEmpty {
-                ContentUnavailableView(
-                    memberQuery.isEmpty ? "No Recordings" : "No Results",
-                    systemImage: memberQuery.isEmpty ? "waveform" : "magnifyingglass"
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(unresolvedItems) { item in
-                            HStack(spacing: 12) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .foregroundStyle(.orange)
-                                    .frame(width: 28)
-                                VStack(alignment: .leading, spacing: 3) {
-                                    Text(item.displayName).font(.headline)
-                                    Text(item.errorMessage ?? "Not completed")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                Spacer()
-                            }
-                            .padding(16)
-                            Divider()
-                        }
-                        ForEach(Array(members.enumerated()), id: \.element.id) { index, recording in
-                            HStack(spacing: 12) {
-                                Image(systemName: recording.libraryIconName)
-                                    .foregroundStyle(recording.libraryBrandColor)
-                                    .frame(width: 28)
-                                VStack(alignment: .leading, spacing: 3) {
-                                    Text(recording.remoteSource?.title ?? recording.sourceFileName ?? recording.libraryDisplayName)
-                                        .font(.headline)
-                                    Text("\(recording.libraryDisplayName) · \(recording.status.displayName)")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    if let preview = recording.transcriptionText {
-                                        Text(preview).lineLimit(2).foregroundStyle(.secondary)
-                                    }
-                                }
-                                Spacer()
-                            }
-                            .padding(16)
-                            if index < members.count - 1 { Divider() }
-                        }
-                    }
-                }
-                .background(Color(.windowBackgroundColor))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
-                }
-            }
-        }
-        .padding(24)
-    }
-
-    private func searchField(_ prompt: String, text: Binding<String>) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
-            TextField(prompt, text: text).textFieldStyle(.plain)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .frame(width: 220)
-        .background(Color(.quaternaryLabelColor).opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
-    }
 }
 
-private struct TranscriptionBatchEditor: View {
-    @Environment(\.dismiss) private var dismiss
-    @State private var name: String
-    @State private var description: String
-    let onSave: (String, String) -> Void
-
-    init(batch: TranscriptionBatch, onSave: @escaping (String, String) -> Void) {
-        _name = State(initialValue: batch.name)
-        _description = State(initialValue: batch.description)
-        self.onSave = onSave
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Edit Batch").font(.title2.bold())
-            TextField("Batch name", text: $name)
-            TextField("Description", text: $description, axis: .vertical)
-            HStack {
-                Spacer()
-                Button("Cancel") { dismiss() }
-                Button("Save") {
-                    onSave(name, description)
-                    dismiss()
-                }
-                .buttonStyle(.borderedProminent)
-            }
-        }
-        .padding(24)
-        .frame(width: 480)
-    }
-}
-
-private struct NewTranscriptionBatchSheet: View {
+struct NewTranscriptionBatchSheet: View {
     @Environment(\.dismiss) private var dismiss
     let recordings: [Recording]
     @State private var name = ""
@@ -317,6 +171,8 @@ private struct NewTranscriptionBatchSheet: View {
     @State private var urlText = ""
     @State private var selectedRecordingIDs = Set<UUID>()
     @State private var validationError: String?
+    @State private var showURLField = false
+    @State private var showRecordingPicker = false
 
     private var canCreate: Bool {
         !files.isEmpty || !urlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -324,37 +180,74 @@ private struct NewTranscriptionBatchSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
             Text("New Transcription Batch").font(.title2.bold())
             TextField("Batch name (optional)", text: $name)
             TextField("Description (optional)", text: $description, axis: .vertical)
+                .lineLimit(2 ... 4)
 
-            GroupBox("Files") {
-                HStack {
-                    Text(files.isEmpty ? "No files selected" : "\(files.count) files selected")
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Button("Choose Files…") {
-                        files = ImportedMediaPicker.selectFiles() ?? files
-                    }
+            HStack {
+                Button("Add Files…", systemImage: "plus") {
+                    files.append(contentsOf: ImportedMediaPicker.selectFiles() ?? [])
                 }
-                .padding(6)
+                Button("Add YouTube URLs", systemImage: "link") {
+                    showURLField.toggle()
+                }
+                Button("Add from Recordings", systemImage: "waveform") {
+                    showRecordingPicker.toggle()
+                }
             }
+            .controlSize(.small)
 
-            GroupBox("YouTube URLs") {
+            if showURLField {
                 TextEditor(text: $urlText)
                     .font(.body.monospaced())
                     .frame(height: 64)
+                    .padding(6)
                     .overlay {
                         RoundedRectangle(cornerRadius: 5).strokeBorder(Color(.separatorColor))
                     }
-                    .padding(6)
             }
 
-            GroupBox("Library") {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("SELECTED SOURCES")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(10)
+
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 8) {
-                        ForEach(recordings) { recording in
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        if files.isEmpty && urlLines.isEmpty && selectedRecordingIDs.isEmpty && !showRecordingPicker {
+                            Text("Add files, YouTube URLs, or existing recordings.")
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.vertical, 36)
+                        }
+
+                        ForEach(files, id: \.self) { file in
+                            sourceRow(file.lastPathComponent, icon: "doc") {
+                                files.removeAll { $0 == file }
+                            }
+                        }
+                        ForEach(urlLines, id: \.self) { url in
+                            sourceRow(url, icon: "play.rectangle") {
+                                removeURL(url)
+                            }
+                        }
+                        ForEach(recordings.filter { selectedRecordingIDs.contains($0.id) }) { recording in
+                            sourceRow(recording.displayTitle, icon: recording.libraryIconName) {
+                                selectedRecordingIDs.remove(recording.id)
+                            }
+                        }
+
+                        if showRecordingPicker {
+                            Divider().padding(.vertical, 6)
+                            Text("RECORDINGS")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 10)
+                                .padding(.bottom, 6)
+                            ForEach(recordings.filter { !selectedRecordingIDs.contains($0.id) }) { recording in
                             Toggle(isOn: Binding(
                                 get: { selectedRecordingIDs.contains(recording.id) },
                                 set: { selected in
@@ -362,15 +255,19 @@ private struct NewTranscriptionBatchSheet: View {
                                     else { selectedRecordingIDs.remove(recording.id) }
                                 }
                             )) {
-                                Text(recording.remoteSource?.title ?? recording.sourceFileName ?? recording.libraryDisplayName)
+                                Text(recording.displayTitle).lineLimit(1)
                             }
                             .toggleStyle(.checkbox)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            }
                         }
                     }
-                    .padding(6)
                 }
-                .frame(height: 150)
+                .frame(minHeight: 160, maxHeight: 260)
             }
+            .background(Color(.textBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+            .overlay { RoundedRectangle(cornerRadius: 8).strokeBorder(Color(.separatorColor)) }
 
             if let validationError {
                 Text(validationError).font(.caption).foregroundStyle(.red)
@@ -385,7 +282,30 @@ private struct NewTranscriptionBatchSheet: View {
             }
         }
         .padding(24)
-        .frame(width: 620, height: 600)
+        .frame(width: 560)
+        .frame(minHeight: 460)
+    }
+
+    private var urlLines: [String] {
+        urlText.split(whereSeparator: \.isNewline).map(String.init)
+    }
+
+    private func sourceRow(_ title: String, icon: String, onRemove: @escaping () -> Void) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon).frame(width: 18).foregroundStyle(.secondary)
+            Text(title).lineLimit(1)
+            Spacer()
+            Button(action: onRemove) { Image(systemName: "xmark.circle.fill") }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Remove \(title)")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+    }
+
+    private func removeURL(_ url: String) {
+        urlText = urlLines.filter { $0 != url }.joined(separator: "\n")
     }
 
     private func createBatch() {

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -96,7 +96,7 @@ struct TranscriptionBatchInspectorView: View {
                                     batchService.resume(batch: currentBatch)
                                 }
                                 .controlSize(.small)
-                                .disabled(batchService.isProcessing)
+                                .disabled(!batchService.canResume(batch: currentBatch))
                             }
                             Button {
                                 ClipboardService.shared.copy(

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -175,6 +175,7 @@ struct TranscriptionBatchesView: View {
                 .buttonStyle(.plain)
                 Spacer()
                 Button("Delete", role: .destructive) { deletingBatch = batch }
+                    .disabled(!batch.isProcessingClosed)
                 Button("Edit") { editingBatch = batch }
                 if canRetry {
                     Button("Retry Failed") {

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -667,6 +667,30 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
 
         service.add(urls: [URL(fileURLWithPath: "/tmp/late.m4a")])
         XCTAssertEqual(service.items.count, 1)
+        XCTAssertEqual(service.items.first?.sourceURL.lastPathComponent, "late.m4a")
+        XCTAssertEqual(batchStore.createCount, 2)
+    }
+
+    func test_beginBatchRejectsOverlappingBatch() async throws {
+        let transcriber = BatchTestTranscriber(waitsForRelease: true)
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: transcriber,
+            recordingStore: BatchTestRecordingStore(),
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")])
+        try await waitUntil { service.isProcessing }
+        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
+
+        XCTAssertEqual(batchStore.createCount, 1)
+        XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
+        transcriber.releaseAll()
+        try await waitUntil { !service.isProcessing }
     }
 
     func test_remoteRetryReusesDownloadedAudioAfterPreparationFailure() async throws {
@@ -1526,12 +1550,14 @@ private final class BatchTestPersistence: FileTranscriptionBatchPersisting {
     private(set) var recordingIDs: [UUID] = []
     private(set) var didClose = false
     private(set) var didReopen = false
+    private(set) var createCount = 0
 
     func createBatch(
         name: String,
         description: String,
         recordingIDs: [UUID]
     ) throws -> UUID {
+        createCount += 1
         createdName = name
         createdDescription = description
         self.recordingIDs = recordingIDs

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -685,10 +685,11 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
             playCompletionSound: {}
         )
 
-        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")])
+        XCTAssertTrue(service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")]))
         try await waitUntil { transcriber.transcribedFileNames == ["first.m4a"] }
-        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
+        let accepted = service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
 
+        XCTAssertFalse(accepted)
         XCTAssertEqual(batchStore.createCount, 1)
         XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
         transcriber.releaseAll()
@@ -706,9 +707,10 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
             playCompletionSound: {}
         )
 
-        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")])
-        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
+        XCTAssertTrue(service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")]))
+        let accepted = service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
 
+        XCTAssertFalse(accepted)
         XCTAssertEqual(batchStore.createCount, 1)
         XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
     }

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -642,6 +642,54 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertTrue(batchStore.didClose)
     }
 
+    func test_beginBatchCombinesFilesURLsAndExistingLibraryRecordingsInOrder() throws {
+        let existingID = UUID()
+        let fileID = UUID()
+        let remoteID = UUID()
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(
+                duplicate: BatchTranscriptionDuplicate(
+                    recordingID: fileID,
+                    transcriptionText: "File",
+                    durationSeconds: 1
+                ),
+                remoteDuplicate: BatchTranscriptionDuplicate(
+                    recordingID: remoteID,
+                    transcriptionText: "Remote",
+                    durationSeconds: 1,
+                    sourceCaptionArtifacts: [
+                        TranscriptArtifact(
+                            text: "Captions",
+                            languageCode: "en",
+                            provenance: .youtubeAuthored
+                        )
+                    ]
+                ),
+                matchingRemoteMediaID: source.mediaID
+            ),
+            remoteExtractor: BatchTestRemoteExtractor(),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(
+            urls: [URL(fileURLWithPath: "/tmp/file.m4a")],
+            remoteSources: [source],
+            name: "Mixed",
+            description: "",
+            existingRecordingIDs: [existingID]
+        )
+
+        XCTAssertEqual(batchStore.recordingIDs, [existingID, fileID, remoteID])
+        XCTAssertTrue(batchStore.didClose)
+    }
+
     func test_remoteDuplicateWithMissingCaptionsRetrievesOnlyCaptionArtifact() async throws {
         let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
         let caption = TranscriptArtifact(

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -37,6 +37,31 @@ final class YouTubeRemoteMediaSourceTests: XCTestCase {
         XCTAssertEqual(sources.map(\.mediaID), ["dQw4w9WgXcQ", "aqz-KE-bpKQ"])
     }
 
+    func test_validateBatch_reportsValidDuplicateAndInvalidLines() {
+        let validation = YouTubeRemoteMediaSource.validateBatch(
+            """
+            https://youtu.be/dQw4w9WgXcQ
+            https://youtube.com/watch?v=dQw4w9WgXcQ&t=10
+            not-a-youtube-url
+            https://youtube.com/shorts/aqz-KE-bpKQ
+            """
+        )
+
+        XCTAssertEqual(validation.sources.map(\.mediaID), ["dQw4w9WgXcQ", "aqz-KE-bpKQ"])
+        XCTAssertEqual(validation.duplicateCount, 1)
+        XCTAssertEqual(validation.invalidValues, ["not-a-youtube-url"])
+    }
+
+    func test_validateBatch_reportsURLsAlreadyInBatchAsDuplicates() {
+        let validation = YouTubeRemoteMediaSource.validateBatch(
+            "https://youtu.be/dQw4w9WgXcQ",
+            excludingMediaIDs: ["dQw4w9WgXcQ"]
+        )
+
+        XCTAssertTrue(validation.sources.isEmpty)
+        XCTAssertEqual(validation.duplicateCount, 1)
+    }
+
     func test_captionSelection_prefersAuthoredOriginalLanguageThenAutomatic() {
         let authored = RemoteCaptionTrack(
             languageCode: "uk",
@@ -802,6 +827,86 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
 
         XCTAssertEqual(batchStore.recordingIDs, [existingID, fileID, remoteID])
         XCTAssertTrue(batchStore.didClose)
+    }
+
+    func test_appendToCompletedBatchReopensAndPreservesAllMembership() throws {
+        let existingID = UUID()
+        let addedExistingID = UUID()
+        let fileID = UUID()
+        let remoteID = UUID()
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(
+                duplicate: BatchTranscriptionDuplicate(
+                    recordingID: fileID,
+                    transcriptionText: "File",
+                    durationSeconds: 1
+                ),
+                remoteDuplicate: BatchTranscriptionDuplicate(
+                    recordingID: remoteID,
+                    transcriptionText: "Remote",
+                    durationSeconds: 1,
+                    sourceCaptionArtifacts: []
+                ),
+                matchingRemoteMediaID: source.mediaID
+            ),
+            remoteExtractor: BatchTestRemoteExtractor(),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+        let batch = TranscriptionBatch(
+            name: "Research",
+            isProcessingClosed: true,
+            recordingIDs: [existingID]
+        )
+
+        let accepted = service.append(
+            to: batch,
+            urls: [URL(fileURLWithPath: "/tmp/file.m4a")],
+            remoteSources: [source],
+            existingRecordingIDs: [addedExistingID]
+        )
+
+        XCTAssertTrue(accepted)
+        XCTAssertTrue(batchStore.didReopen)
+        XCTAssertTrue(batchStore.didClose)
+        XCTAssertEqual(batchStore.createCount, 0)
+        XCTAssertEqual(batchStore.recordingIDs, [existingID, addedExistingID, fileID, remoteID])
+    }
+
+    func test_appendRemoteSourceRequiresRightsBeforeReopeningBatch() throws {
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(),
+            remoteExtractor: BatchTestRemoteExtractor(),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            remoteMediaAuthorized: { false },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        let accepted = service.append(
+            to: TranscriptionBatch(name: "Research", isProcessingClosed: true),
+            urls: [],
+            remoteSources: [source],
+            existingRecordingIDs: []
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertFalse(batchStore.didReopen)
+        XCTAssertEqual(
+            service.batchError,
+            "Confirm that you own this content or have permission to transcribe it."
+        )
     }
 
     func test_resumePersistedBatchReusesPreparedRecordingCheckpoint() async throws {

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -840,6 +840,36 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertTrue(batchStore.didClose)
     }
 
+    func test_resumedLocalBatchMarksTranscriptAsLocal() async throws {
+        let recordingID = UUID()
+        var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/source.m4a"))
+        item.recordingID = recordingID
+        item.status = .failed
+        let batch = TranscriptionBatch(
+            name: "Local retry",
+            isProcessingClosed: true,
+            recordingIDs: [recordingID],
+            workItems: [item]
+        )
+        let store = BatchTestRecordingStore(
+            existingRecordingID: recordingID,
+            audioFileURL: URL(fileURLWithPath: "/tmp/saved.m4a")
+        )
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: store,
+            batchPersistence: BatchTestPersistence(),
+            settingsSnapshot: { .localTestValue },
+            playCompletionSound: {}
+        )
+
+        service.resume(batch: batch)
+        try await waitUntil { !service.isProcessing }
+
+        XCTAssertEqual(store.completedProvenance?.provider, "local")
+    }
+
     func test_remoteDuplicateWithMissingCaptionsRetrievesOnlyCaptionArtifact() async throws {
         let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
         let caption = TranscriptArtifact(
@@ -1486,6 +1516,7 @@ private final class BatchTestRecordingStore: FileTranscriptionBatchRecordingStor
     private var storedAudioURLs: [UUID: URL] = [:]
     private(set) var updatedCaptionArtifacts: [TranscriptArtifact] = []
     private(set) var completedTranscript: GeneratedTranscript?
+    private(set) var completedProvenance: GeneratedTranscriptProvenance?
 
     init(
         duplicate: BatchTranscriptionDuplicate? = nil,
@@ -1553,9 +1584,10 @@ private final class BatchTestRecordingStore: FileTranscriptionBatchRecordingStor
     func markCompleted(
         recordingID _: UUID,
         transcript: GeneratedTranscript,
-        provenance _: GeneratedTranscriptProvenance?
+        provenance: GeneratedTranscriptProvenance?
     ) {
         completedTranscript = transcript
+        completedProvenance = provenance
     }
 
     func markFailed(recordingID _: UUID, error _: String) {}

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -600,6 +600,48 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertEqual(extractor.metadataCallCount, 0)
     }
 
+    func test_beginBatchPersistsReusedMembershipAndClosesFinishedBatch() throws {
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        let recordingID = UUID()
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(
+                remoteDuplicate: BatchTranscriptionDuplicate(
+                    recordingID: recordingID,
+                    transcriptionText: "Existing transcript",
+                    durationSeconds: 90,
+                    sourceCaptionArtifacts: [
+                        TranscriptArtifact(
+                            text: "Captions",
+                            languageCode: "en",
+                            provenance: .youtubeAuthored
+                        )
+                    ]
+                ),
+                matchingRemoteMediaID: source.mediaID
+            ),
+            remoteExtractor: BatchTestRemoteExtractor(),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(
+            remoteSources: [source],
+            name: "Research",
+            description: "Reused source",
+            existingRecordingIDs: []
+        )
+
+        XCTAssertEqual(batchStore.createdName, "Research")
+        XCTAssertEqual(batchStore.createdDescription, "Reused source")
+        XCTAssertEqual(batchStore.recordingIDs, [recordingID])
+        XCTAssertTrue(batchStore.didClose)
+    }
+
     func test_remoteDuplicateWithMissingCaptionsRetrievesOnlyCaptionArtifact() async throws {
         let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
         let caption = TranscriptArtifact(
@@ -1303,6 +1345,40 @@ private final class BatchTestRecordingStore: FileTranscriptionBatchRecordingStor
 
     func markFailed(recordingID _: UUID, error _: String) {}
     func markUnprocessed(recordingID _: UUID) {}
+}
+
+@MainActor
+private final class BatchTestPersistence: FileTranscriptionBatchPersisting {
+    let batchID = UUID()
+    private(set) var createdName: String?
+    private(set) var createdDescription: String?
+    private(set) var recordingIDs: [UUID] = []
+    private(set) var didClose = false
+
+    func createBatch(
+        name: String,
+        description: String,
+        recordingIDs: [UUID]
+    ) throws -> UUID {
+        createdName = name
+        createdDescription = description
+        self.recordingIDs = recordingIDs
+        return batchID
+    }
+
+    func addRecordingIDs(_ recordingIDs: [UUID], to _: UUID) throws {
+        for id in recordingIDs where !self.recordingIDs.contains(id) {
+            self.recordingIDs.append(id)
+        }
+    }
+
+    func replaceRecordingIDs(_ recordingIDs: [UUID], in _: UUID) throws {
+        self.recordingIDs = recordingIDs
+    }
+
+    func closeBatch(_: UUID) throws {
+        didClose = true
+    }
 }
 
 private enum BatchTestError: Error {

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -690,6 +690,44 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertTrue(batchStore.didClose)
     }
 
+    func test_resumePersistedBatchReusesPreparedRecordingCheckpoint() async throws {
+        let recordingID = UUID()
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        var item = BatchTranscriptionItem(remoteSource: source)
+        item.recordingID = recordingID
+        item.status = .failed
+        item.errorMessage = "Offline"
+        let batch = TranscriptionBatch(
+            name: "Retry",
+            isProcessingClosed: true,
+            recordingIDs: [recordingID],
+            workItems: [item]
+        )
+        let preparer = BatchTestPreparer()
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: preparer,
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(
+                existingRecordingID: recordingID,
+                audioFileURL: URL(fileURLWithPath: "/tmp/saved.m4a")
+            ),
+            remoteExtractor: BatchTestRemoteExtractor(),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.resume(batch: batch)
+        try await waitUntil { !service.isProcessing }
+
+        XCTAssertEqual(preparer.preparedSourceNames, [])
+        XCTAssertEqual(service.items.first?.status, .completed)
+        XCTAssertTrue(batchStore.didReopen)
+        XCTAssertTrue(batchStore.didClose)
+    }
+
     func test_remoteDuplicateWithMissingCaptionsRetrievesOnlyCaptionArtifact() async throws {
         let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
         let caption = TranscriptArtifact(
@@ -1330,13 +1368,18 @@ private final class BatchTestRecordingStore: FileTranscriptionBatchRecordingStor
         matchingSourceIdentity: ImportedMediaIdentity? = nil,
         remoteDuplicate: BatchTranscriptionDuplicate? = nil,
         matchingRemoteMediaID: String? = nil,
-        storesRemoteAudio: Bool = false
+        storesRemoteAudio: Bool = false,
+        existingRecordingID: UUID? = nil,
+        audioFileURL: URL? = nil
     ) {
         self.duplicate = duplicate
         self.matchingSourceIdentity = matchingSourceIdentity
         self.remoteDuplicate = remoteDuplicate
         self.matchingRemoteMediaID = matchingRemoteMediaID
         self.storesRemoteAudio = storesRemoteAudio
+        if let existingRecordingID, let audioFileURL {
+            storedAudioURLs[existingRecordingID] = audioFileURL
+        }
     }
 
     func completedDuplicate(sourceIdentity: ImportedMediaIdentity) -> BatchTranscriptionDuplicate? {
@@ -1402,6 +1445,7 @@ private final class BatchTestPersistence: FileTranscriptionBatchPersisting {
     private(set) var createdDescription: String?
     private(set) var recordingIDs: [UUID] = []
     private(set) var didClose = false
+    private(set) var didReopen = false
 
     func createBatch(
         name: String,
@@ -1422,6 +1466,12 @@ private final class BatchTestPersistence: FileTranscriptionBatchPersisting {
 
     func replaceRecordingIDs(_ recordingIDs: [UUID], in _: UUID) throws {
         self.recordingIDs = recordingIDs
+    }
+
+    func replaceWorkItems(_: [BatchTranscriptionItem], in _: UUID) throws {}
+
+    func reopenBatch(_: UUID) throws {
+        didReopen = true
     }
 
     func closeBatch(_: UUID) throws {

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -829,7 +829,7 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertTrue(batchStore.didClose)
     }
 
-    func test_appendToCompletedBatchReopensAndPreservesAllMembership() throws {
+    func test_appendToCompletedBatchReopensAndPreservesAllMembership() async throws {
         let existingID = UUID()
         let addedExistingID = UUID()
         let fileID = UUID()
@@ -873,6 +873,7 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(accepted)
+        try await waitUntil { batchStore.didClose }
         XCTAssertTrue(batchStore.didReopen)
         XCTAssertTrue(batchStore.didClose)
         XCTAssertEqual(batchStore.createCount, 0)

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -403,6 +403,30 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(extractor.metadataCallCount, 3)
     }
 
+    func test_remoteAuthorizationPauseIsPersistedForRestart() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BatchAuthorizationPersistence-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(),
+            remoteExtractor: BatchTestRemoteExtractor(captionAuthorizationFailureCount: 1),
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+
+        service.beginBatch(remoteSources: [source])
+        try await waitUntil { service.items.first?.status == .authorizationPaused }
+
+        let reloaded = try TranscriptionBatchStorage(baseDirectory: directory)
+        XCTAssertEqual(reloaded.batches.first?.workItems?.first?.status, .authorizationPaused)
+    }
+
     func test_stopBatchDuringRemotePreflightMarksItemsCancelledWithoutAcquisition() async throws {
         let extractor = BatchTestRemoteExtractor(metadataDelay: .milliseconds(500))
         let service = FileTranscriptionBatchService(
@@ -1187,6 +1211,7 @@ private final class BatchTestPreparer: FileTranscriptionBatchPreparing {
 @MainActor
 private final class BatchTestRemoteExtractor: RemoteMediaExtracting {
     private var remainingAuthorizationFailures: Int
+    private var remainingCaptionAuthorizationFailures: Int
     private var remainingCaptionFailures: Int
     private let caption: TranscriptArtifact?
     private let metadataDelay: Duration
@@ -1198,12 +1223,14 @@ private final class BatchTestRemoteExtractor: RemoteMediaExtracting {
 
     init(
         metadataAuthorizationFailureCount: Int = 0,
+        captionAuthorizationFailureCount: Int = 0,
         caption: TranscriptArtifact? = nil,
         captionFailureCount: Int = 0,
         metadataDelay: Duration = .zero,
         downloadDelay: Duration = .zero
     ) {
         remainingAuthorizationFailures = metadataAuthorizationFailureCount
+        remainingCaptionAuthorizationFailures = captionAuthorizationFailureCount
         remainingCaptionFailures = captionFailureCount
         self.caption = caption
         self.metadataDelay = metadataDelay
@@ -1248,6 +1275,10 @@ private final class BatchTestRemoteExtractor: RemoteMediaExtracting {
         metadata _: RemoteMediaMetadata,
         profile _: ChromeProfile
     ) async throws -> TranscriptArtifact? {
+        if remainingCaptionAuthorizationFailures > 0 {
+            remainingCaptionAuthorizationFailures -= 1
+            throw RemoteMediaExtractorError.authorizationRequired
+        }
         if remainingCaptionFailures > 0 {
             remainingCaptionFailures -= 1
             throw BatchTestError.captionFailed

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -104,6 +104,7 @@ final class YouTubeRemoteMediaSourceTests: XCTestCase {
           "id": "dQw4w9WgXcQ",
           "title": "A video",
           "uploader": "A channel",
+          "description": "Source description",
           "duration": 125.5,
           "original_language": "uk",
           "is_live": false,
@@ -123,6 +124,7 @@ final class YouTubeRemoteMediaSourceTests: XCTestCase {
 
         XCTAssertEqual(metadata.source.title, "A video")
         XCTAssertEqual(metadata.source.channelName, "A channel")
+        XCTAssertEqual(metadata.source.description, "Source description")
         XCTAssertEqual(metadata.audioFormatID, "audio-best")
         XCTAssertEqual(metadata.preferredCaption?.kind, .authored)
         XCTAssertEqual(metadata.durationSeconds, 125.5, accuracy: 0.001)

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -664,6 +664,50 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertEqual(batchStore.createdDescription, "Reused source")
         XCTAssertEqual(batchStore.recordingIDs, [recordingID])
         XCTAssertTrue(batchStore.didClose)
+
+        service.add(urls: [URL(fileURLWithPath: "/tmp/late.m4a")])
+        XCTAssertEqual(service.items.count, 1)
+    }
+
+    func test_remoteRetryReusesDownloadedAudioAfterPreparationFailure() async throws {
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        let extractor = BatchTestRemoteExtractor()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(failingSourceNames: ["dQw4w9WgXcQ.m4a"]),
+            transcriber: BatchTestTranscriber(),
+            recordingStore: BatchTestRecordingStore(),
+            remoteExtractor: extractor,
+            chromeProfile: { ChromeProfile(id: "Default", name: "Roman") },
+            batchPersistence: BatchTestPersistence(),
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(remoteSources: [source])
+        try await waitUntil { !service.isProcessing }
+        service.retryFailed()
+        try await waitUntil { !service.isProcessing }
+
+        XCTAssertEqual(extractor.downloadCallCount, 1)
+    }
+
+    func test_retryResumesSubmittedCloudJobWithoutUploadingAgain() async throws {
+        let transcriber = BatchTestTranscriber(failureCount: 1)
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: transcriber,
+            recordingStore: BatchTestRecordingStore(),
+            batchPersistence: BatchTestPersistence(),
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/upload.m4a")])
+        try await waitUntil { !service.isProcessing }
+        service.retryFailed()
+        try await waitUntil { !service.isProcessing }
+
+        XCTAssertEqual(transcriber.receivedResumeJobIDs, [nil, "test-job"])
     }
 
     func test_beginBatchCombinesFilesURLsAndExistingLibraryRecordingsInOrder() throws {
@@ -1317,6 +1361,7 @@ private final class BatchTestTranscriber: FileTranscriptionBatchTranscribing {
     private(set) var transcribedFileNames: [String] = []
     private(set) var receivedSettings: [FileTranscriptionSettingsSnapshot] = []
     private(set) var maximumConcurrentCount = 0
+    private(set) var receivedResumeJobIDs: [String?] = []
     private var concurrentCount = 0
     private var remainingFailures: Int
     private let delay: Duration
@@ -1351,8 +1396,12 @@ private final class BatchTestTranscriber: FileTranscriptionBatchTranscribing {
         settings: FileTranscriptionSettingsSnapshot,
         source _: String,
         sourceDurationSeconds _: TimeInterval?,
+        resumeJobID: String?,
+        onJobSubmitted: @escaping (String) -> Void,
         onUpdate: @escaping (JobProgressUpdate) -> Void
     ) async throws -> GeneratedTranscript {
+        receivedResumeJobIDs.append(resumeJobID)
+        if resumeJobID == nil { onJobSubmitted("test-job") }
         transcribedFileNames.append(audioFileURL.lastPathComponent)
         receivedSettings.append(settings)
         concurrentCount += 1

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -684,13 +684,31 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         )
 
         service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")])
-        try await waitUntil { service.isProcessing }
+        try await waitUntil { transcriber.transcribedFileNames == ["first.m4a"] }
         service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
 
         XCTAssertEqual(batchStore.createCount, 1)
         XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
         transcriber.releaseAll()
         try await waitUntil { !service.isProcessing }
+    }
+
+    func test_beginBatchRejectsOverlapWhileFirstBatchIsPreflightBlocked() {
+        let batchStore = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(preflightError: "Offline"),
+            recordingStore: BatchTestRecordingStore(),
+            batchPersistence: batchStore,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+
+        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/first.m4a")])
+        service.beginBatch(urls: [URL(fileURLWithPath: "/tmp/second.m4a")])
+
+        XCTAssertEqual(batchStore.createCount, 1)
+        XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
     }
 
     func test_remoteRetryReusesDownloadedAudioAfterPreparationFailure() async throws {

--- a/DidunyTests/FileTranscriptionBatchServiceTests.swift
+++ b/DidunyTests/FileTranscriptionBatchServiceTests.swift
@@ -840,6 +840,33 @@ final class FileTranscriptionBatchServiceTests: XCTestCase {
         XCTAssertTrue(batchStore.didClose)
     }
 
+    func test_resumeDoesNotReplaceAnotherBlockedPersistentBatch() {
+        let persistence = BatchTestPersistence()
+        let service = FileTranscriptionBatchService(
+            preparer: BatchTestPreparer(),
+            transcriber: BatchTestTranscriber(preflightError: "Offline"),
+            recordingStore: BatchTestRecordingStore(),
+            batchPersistence: persistence,
+            settingsSnapshot: { .testValue },
+            playCompletionSound: {}
+        )
+        service.beginBatch(
+            urls: [URL(fileURLWithPath: "/tmp/first.m4a")],
+            remoteSources: [],
+            name: "First",
+            description: "",
+            existingRecordingIDs: []
+        )
+        var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/second.m4a"))
+        item.status = .failed
+        let second = TranscriptionBatch(name: "Second", isProcessingClosed: true, workItems: [item])
+
+        XCTAssertFalse(service.canResume(batch: second))
+        service.resume(batch: second)
+
+        XCTAssertEqual(service.items.map(\.sourceURL.lastPathComponent), ["first.m4a"])
+    }
+
     func test_resumedLocalBatchMarksTranscriptAsLocal() async throws {
         let recordingID = UUID()
         var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/source.m4a"))

--- a/DidunyTests/NotchManagerTests.swift
+++ b/DidunyTests/NotchManagerTests.swift
@@ -232,3 +232,28 @@ struct NotchManagerTests {
                 "Timer must continue from original start time after ESC info")
     }
 }
+
+@Suite("Dictation overlay controls")
+@MainActor
+struct DictationOverlayControllerTests {
+    @Test("Stop cancels voice recording while it is still starting")
+    func stopCancelsStartingVoiceRecording() async {
+        let delegate = AppDelegate()
+        delegate.appState.recordingState = .processing
+
+        await delegate.stopActiveRecordingFromNotch()
+
+        #expect(delegate.appState.recordingState == .idle)
+    }
+
+    @Test("Stop does not cancel voice recording while it is finalizing")
+    func stopDoesNotCancelFinalizingVoiceRecording() async {
+        let delegate = AppDelegate()
+        delegate.appState.recordingState = .processing
+        delegate.appState.recordingStartTime = Date()
+
+        await delegate.stopActiveRecordingFromNotch()
+
+        #expect(delegate.appState.recordingState == .processing)
+    }
+}

--- a/DidunyTests/RecordingModelMigrationTests.swift
+++ b/DidunyTests/RecordingModelMigrationTests.swift
@@ -195,7 +195,7 @@ final class RecordingModelMigrationTests: XCTestCase {
                     startMilliseconds: 3_661_000,
                     endMilliseconds: 3_662_000,
                     text: "Later phrase."
-                ),
+                )
             ]
         )
 

--- a/DidunyTests/RecordingModelMigrationTests.swift
+++ b/DidunyTests/RecordingModelMigrationTests.swift
@@ -89,6 +89,18 @@ final class RecordingModelMigrationTests: XCTestCase {
         XCTAssertEqual(recording.transcriptionText, "Hello world.")
     }
 
+    func test_legacyJSON_surfacesScalarTranscriptAsHistoryWithoutDataLoss() throws {
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let recording = try iso8601.decode([Recording].self, from: data)[0]
+
+        let version = try XCTUnwrap(recording.resolvedTranscriptHistory.first)
+        XCTAssertEqual(recording.resolvedTranscriptHistory.count, 1)
+        XCTAssertEqual(version.id, recording.id)
+        XCTAssertEqual(version.createdAt, recording.processedAt)
+        XCTAssertEqual(version.kind, .cloud)
+        XCTAssertEqual(version.text, "Hello world.")
+    }
+
     // MARK: - 2. Round-trip
 
     func test_roundTrip_orphanedSession_partiallyRecovered() throws {
@@ -237,6 +249,40 @@ final class RecordingModelMigrationTests: XCTestCase {
 
         XCTAssertEqual(decoded.sourceFileName, "Product walkthrough.mov")
         XCTAssertEqual(decoded.sourceFileSizeBytes, 81920)
+    }
+
+    func test_roundTrip_preservesEditableDetailsAndTranscriptHistory() throws {
+        let version = TranscriptVersion(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 1_700_100_100),
+            kind: .translation,
+            provider: "cloud",
+            sourceLanguageCode: "en",
+            targetLanguageCode: "es",
+            text: "Hola"
+        )
+        let original = Recording(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 1_700_100_000),
+            type: .fileTranscription,
+            audioFileName: "interview.m4a",
+            durationSeconds: 30,
+            fileSizeBytes: 4096,
+            status: .translated,
+            transcriptionText: "Hola",
+            sourceDevice: nil,
+            title: "Customer interview",
+            description: "Onboarding research",
+            transcriptHistory: [version]
+        )
+
+        let data = try iso8601Encoder.encode([original])
+        let decoded = try iso8601.decode([Recording].self, from: data)[0]
+
+        XCTAssertEqual(decoded.title, "Customer interview")
+        XCTAssertEqual(decoded.description, "Onboarding research")
+        XCTAssertEqual(decoded.displayTitle, "Customer interview")
+        XCTAssertEqual(decoded.resolvedTranscriptHistory, [version])
     }
 
     func test_interruptedProcessingResetsToUnprocessedAfterLoad() {

--- a/DidunyTests/RecordingsLibraryFilterTests.swift
+++ b/DidunyTests/RecordingsLibraryFilterTests.swift
@@ -2,6 +2,23 @@
 import XCTest
 
 final class RecordingsLibraryFilterTests: XCTestCase {
+    @MainActor
+    func test_batchComposerActionTargetsRecordingsWithSharedTitle() {
+        let controller = MainWindowController.shared
+        controller.requestedSection = nil
+        controller.requestedBatchComposer = false
+        defer {
+            controller.requestedSection = nil
+            controller.requestedBatchComposer = false
+        }
+
+        controller.requestBatchComposer()
+
+        XCTAssertEqual(MainWindowController.batchComposerActionTitle, "Batch Files and URLs…")
+        XCTAssertEqual(controller.requestedSection, .recordings)
+        XCTAssertTrue(controller.requestedBatchComposer)
+    }
+
     func test_filesFilterMatchesOnlyImportedFileTranscriptions() {
         let file = makeRecording(remoteSource: nil)
         let youtube = makeRecording(remoteSource: makeYouTubeSource())

--- a/DidunyTests/RecordingsLibraryFilterTests.swift
+++ b/DidunyTests/RecordingsLibraryFilterTests.swift
@@ -28,6 +28,31 @@ final class RecordingsLibraryFilterTests: XCTestCase {
         XCTAssertTrue(RecordingsLibraryView.RecordingTypeFilter.hasTranslation.matches(recording))
     }
 
+    func test_batchesFilterShowsBatchesInsteadOfIndividualRecordings() {
+        let recording = makeRecording(remoteSource: nil)
+
+        XCTAssertTrue(RecordingsLibraryView.RecordingTypeFilter.batches.showsBatches)
+        XCTAssertFalse(RecordingsLibraryView.RecordingTypeFilter.batches.matches(recording))
+    }
+
+    func test_recordingOpenedFromBatchCanNavigateBackButDirectRecordingCannot() {
+        let batchID = UUID()
+        let recordingID = UUID()
+        let nested = RecordingsInspectorSelection.recording(
+            recordingID,
+            parentBatchID: batchID
+        )
+        let direct = RecordingsInspectorSelection.recording(
+            recordingID,
+            parentBatchID: nil
+        )
+
+        XCTAssertEqual(nested.parentBatchID, batchID)
+        XCTAssertEqual(nested.backDestination, .batch(batchID))
+        XCTAssertNil(direct.parentBatchID)
+        XCTAssertNil(direct.backDestination)
+    }
+
     private func makeRecording(remoteSource: RemoteMediaSourceMetadata?) -> Recording {
         Recording(
             id: UUID(),

--- a/DidunyTests/RecordingsLibraryFilterTests.swift
+++ b/DidunyTests/RecordingsLibraryFilterTests.swift
@@ -19,6 +19,15 @@ final class RecordingsLibraryFilterTests: XCTestCase {
         XCTAssertEqual(recording.libraryIconName, "play.rectangle.fill")
     }
 
+    func test_hasTranslationMatchesAttachedTranslationArtifact() {
+        var recording = makeRecording(remoteSource: nil)
+        XCTAssertFalse(RecordingsLibraryView.RecordingTypeFilter.hasTranslation.matches(recording))
+
+        recording.translationTargetLanguageCode = "en"
+
+        XCTAssertTrue(RecordingsLibraryView.RecordingTypeFilter.hasTranslation.matches(recording))
+    }
+
     private func makeRecording(remoteSource: RemoteMediaSourceMetadata?) -> Recording {
         Recording(
             id: UUID(),

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -74,7 +74,24 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(persisted.markdown(recordings: []).contains("Network unavailable"))
     }
 
-    func test_batchDerivesStatusSearchAndMarkdownFromCurrentRecordings() throws {
+    func test_corruptMetadataIsPreservedAndBlocksWritesInsteadOfCrashing() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadataURL = directory.appendingPathComponent("transcription_batches.json")
+        let corruptData = Data("not-json".utf8)
+        try corruptData.write(to: metadataURL)
+
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+
+        XCTAssertTrue(store.batches.isEmpty)
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertThrowsError(try store.create(name: "Must not overwrite", recordingIDs: []))
+        XCTAssertEqual(try Data(contentsOf: metadataURL), corruptData)
+    }
+
+    func test_batchDerivesStatusSearchAndMarkdownFromCurrentRecordings() {
         let completed = makeRecording(title: "Quarterly planning", transcript: "Revenue grew")
         let failed = makeRecording(title: "Customer call", status: .failed, transcript: nil)
         let batch = TranscriptionBatch(
@@ -184,7 +201,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         let target = try batchStore.create(name: "Target", recordingIDs: [firstID, secondID])
         _ = try batchStore.create(name: "Other", recordingIDs: [secondID])
 
-        recordingStore.deleteRecording(try XCTUnwrap(
+        try recordingStore.deleteRecording(XCTUnwrap(
             recordingStore.recordings.first(where: { $0.id == firstID })
         ))
         XCTAssertTrue(batchStore.batches.allSatisfy { !$0.recordingIDs.contains(firstID) })
@@ -213,6 +230,41 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         let recording = try XCTUnwrap(store.recordings.first(where: { $0.id == id }))
         XCTAssertEqual(recording.title, "Interview")
         XCTAssertEqual(recording.description, "Research notes")
+    }
+
+    func test_audioExtensionOptimizationPreservesDetailsAndTranscriptHistory() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingOptimizationTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let sourceURL = directory.appendingPathComponent("source.wav")
+        try Data("fLaC-audio".utf8).write(to: sourceURL)
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let id = try XCTUnwrap(store.saveRecording(
+            audioURL: sourceURL,
+            type: .fileTranscription,
+            duration: 1,
+            transcriptionText: "Original",
+            forceSave: true
+        ))
+        store.updateDetails(id: id, title: "Interview", description: "Research notes")
+        store.completeTranscription(
+            id: id,
+            status: .transcribed,
+            text: "Local revision",
+            segments: nil,
+            kind: .local,
+            provider: "local"
+        )
+
+        _ = await store.optimizeStoredRecordingIfNeeded(id: id)
+
+        let recording = try XCTUnwrap(store.recordings.first(where: { $0.id == id }))
+        XCTAssertEqual(recording.audioFileName, "\(id.uuidString).flac")
+        XCTAssertEqual(recording.title, "Interview")
+        XCTAssertEqual(recording.description, "Research notes")
+        XCTAssertEqual(recording.resolvedTranscriptHistory.map(\.text), ["Original", "Local revision"])
     }
 
     func test_completedTranscriptionsAppendHistoryInsteadOfReplacingIt() throws {
@@ -255,7 +307,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertEqual(recording.resolvedTranscriptHistory.map(\.text), [
             "Cloud original",
             "Local revision",
-            "Revisión local",
+            "Revisión local"
         ])
         XCTAssertEqual(recording.resolvedTranscriptHistory.map(\.kind), [.cloud, .local, .translation])
         XCTAssertEqual(recording.resolvedTranscriptHistory[1].modelIdentifier, "whisper-small")
@@ -264,10 +316,10 @@ final class TranscriptionBatchStorageTests: XCTestCase {
     }
 
     func test_batchSearchAndMarkdownIncludeDetailsSourceAndEveryTranscriptVersion() throws {
-        let source = RemoteMediaSourceMetadata(
+        let source = try RemoteMediaSourceMetadata(
             provider: YouTubeRemoteMediaSource.provider,
             mediaID: "dQw4w9WgXcQ",
-            canonicalURL: try XCTUnwrap(URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")),
+            canonicalURL: XCTUnwrap(URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")),
             title: "Original YouTube title",
             channelName: "Channel",
             description: "YouTube source notes"
@@ -300,7 +352,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
                     sourceLanguageCode: "en",
                     targetLanguageCode: "es",
                     text: "Texto actual"
-                ),
+                )
             ]
         )
         let batch = TranscriptionBatch(

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -91,6 +91,21 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: metadataURL), corruptData)
     }
 
+    func test_unreadableExistingMetadataBlocksWrites() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadataURL = directory.appendingPathComponent("transcription_batches.json")
+        try FileManager.default.createDirectory(at: metadataURL, withIntermediateDirectories: true)
+
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+
+        XCTAssertNotNil(store.loadErrorMessage)
+        XCTAssertThrowsError(try store.create(name: "Must not overwrite", recordingIDs: []))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: metadataURL.path))
+    }
+
     func test_batchDerivesStatusSearchAndMarkdownFromCurrentRecordings() {
         let completed = makeRecording(title: "Quarterly planning", transcript: "Revenue grew")
         let failed = makeRecording(title: "Customer call", status: .failed, transcript: nil)
@@ -467,5 +482,62 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(store.recordings.contains(where: { $0.id == recordingID }))
         XCTAssertTrue(FileManager.default.fileExists(atPath: store.audioFileURL(for: recording).path))
         XCTAssertEqual(batchStore.batches.first?.recordingIDs, [recordingID])
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("recordings_delete_recovery.json").path
+        ))
+    }
+
+    func test_startupRestoresRecordingMetadataFromDeletionRecoveryJournal() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingDeleteRecoveryTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let recordingsDirectory = directory.appendingPathComponent("Recordings")
+        try FileManager.default.createDirectory(at: recordingsDirectory, withIntermediateDirectories: true)
+        let recording = Recording(
+            id: UUID(),
+            createdAt: Date(),
+            type: .fileTranscription,
+            audioFileName: "recovered.m4a",
+            durationSeconds: 1,
+            fileSizeBytes: 5,
+            status: .transcribed,
+            transcriptionText: "Recovered",
+            sourceDevice: nil,
+            title: "Recovered"
+        )
+        try Data("audio".utf8).write(
+            to: recordingsDirectory.appendingPathComponent(recording.audioFileName)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode([recording]).write(
+            to: directory.appendingPathComponent("recordings_delete_recovery.json")
+        )
+        try Data("[]".utf8).write(to: directory.appendingPathComponent("recordings_metadata.json"))
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        for _ in 0 ..< 100 where store.recordings.isEmpty {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(store.recordings.map(\.id), [recording.id])
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("recordings_delete_recovery.json").path
+        ))
+    }
+
+    func test_batchDeletionRejectsArtifactOutsideDidunyTemporaryDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BatchArtifactBoundaryTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/source.m4a"))
+        item.downloadedAudioURL = URL(fileURLWithPath: "/Applications/not-a-diduny-checkpoint")
+        let batch = try batchStore.create(name: "Protected", recordingIDs: [])
+        try batchStore.replaceWorkItems([item], in: batch.id)
+
+        XCTAssertThrowsError(try batchStore.delete(batchID: batch.id))
+        XCTAssertEqual(batchStore.batches.map(\.id), [batch.id])
     }
 }

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -52,6 +52,28 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(persisted.isProcessingClosed)
     }
 
+    func test_storeRoundTripPreservesFailedWorkForRestartRetry() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = try YouTubeRemoteMediaSource.normalize("https://youtu.be/dQw4w9WgXcQ")
+        var item = BatchTranscriptionItem(remoteSource: source)
+        item.status = .failed
+        item.errorMessage = "Network unavailable"
+
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+        let batch = try store.create(name: "Retry", recordingIDs: [])
+        try store.replaceWorkItems([item], in: batch.id)
+        try store.close(batchID: batch.id)
+
+        let persisted = try XCTUnwrap(
+            try TranscriptionBatchStorage(baseDirectory: directory).batches.first
+        )
+        XCTAssertEqual(persisted.workItems, [item])
+        XCTAssertEqual(persisted.status(in: []), .completedWithIssues)
+        XCTAssertTrue(persisted.markdown(recordings: []).contains("Network unavailable"))
+    }
+
     func test_batchDerivesStatusSearchAndMarkdownFromCurrentRecordings() throws {
         let completed = makeRecording(title: "Quarterly planning", transcript: "Revenue grew")
         let failed = makeRecording(title: "Customer call", status: .failed, transcript: nil)

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -115,6 +115,8 @@ final class TranscriptionBatchStorageTests: XCTestCase {
             try XCTUnwrap(markdown.range(of: "first.m4a")?.lowerBound),
             try XCTUnwrap(markdown.range(of: "Second")?.lowerBound)
         )
+        XCTAssertTrue(markdown.contains("Source: File Transcription"))
+        XCTAssertFalse(markdown.contains("/tmp/first.m4a"))
     }
 
     func test_removingRecordingCleansEveryBatchReference() throws {

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -428,4 +428,44 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: checkpointDirectory.path))
         XCTAssertTrue(batchStore.batches.allSatisfy { !$0.recordingIDs.contains(id) })
     }
+
+    func test_failedBatchMetadataWriteRollsBackInMemoryReferences() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BatchDeleteRollbackTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let recordingID = UUID()
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        _ = try batchStore.create(name: "Protected", recordingIDs: [recordingID])
+        let metadataURL = directory.appendingPathComponent("transcription_batches.json")
+        try FileManager.default.removeItem(at: metadataURL)
+        try FileManager.default.createDirectory(at: metadataURL, withIntermediateDirectories: true)
+
+        XCTAssertThrowsError(try batchStore.removeRecordingReferences(Set([recordingID])))
+        XCTAssertEqual(batchStore.batches.first?.recordingIDs, [recordingID])
+    }
+
+    func test_failedRecordingMetadataWriteKeepsRecordingFileAndBatchReference() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingDeleteRollbackTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let recordingID = try XCTUnwrap(store.saveRecording(
+            audioData: Data("audio".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            forceSave: true
+        ))
+        let recording = try XCTUnwrap(store.recordings.first)
+        _ = try batchStore.create(name: "Protected", recordingIDs: [recordingID])
+        let metadataURL = directory.appendingPathComponent("recordings_metadata.json")
+        try FileManager.default.removeItem(at: metadataURL)
+        try FileManager.default.createDirectory(at: metadataURL, withIntermediateDirectories: true)
+
+        XCTAssertFalse(store.deleteRecording(recording))
+
+        XCTAssertTrue(store.recordings.contains(where: { $0.id == recordingID }))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.audioFileURL(for: recording).path))
+        XCTAssertEqual(batchStore.batches.first?.recordingIDs, [recordingID])
+    }
 }

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -494,6 +494,61 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         ))
     }
 
+    @MainActor
+    func test_immediateSaveAfterStartupPreservesExistingRecordingMetadata() async throws {
+        let originalPolicy = SettingsStorage.shared.dictationTranslationHistoryRetentionPolicy
+        SettingsStorage.shared.dictationTranslationHistoryRetentionPolicy = .forever
+        defer {
+            SettingsStorage.shared.dictationTranslationHistoryRetentionPolicy = originalPolicy
+        }
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingStartupSaveTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let recordingsDirectory = directory.appendingPathComponent("Recordings")
+        try FileManager.default.createDirectory(
+            at: recordingsDirectory,
+            withIntermediateDirectories: true
+        )
+        let existing = Recording(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .fileTranscription,
+            audioFileName: "existing.wav",
+            durationSeconds: 1,
+            fileSizeBytes: 8,
+            status: .transcribed,
+            transcriptionText: "Existing",
+            sourceDevice: nil
+        )
+        try Data("existing".utf8).write(
+            to: recordingsDirectory.appendingPathComponent(existing.audioFileName)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode([existing]).write(
+            to: directory.appendingPathComponent("recordings_metadata.json"),
+            options: .atomic
+        )
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let newID = try XCTUnwrap(store.saveRecording(
+            audioData: Data("new".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            transcriptionText: "New",
+            forceSave: true
+        ))
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(100))
+
+        let data = try Data(contentsOf: directory.appendingPathComponent("recordings_metadata.json"))
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let persisted = try decoder.decode([Recording].self, from: data)
+        XCTAssertEqual(Set(persisted.map(\.id)), Set([existing.id, newID]))
+    }
+
     func test_startupRestoresRecordingMetadataFromDeletionRecoveryJournal() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("RecordingDeleteRecoveryTests-\(UUID())")

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -105,4 +105,41 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertEqual(store.batches.count, 1)
         XCTAssertEqual(store.batches[0].recordingIDs, [])
     }
+
+    func test_recordingAndBatchDeletionStayReferentiallyConsistent() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let recordingStore = RecordingsLibraryStorage(
+            baseDirectory: directory,
+            batchStorage: batchStore
+        )
+        let firstID = try XCTUnwrap(recordingStore.saveRecording(
+            audioData: Data("first".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            transcriptionText: "First",
+            forceSave: true
+        ))
+        let secondID = try XCTUnwrap(recordingStore.saveRecording(
+            audioData: Data("second".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            transcriptionText: "Second",
+            forceSave: true
+        ))
+        let target = try batchStore.create(name: "Target", recordingIDs: [firstID, secondID])
+        _ = try batchStore.create(name: "Other", recordingIDs: [secondID])
+
+        recordingStore.deleteRecording(try XCTUnwrap(
+            recordingStore.recordings.first(where: { $0.id == firstID })
+        ))
+        XCTAssertTrue(batchStore.batches.allSatisfy { !$0.recordingIDs.contains(firstID) })
+
+        recordingStore.deleteBatch(target)
+        XCTAssertTrue(recordingStore.recordings.isEmpty)
+        XCTAssertEqual(batchStore.batches.count, 1)
+        XCTAssertTrue(batchStore.batches[0].recordingIDs.isEmpty)
+    }
 }

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -269,7 +269,8 @@ final class TranscriptionBatchStorageTests: XCTestCase {
             mediaID: "dQw4w9WgXcQ",
             canonicalURL: try XCTUnwrap(URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")),
             title: "Original YouTube title",
-            channelName: "Channel"
+            channelName: "Channel",
+            description: "YouTube source notes"
         )
         let recording = Recording(
             id: UUID(),
@@ -313,6 +314,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(batch.matches("Customer workflow", recordings: [recording]))
         XCTAssertTrue(batch.matches("Research interview", recordings: [recording]))
         XCTAssertTrue(batch.matches("Original phrase", recordings: [recording]))
+        XCTAssertTrue(batch.matches("YouTube source notes", recordings: [recording]))
 
         let markdown = batch.markdown(recordings: [recording])
         XCTAssertTrue(markdown.contains("# Product research"))

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -1,0 +1,108 @@
+@testable import Diduny
+import XCTest
+
+@MainActor
+final class TranscriptionBatchStorageTests: XCTestCase {
+    private func makeRecording(
+        id: UUID = UUID(),
+        title: String,
+        status: Recording.ProcessingStatus = .transcribed,
+        transcript: String? = "Transcript"
+    ) -> Recording {
+        Recording(
+            id: id,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .fileTranscription,
+            audioFileName: "\(id).m4a",
+            durationSeconds: 60,
+            fileSizeBytes: 42,
+            status: status,
+            transcriptionText: transcript,
+            sourceDevice: nil,
+            sourceFileName: title
+        )
+    }
+
+    func test_storeRoundTripPreservesOrderedMembershipAndEditableMetadata() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstID = UUID()
+        let secondID = UUID()
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+        let batch = try store.create(
+            name: "  ",
+            description: "Initial",
+            recordingIDs: [firstID, secondID],
+            createdAt: createdAt
+        )
+        XCTAssertTrue(batch.name.hasPrefix("Batch — "))
+        XCTAssertTrue(batch.name.contains("2023"))
+        try store.update(batchID: batch.id, name: "Research", description: "Updated")
+        try store.close(batchID: batch.id)
+
+        let reloaded = try TranscriptionBatchStorage(baseDirectory: directory)
+        let persisted = try XCTUnwrap(reloaded.batches.first)
+        XCTAssertEqual(persisted.name, "Research")
+        XCTAssertEqual(persisted.description, "Updated")
+        XCTAssertEqual(persisted.createdAt, createdAt)
+        XCTAssertEqual(persisted.recordingIDs, [firstID, secondID])
+        XCTAssertTrue(persisted.isProcessingClosed)
+    }
+
+    func test_batchDerivesStatusSearchAndMarkdownFromCurrentRecordings() throws {
+        let completed = makeRecording(title: "Quarterly planning", transcript: "Revenue grew")
+        let failed = makeRecording(title: "Customer call", status: .failed, transcript: nil)
+        let batch = TranscriptionBatch(
+            name: "Planning",
+            description: "Board preparation",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isProcessingClosed: true,
+            recordingIDs: [completed.id, failed.id]
+        )
+        let recordings = [completed, failed]
+
+        XCTAssertEqual(batch.status(in: recordings), .completedWithIssues)
+        XCTAssertTrue(batch.matches("revenue", recordings: recordings))
+        XCTAssertTrue(batch.matches("customer", recordings: recordings))
+        XCTAssertEqual(
+            batch.markdown(recordings: recordings),
+            "# Quarterly planning\n\nSource: File Transcription\n\nRevenue grew\n\n# Customer call\n\nSource: File Transcription\n\n[Transcript unavailable — Failed]"
+        )
+    }
+
+    func test_removingRecordingCleansEveryBatchReference() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sharedID = UUID()
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+        _ = try store.create(name: "One", recordingIDs: [sharedID])
+        _ = try store.create(name: "Two", recordingIDs: [UUID(), sharedID])
+
+        try store.removeRecordingReferences(Set([sharedID]))
+
+        XCTAssertTrue(store.batches.allSatisfy { !$0.recordingIDs.contains(sharedID) })
+        let reloaded = try TranscriptionBatchStorage(baseDirectory: directory)
+        XCTAssertTrue(reloaded.batches.allSatisfy { !$0.recordingIDs.contains(sharedID) })
+    }
+
+    func test_deleteReturnsAllAffectedRecordingIDsAndRemovesSharedReferences() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sharedID = UUID()
+        let ownedID = UUID()
+        let store = try TranscriptionBatchStorage(baseDirectory: directory)
+        let target = try store.create(name: "Target", recordingIDs: [ownedID, sharedID])
+        _ = try store.create(name: "Other", recordingIDs: [sharedID])
+
+        let affected = try store.delete(batchID: target.id)
+
+        XCTAssertEqual(affected, Set([ownedID, sharedID]))
+        XCTAssertEqual(store.batches.count, 1)
+        XCTAssertEqual(store.batches[0].recordingIDs, [])
+    }
+}

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -95,6 +95,28 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         )
     }
 
+    func test_markdownKeepsFailedAndCompletedWorkItemOrder() throws {
+        let completed = makeRecording(title: "Second", transcript: "Done")
+        var failedItem = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/first.m4a"))
+        failedItem.status = .failed
+        failedItem.errorMessage = "Failed first"
+        var completedItem = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/second.m4a"))
+        completedItem.status = .completed
+        completedItem.recordingID = completed.id
+        let batch = TranscriptionBatch(
+            name: "Ordered",
+            isProcessingClosed: true,
+            recordingIDs: [completed.id],
+            workItems: [failedItem, completedItem]
+        )
+
+        let markdown = batch.markdown(recordings: [completed])
+        XCTAssertLessThan(
+            try XCTUnwrap(markdown.range(of: "first.m4a")?.lowerBound),
+            try XCTUnwrap(markdown.range(of: "Second")?.lowerBound)
+        )
+    }
+
     func test_removingRecordingCleansEveryBatchReference() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptionBatchStorageTests-\(UUID())")
@@ -119,13 +141,17 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         let ownedID = UUID()
         let store = try TranscriptionBatchStorage(baseDirectory: directory)
         let target = try store.create(name: "Target", recordingIDs: [ownedID, sharedID])
-        _ = try store.create(name: "Other", recordingIDs: [sharedID])
+        let other = try store.create(name: "Other", recordingIDs: [sharedID])
+        var sharedItem = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/shared.m4a"))
+        sharedItem.recordingID = sharedID
+        try store.replaceWorkItems([sharedItem], in: other.id)
 
         let affected = try store.delete(batchID: target.id)
 
         XCTAssertEqual(affected, Set([ownedID, sharedID]))
         XCTAssertEqual(store.batches.count, 1)
         XCTAssertEqual(store.batches[0].recordingIDs, [])
+        XCTAssertEqual(store.batches[0].workItems, [])
     }
 
     func test_recordingAndBatchDeletionStayReferentiallyConsistent() throws {

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -89,10 +89,12 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertEqual(batch.status(in: recordings), .completedWithIssues)
         XCTAssertTrue(batch.matches("revenue", recordings: recordings))
         XCTAssertTrue(batch.matches("customer", recordings: recordings))
-        XCTAssertEqual(
-            batch.markdown(recordings: recordings),
-            "# Quarterly planning\n\nSource: File Transcription\n\nRevenue grew\n\n# Customer call\n\nSource: File Transcription\n\n[Transcript unavailable — Failed]"
-        )
+        let markdown = batch.markdown(recordings: recordings)
+        XCTAssertTrue(markdown.contains("# Planning"))
+        XCTAssertTrue(markdown.contains("## Quarterly planning"))
+        XCTAssertTrue(markdown.contains("Revenue grew"))
+        XCTAssertTrue(markdown.contains("## Customer call"))
+        XCTAssertTrue(markdown.contains("[Transcript unavailable — Failed]"))
     }
 
     func test_markdownKeepsFailedAndCompletedWorkItemOrder() throws {
@@ -115,7 +117,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
             try XCTUnwrap(markdown.range(of: "first.m4a")?.lowerBound),
             try XCTUnwrap(markdown.range(of: "Second")?.lowerBound)
         )
-        XCTAssertTrue(markdown.contains("Source: File Transcription"))
+        XCTAssertTrue(markdown.contains("Type: File Transcription"))
         XCTAssertFalse(markdown.contains("/tmp/first.m4a"))
     }
 
@@ -191,5 +193,169 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(recordingStore.recordings.isEmpty)
         XCTAssertEqual(batchStore.batches.count, 1)
         XCTAssertTrue(batchStore.batches[0].recordingIDs.isEmpty)
+    }
+
+    func test_recordingDetailsUpdateThroughLibraryStorage() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingDetailsTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let id = try XCTUnwrap(store.saveRecording(
+            audioData: Data("audio".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            forceSave: true
+        ))
+
+        store.updateDetails(id: id, title: "  Interview  ", description: "  Research notes  ")
+
+        let recording = try XCTUnwrap(store.recordings.first(where: { $0.id == id }))
+        XCTAssertEqual(recording.title, "Interview")
+        XCTAssertEqual(recording.description, "Research notes")
+    }
+
+    func test_completedTranscriptionsAppendHistoryInsteadOfReplacingIt() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptHistoryTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let id = try XCTUnwrap(store.saveRecording(
+            audioData: Data("audio".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            transcriptionText: "Cloud original",
+            generatedTranscriptProvenance: GeneratedTranscriptProvenance(provider: "cloud"),
+            forceSave: true
+        ))
+
+        store.completeTranscription(
+            id: id,
+            status: .transcribed,
+            text: "Local revision",
+            segments: nil,
+            kind: .local,
+            provider: "local",
+            modelIdentifier: "whisper-small"
+        )
+        store.completeTranscription(
+            id: id,
+            status: .translated,
+            text: "Revisión local",
+            segments: nil,
+            translationTargetLanguageCode: "es",
+            kind: .translation,
+            provider: "cloud",
+            sourceLanguageCode: "en"
+        )
+
+        let recording = try XCTUnwrap(store.recordings.first(where: { $0.id == id }))
+        XCTAssertEqual(recording.transcriptionText, "Revisión local")
+        XCTAssertEqual(recording.resolvedTranscriptHistory.map(\.text), [
+            "Cloud original",
+            "Local revision",
+            "Revisión local",
+        ])
+        XCTAssertEqual(recording.resolvedTranscriptHistory.map(\.kind), [.cloud, .local, .translation])
+        XCTAssertEqual(recording.resolvedTranscriptHistory[1].modelIdentifier, "whisper-small")
+        XCTAssertEqual(recording.resolvedTranscriptHistory[2].sourceLanguageCode, "en")
+        XCTAssertEqual(recording.resolvedTranscriptHistory[2].targetLanguageCode, "es")
+    }
+
+    func test_batchSearchAndMarkdownIncludeDetailsSourceAndEveryTranscriptVersion() throws {
+        let source = RemoteMediaSourceMetadata(
+            provider: YouTubeRemoteMediaSource.provider,
+            mediaID: "dQw4w9WgXcQ",
+            canonicalURL: try XCTUnwrap(URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")),
+            title: "Original YouTube title",
+            channelName: "Channel"
+        )
+        let recording = Recording(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .fileTranscription,
+            audioFileName: "video.m4a",
+            durationSeconds: 65,
+            fileSizeBytes: 42,
+            status: .translated,
+            transcriptionText: "Texto actual",
+            sourceDevice: nil,
+            remoteSource: source,
+            title: "Customer workflow",
+            description: "Research interview",
+            transcriptHistory: [
+                TranscriptVersion(
+                    createdAt: Date(timeIntervalSince1970: 1_700_000_010),
+                    kind: .cloud,
+                    provider: "cloud",
+                    sourceLanguageCode: "en",
+                    text: "Original phrase"
+                ),
+                TranscriptVersion(
+                    createdAt: Date(timeIntervalSince1970: 1_700_000_020),
+                    kind: .translation,
+                    provider: "cloud",
+                    sourceLanguageCode: "en",
+                    targetLanguageCode: "es",
+                    text: "Texto actual"
+                ),
+            ]
+        )
+        let batch = TranscriptionBatch(
+            name: "Product research",
+            description: "Onboarding",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            isProcessingClosed: true,
+            recordingIDs: [recording.id]
+        )
+
+        XCTAssertTrue(batch.matches("Customer workflow", recordings: [recording]))
+        XCTAssertTrue(batch.matches("Research interview", recordings: [recording]))
+        XCTAssertTrue(batch.matches("Original phrase", recordings: [recording]))
+
+        let markdown = batch.markdown(recordings: [recording])
+        XCTAssertTrue(markdown.contains("# Product research"))
+        XCTAssertTrue(markdown.contains("Onboarding"))
+        XCTAssertTrue(markdown.contains("## Customer workflow"))
+        XCTAssertTrue(markdown.contains("Duration: 1:05"))
+        XCTAssertTrue(markdown.contains("Research interview"))
+        XCTAssertTrue(markdown.contains(source.canonicalURL.absoluteString))
+        XCTAssertTrue(markdown.contains("### Cloud"))
+        XCTAssertTrue(markdown.contains("Original phrase"))
+        XCTAssertTrue(markdown.contains("### Translation · en → es"))
+        XCTAssertTrue(markdown.contains("Texto actual"))
+    }
+
+    func test_deletingRecordingRemovesStoredMediaCheckpointAndBatchReferences() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingCascadeDeleteTests-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let checkpointDirectory = directory.appendingPathComponent("checkpoint", isDirectory: true)
+        try FileManager.default.createDirectory(at: checkpointDirectory, withIntermediateDirectories: true)
+        let checkpointURL = checkpointDirectory.appendingPathComponent("download.m4a")
+        try Data("checkpoint".utf8).write(to: checkpointURL)
+
+        let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
+        let store = RecordingsLibraryStorage(baseDirectory: directory, batchStorage: batchStore)
+        let id = try XCTUnwrap(store.saveRecording(
+            audioData: Data("audio".utf8),
+            type: .fileTranscription,
+            duration: 1,
+            forceSave: true
+        ))
+        let recording = try XCTUnwrap(store.recordings.first(where: { $0.id == id }))
+        let storedMediaURL = store.audioFileURL(for: recording)
+        var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/source.m4a"))
+        item.recordingID = id
+        item.downloadedAudioURL = checkpointURL
+        let batch = try batchStore.create(name: "Delete", recordingIDs: [id])
+        try batchStore.replaceWorkItems([item], in: batch.id)
+
+        store.deleteRecording(recording)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storedMediaURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: checkpointDirectory.path))
+        XCTAssertTrue(batchStore.batches.allSatisfy { !$0.recordingIDs.contains(id) })
     }
 }

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -450,13 +450,20 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: directory) }
         let recordingID = UUID()
         let batchStore = try TranscriptionBatchStorage(baseDirectory: directory)
-        _ = try batchStore.create(name: "Protected", recordingIDs: [recordingID])
+        let checkpointURL = directory.appendingPathComponent("checkpoint.m4a")
+        try Data("checkpoint".utf8).write(to: checkpointURL)
+        var item = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/source.m4a"))
+        item.recordingID = recordingID
+        item.downloadedAudioURL = checkpointURL
+        let batch = try batchStore.create(name: "Protected", recordingIDs: [recordingID])
+        try batchStore.replaceWorkItems([item], in: batch.id)
         let metadataURL = directory.appendingPathComponent("transcription_batches.json")
         try FileManager.default.removeItem(at: metadataURL)
         try FileManager.default.createDirectory(at: metadataURL, withIntermediateDirectories: true)
 
         XCTAssertThrowsError(try batchStore.removeRecordingReferences(Set([recordingID])))
         XCTAssertEqual(batchStore.batches.first?.recordingIDs, [recordingID])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: checkpointURL.path))
     }
 
     func test_failedRecordingMetadataWriteKeepsRecordingFileAndBatchReference() throws {
@@ -505,12 +512,18 @@ final class TranscriptionBatchStorageTests: XCTestCase {
             sourceDevice: nil,
             title: "Recovered"
         )
-        try Data("audio".utf8).write(
-            to: recordingsDirectory.appendingPathComponent(recording.audioFileName)
-        )
+        let originalURL = recordingsDirectory.appendingPathComponent(recording.audioFileName)
+        let stagedURL = recordingsDirectory.appendingPathComponent(".recovered.deleting-test")
+        try Data("audio".utf8).write(to: stagedURL)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        try encoder.encode([recording]).write(
+        try encoder.encode(RecordingDeletionRecovery(
+            recordings: [recording],
+            stagedFiles: [RecordingDeletionStagedFile(
+                originalPath: originalURL.path,
+                stagedPath: stagedURL.path
+            )]
+        )).write(
             to: directory.appendingPathComponent("recordings_delete_recovery.json")
         )
         try Data("[]".utf8).write(to: directory.appendingPathComponent("recordings_metadata.json"))
@@ -522,6 +535,7 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         }
 
         XCTAssertEqual(store.recordings.map(\.id), [recording.id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: originalURL.path))
         XCTAssertFalse(FileManager.default.fileExists(
             atPath: directory.appendingPathComponent("recordings_delete_recovery.json").path
         ))

--- a/DidunyTests/TranscriptionBatchStorageTests.swift
+++ b/DidunyTests/TranscriptionBatchStorageTests.swift
@@ -114,6 +114,22 @@ final class TranscriptionBatchStorageTests: XCTestCase {
         XCTAssertTrue(markdown.contains("[Transcript unavailable — Failed]"))
     }
 
+    func test_retryableWorkItemsExcludeCompletedAndDuplicateResults() {
+        var failed = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/failed.m4a"))
+        failed.status = .failed
+        var completed = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/completed.m4a"))
+        completed.status = .completed
+        var duplicate = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/duplicate.m4a"))
+        duplicate.status = .duplicate
+        let batch = TranscriptionBatch(
+            name: "Retry",
+            isProcessingClosed: true,
+            workItems: [failed, completed, duplicate]
+        )
+
+        XCTAssertEqual(batch.retryableWorkItems.map(\.id), [failed.id])
+    }
+
     func test_markdownKeepsFailedAndCompletedWorkItemOrder() throws {
         let completed = makeRecording(title: "Second", transcript: "Done")
         var failedItem = BatchTranscriptionItem(sourceURL: URL(fileURLWithPath: "/tmp/first.m4a"))

--- a/docs/adr/0007-retranscribe-existing-recording-in-place.md
+++ b/docs/adr/0007-retranscribe-existing-recording-in-place.md
@@ -1,3 +1,5 @@
 # Re-transcribe an existing recording in place
 
+Status: Superseded by ADR 0009.
+
 `Transcribe Again` will update the existing recording's generated transcript after explicit confirmation instead of creating a second recording or retaining transcript versions. Source captions, source identity, and recording metadata remain attached to the same recording. This keeps the recordings list deduplicated while accepting that the previous generated transcript is replaced.

--- a/docs/adr/0008-cascade-delete-batch-recordings.md
+++ b/docs/adr/0008-cascade-delete-batch-recordings.md
@@ -1,0 +1,3 @@
+# Cascade-delete recordings with their batch
+
+Deleting a transcription batch will delete every recording referenced by that batch, including recordings that were added from the Library or shared with another batch. Those recordings are removed from the Library and from every other batch, so completed batch membership and counts may change. The UI must explicitly confirm the affected recording count and warn about shared recordings. This favors a simple ownership experience over preserving shared material and accepts the resulting data-loss risk as an intentional product decision.

--- a/docs/adr/0009-preserve-recording-transcript-history.md
+++ b/docs/adr/0009-preserve-recording-transcript-history.md
@@ -1,0 +1,3 @@
+# Preserve recording transcript history
+
+Each successful cloud transcription, local transcription, or translation appends a durable version to the existing recording. Reprocessing does not create a duplicate recording and does not overwrite earlier successful output. The latest version remains projected through the legacy scalar transcript fields until their consumers migrate. Existing scalar-only recordings surface as one legacy history entry, while YouTube source captions remain separate provenance artifacts under ADR 0003.

--- a/docs/design/transcription-batches.md
+++ b/docs/design/transcription-batches.md
@@ -1,0 +1,23 @@
+# Transcription Batches Design
+
+## Model
+
+Persist a `TranscriptionBatch` with an identifier, editable name and description, immutable creation date, processing-closed flag, and ordered recording identifiers. Derive counts and status from referenced recordings instead of storing duplicate summary values.
+
+Each in-progress recording persists its latest completed processing checkpoint and the artifact needed by the next step. Existing completed recordings enter a batch by identifier and do not enter the processing queue.
+
+## Flow
+
+1. The composer collects files, YouTube URLs, and existing recording identifiers.
+2. Create the batch and recording rows together, then start only work that lacks a completed transcript.
+3. Persist each successful pipeline artifact before advancing the item state.
+4. On failure, keep the item and checkpoint. Retry schedules the failed step.
+5. When no work remains, derive Completed or Completed with Issues and close normal membership editing.
+
+## Deletion integrity
+
+Batch deletion is one destructive operation: resolve all referenced recording identifiers, show their count in confirmation, delete the recordings, remove their references from other batches, then delete the selected batch. Recording deletion uses the same shared reference cleanup. The operation must not leave a batch pointing to a missing recording.
+
+## Reuse
+
+Extend the existing recording storage, duplicate matching, transcript artifact provenance, and file/remote transcription pipeline. Do not introduce Project, Folder, or Calendar models in this slice.

--- a/docs/design/transcription-batches.md
+++ b/docs/design/transcription-batches.md
@@ -4,15 +4,21 @@
 
 Persist a `TranscriptionBatch` with an identifier, editable name and description, immutable creation date, processing-closed flag, and ordered recording identifiers. Derive counts and status from referenced recordings instead of storing duplicate summary values.
 
+Persist optional recording title, description, and transcript history. Keep the existing scalar transcript fields as the current projection for compatible consumers; legacy scalar transcripts surface as one history entry.
+
 Each in-progress recording persists its latest completed processing checkpoint and the artifact needed by the next step. Existing completed recordings enter a batch by identifier and do not enter the processing queue.
 
 ## Flow
 
-1. The composer collects files, YouTube URLs, and existing recording identifiers.
+1. Recordings exposes a Batches filter. Its compact composer collects files, YouTube URLs, and existing recording identifiers in one selected-sources list.
 2. Create the batch and recording rows together, then start only work that lacks a completed transcript.
 3. Persist each successful pipeline artifact before advancing the item state.
 4. On failure, keep the item and checkpoint. Retry schedules the failed step.
 5. When no work remains, derive Completed or Completed with Issues and close normal membership editing.
+
+Selecting either a recording or a batch opens the native right inspector. A recording opened from a batch retains the batch identifier so `Back to Batch` restores the parent inspector; a directly opened recording has no back action.
+
+Each successful cloud transcription, local transcription, or translation appends a transcript-history entry and updates the scalar current projection. Failures preserve earlier entries. YouTube captions remain separate source artifacts.
 
 ## Deletion integrity
 

--- a/docs/specs/transcription-batches.md
+++ b/docs/specs/transcription-batches.md
@@ -8,7 +8,7 @@ Let a user create a durable batch from new files, YouTube URLs, and existing Lib
 
 ## Scope
 
-- Keep Batches in the existing Library sidebar design.
+- Show Batches as a filter in Recordings; do not add a sidebar destination.
 - Create a batch when the user chooses Create and Transcribe.
 - Generate `Batch — <date>, <time>` when no name is supplied.
 - Allow the name and optional description to be edited later.
@@ -18,7 +18,10 @@ Let a user create a durable batch from new files, YouTube URLs, and existing Lib
 - Treat translation as an artifact and `Has Translation` as a Library filter.
 - Search batches by name, description, member title, and member transcript.
 - Sort batches by immutable creation date, newest first.
-- Copy all member transcripts as Markdown with a heading and source type for each member. Include a status placeholder when a transcript is unavailable.
+- Open recordings and batches in the same right inspector, with contextual `Back to Batch` navigation.
+- Persist editable titles and descriptions for recordings and batches.
+- Retain every cloud, local, and translated transcript as history instead of replacing earlier output.
+- Copy all history as Markdown with recording metadata and a status placeholder when a transcript is unavailable.
 
 Projects, folders, and Calendar integration are outside this scope.
 
@@ -45,3 +48,5 @@ Projects, folders, and Calendar integration are outside this scope.
 4. A completed batch remains available with editable name and description, searchable members, creation date, and computed status.
 5. Copy Markdown includes every member in batch order and clearly labels unavailable transcripts.
 6. Destructive deletion requires confirmation and leaves no dangling batch references.
+7. Batch creation uses one compact selected-sources list for files, YouTube URLs, and existing recordings.
+8. A recording inspector supports playback, cloud/local transcription, translation, per-version copy, source metadata, and deletion.

--- a/docs/specs/transcription-batches.md
+++ b/docs/specs/transcription-batches.md
@@ -1,0 +1,47 @@
+# Transcription Batches
+
+Status: Agreed for implementation on 2026-07-27.
+
+## Goal
+
+Let a user create a durable batch from new files, YouTube URLs, and existing Library recordings, then return to the grouped results after processing finishes.
+
+## Scope
+
+- Keep Batches in the existing Library sidebar design.
+- Create a batch when the user chooses Create and Transcribe.
+- Generate `Batch — <date>, <time>` when no name is supplied.
+- Allow the name and optional description to be edited later.
+- Allow new items while processing; close normal membership editing when processing finishes.
+- Accept any existing Library recording and reuse its transcript without retranscription.
+- Allow the same recording to belong to multiple batches.
+- Treat translation as an artifact and `Has Translation` as a Library filter.
+- Search batches by name, description, member title, and member transcript.
+- Sort batches by immutable creation date, newest first.
+- Copy all member transcripts as Markdown with a heading and source type for each member. Include a status placeholder when a transcript is unavailable.
+
+Projects, folders, and Calendar integration are outside this scope.
+
+## Processing and retry
+
+- Derive batch status from its items: Processing, Completed, or Completed with Issues.
+- Keep failed and partial items visible with their failed step and retry action.
+- Persist the successful result of each YouTube step: metadata, duplicate check, captions, audio download, preparation, upload, and transcription.
+- Retry from the failed step and reuse every valid earlier checkpoint.
+- Remove intermediate files after the item succeeds or the batch is deleted.
+
+## Deletion
+
+- Deleting a recording removes it from the Library and every batch that references it.
+- Deleting a batch deletes the batch and every recording it references, including recordings shared with other batches.
+- Before batch deletion, explicitly show the number of recordings that will be deleted and state that shared recordings will disappear from other batches.
+- Batch membership and counts update after deletion.
+
+## Acceptance criteria
+
+1. A user can create one batch containing files, YouTube URLs, and selected Library recordings.
+2. A completed Library recording is reused without running transcription again.
+3. A failed YouTube item exposes its failed step, and Retry does not repeat successful earlier steps.
+4. A completed batch remains available with editable name and description, searchable members, creation date, and computed status.
+5. Copy Markdown includes every member in batch order and clearly labels unavailable transcripts.
+6. Destructive deletion requires confirmation and leaves no dangling batch references.

--- a/scripts/prepare-remote-media-runtime.sh
+++ b/scripts/prepare-remote-media-runtime.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ "${SKIP_REMOTE_MEDIA_RUNTIME:-NO}" == "YES" ]]; then
+    echo "Skipping remote media runtime bundle for this build."
+    exit 0
+fi
+
 readonly YTDLP_VERSION="2026.06.09"
 readonly YTDLP_SHA256="b82c3626952e6c14eaf654cc565866775ffd0b9ffb7021628ac59b42c2f4f244"
 readonly DENO_VERSION="2.8.1"


### PR DESCRIPTION
## What changed

- Keep transcription batches inside Recordings as a filter instead of a separate sidebar destination.
- Add one batch creation flow for files, multiple YouTube URLs, and existing recordings.
- Persist editable batch and recording details, source metadata, transcript history, and batch membership.
- Add the right-side recording and batch inspectors with transcript actions, retry/retranscription controls, translation controls, navigation, and Markdown copy-all output.
- Let completed batches reopen and accept more files, multiple YouTube URLs, or Library recordings without losing existing membership.
- Preserve resumable YouTube processing checkpoints and validate ownership/profile requirements before append.
- Fix the realtime transcript overlay Stop action during recording startup without cancelling an in-flight finalization.

## Why

Recordings previously exposed separate file and URL transcription entry points without a durable way to group related sources. The new flow makes a batch a first-class grouping inside the existing Recordings library while preserving access to individual recordings and transcript history.

The Stop issue was caused by `.processing` representing both startup and finalization. Stop now cancels only startup when no recording start time exists; active recordings use the normal stop path, while finalization is left untouched.

## Validation

- `xcodebuild -quiet -project Diduny.xcodeproj -scheme 'Diduny DEV' -configuration Debug -destination 'platform=macOS' test`
- Focused batch append, overlay startup-stop, and finalization regression tests
- Two independent correctness/standards review passes with no remaining findings
- Installed and launched the signed `Diduny DEV.app`
- Compared the implemented batch inspector against the approved Variant A HTML prototype


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create transcription batches from files, YouTube URLs, or existing recordings.
  * Monitor batch progress, retry failed items, add sources, edit details, and export transcripts.
  * View recordings and batches in the Library with improved search, filtering, and inspector navigation.
  * Preserve transcript and translation history, including provider and language details.
  * Use the unified “Batch Files and URLs…” command with ⌘⇧B.
* **Bug Fixes**
  * Improved recovery for interrupted processing and safer deletion handling.
  * Prevented incomplete processing states from remaining active when canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->