### PR TITLE
fix: restore Dynamic Notch, fix launch-at-login, panel drag, and meeting stop/transcribe

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */; };
 		03386BD1EB00ACDF8DD60759 /* EscapeCancelServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */; };
 		03BA270D9BB719167A7AA9B3 /* RealtimeTokenCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */; };
 		03EBBAC2178925692C5B0F28 /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7E2F21047194B8A5423BF5 /* OnboardingManager.swift */; };
@@ -25,7 +26,7 @@
 		22F85E040AEC97503AF68835 /* OnboardingContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1967633DAD0607B3B2756CC8 /* OnboardingContainerView.swift */; };
 		23C6396709CDCA776807C023 /* LiveDictationOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0020FC49058C60D9F2F8B4 /* LiveDictationOverlayView.swift */; };
 		247921044E1EB03B31AFDB28 /* TextTranslationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312D39F00F29463EB9AD6DE4 /* TextTranslationView.swift */; };
-		247C7BD6AD352D40A40CCFD0 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 57D44526E8ECA54C87677F5B /* LaunchAtLogin */; };
+		247C7BD6AD352D40A40CCFD0 /* DynamicNotchKit in Frameworks */ = {isa = PBXBuildFile; productRef = B431F17EA826367ED3C4D989 /* DynamicNotchKit */; };
 		25EDCFE17C039B0D2ED31505 /* TranscriptionBatchStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17DDE5421515DDFE13E751C6 /* TranscriptionBatchStorageTests.swift */; };
 		282F528D9F0D4B11455FFA3A /* AppDelegate+FileTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */; };
 		2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */; };
@@ -39,6 +40,7 @@
 		40F99144735911B3C0DF19AC /* AsyncTranscriptionJobFileUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB03AFCF7D534F613B88F580 /* AsyncTranscriptionJobFileUploadTests.swift */; };
 		438C177832C516A8BD571C36 /* WhisperModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71FCAF64D600F8EFA8B20A2 /* WhisperModelManager.swift */; };
 		45F7A5C71CE4990E10BCFCA0 /* InProgressRecordingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ECCCBC345EE579CFE2AD5F /* InProgressRecordingStoreTests.swift */; };
+		474BEF9A6D5E57064A709DFD /* NotchStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */; };
 		4845580D664C6BE034CF6835 /* MeetingChapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A53A5FD4196FA12DF76141 /* MeetingChapter.swift */; };
 		487940F814CFC276AD220600 /* RecordingsLibraryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB1662505C3C86F87F1DC06 /* RecordingsLibraryFilterTests.swift */; };
 		48D234DA0A725C503B5DEA75 /* HistoryPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED41A85ABE10582EF485F5D /* HistoryPaletteView.swift */; };
@@ -59,11 +61,13 @@
 		572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */; };
 		57FF194266BABFA6EA107750 /* HTTPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622D792451975A00E4A3FCBF /* HTTPLogger.swift */; };
 		5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F045E726DADF6E51D7778 /* ConnectMetrics.swift */; };
+		5A18DAA2CFAE9E95CCA51D24 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B9A32E3B977C8D9C16E2DC20 /* Sparkle */; };
 		5B89431A91667B55380925FB /* MainSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15385C5553FC7E235C629D0 /* MainSection.swift */; };
 		5C38E65B15A426A3B51A9EEB /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF35CE111AABBE5F2797242F /* whisper.xcframework */; };
 		62EBB796CFA5A63DB61BA0B6 /* WhisperContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */; };
 		6714EFD87502A88E18B6F7EE /* UsageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A09F4B066D5CA8FBA776EB /* UsageService.swift */; };
 		6947A364CF4E8E1A7AC3018C /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E7F6FB04A54A9F5A3F9A8F /* AuthService.swift */; };
+		6B6EA4D239D9BC8D7CB2D802 /* RecordingFeedbackSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECD47EAFC19CDD9D6561326 /* RecordingFeedbackSurface.swift */; };
 		6E95C33622E89CBD05C763D5 /* EscapeCancelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A0045FAC17572590BE16F /* EscapeCancelService.swift */; };
 		728A1A58EC0A9C07D7EA9CFC /* LiveDictationOverlayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C737BE018A4A18E4479FAD1F /* LiveDictationOverlayStore.swift */; };
 		733D324CBB0ADB12B3780BF8 /* WhisperTranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6206FCF30AD9AFE3530CB50 /* WhisperTranscriptionService.swift */; };
@@ -71,12 +75,13 @@
 		78E2E9B4903AA5A8A50AA6FC /* AppDelegate+Hotkeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */; };
 		7A7AA8F88FE669AF3F3D3981 /* RealtimeTokenCoalescerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B570652EBADE0FBAE4F9E5 /* RealtimeTokenCoalescerTests.swift */; };
 		7E2725D4B5424D54367BCC82 /* WhisperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06909181E0B9AD3B70E57E3 /* WhisperError.swift */; };
-		8089B2EF55ADCDC2F120C765 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B9A32E3B977C8D9C16E2DC20 /* Sparkle */; };
+		8089B2EF55ADCDC2F120C765 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 57D44526E8ECA54C87677F5B /* LaunchAtLogin */; };
 		818876F960D5611C3320AEC9 /* RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58445C3A1AF119838326EC9F /* RemoteConfig.swift */; };
 		86207F57859F544F066B0140 /* PushToTalkKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */; };
 		8652A9D79DB6EF0EA183113A /* CloudTranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */; };
 		87F253A77ACCB17F1C432ABC /* RecordingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2557CB1E6202CAC116B9137B /* RecordingMode.swift */; };
 		8864F470B8EFDFF965ABAA76 /* SupportedLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DCE179DA235DE6208C013 /* SupportedLanguage.swift */; };
+		8CAA1C227A9788C6A9687E7D /* NotchContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622FD84CF56FC17420114B9C /* NotchContentView.swift */; };
 		8D4D2E64E0D98B0052939BEF /* LiveTranscriptStorePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF436ACD38BA065B33601DBE /* LiveTranscriptStorePerformanceTests.swift */; };
 		8E61D4628397B11E5BCEE03D /* SystemAudioCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */; };
 		8FA6B8A6240D6AE7AEA1754C /* RealtimeTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */; };
@@ -84,6 +89,7 @@
 		91DAD0D89CF8564C34F51FD2 /* MeetingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8AA95900CA6960A83BD398 /* MeetingsView.swift */; };
 		948ADBEBD5ED5D02955F7E28 /* AudioRecorderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBD93A73F0292748E989CA5 /* AudioRecorderService.swift */; };
 		951FD5A8D4F78E536BAB7740 /* OfflineModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7786C88C96F6C70862A1E /* OfflineModelsSettingsView.swift */; };
+		9876807751B2F948878C2BDF /* NotchManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BE9CBB73A253BFF5530CBD /* NotchManager.swift */; };
 		9C3AB3F7109D41F8F612797B /* RecordingModelMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E5C44735AFF2B3983C06A1 /* RecordingModelMigrationTests.swift */; };
 		9FD5B6627D4A5BE503A607FF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E1CBBAFEDD499C3BD8C811 /* AppState.swift */; };
 		A09E73F9CCF5D1023A1E3D2F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52166362DE73BAC6891FA206 /* AppDelegate.swift */; };
@@ -171,6 +177,7 @@
 		1023A30E21CD6C2DF35A832B /* ImportedMediaAudioPreparerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportedMediaAudioPreparerTests.swift; sourceTree = "<group>"; };
 		118CE8BCA0160E31FD916B10 /* AudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevice.swift; sourceTree = "<group>"; };
 		1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTokenCoalescer.swift; sourceTree = "<group>"; };
+		12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManagerTests.swift; sourceTree = "<group>"; };
 		158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTranscription.swift; sourceTree = "<group>"; };
 		17DDE5421515DDFE13E751C6 /* TranscriptionBatchStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionBatchStorageTests.swift; sourceTree = "<group>"; };
 		18174CC5740A330799589646 /* AppDelegate+MeetingRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MeetingRecording.swift"; sourceTree = "<group>"; };
@@ -196,6 +203,7 @@
 		31E7F6FB04A54A9F5A3F9A8F /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		33AFD13CA942F8BADB2B1CC9 /* PreConnectAudioBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreConnectAudioBuffer.swift; sourceTree = "<group>"; };
 		37F0D303A220D46E8D6F7A57 /* AudioConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioConverter.swift; sourceTree = "<group>"; };
+		38BE9CBB73A253BFF5530CBD /* NotchManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManager.swift; sourceTree = "<group>"; };
 		39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlaybackService.swift; sourceTree = "<group>"; };
 		3B8AA95900CA6960A83BD398 /* MeetingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingsView.swift; sourceTree = "<group>"; };
 		3E35E1F13A5F9761C79FB488 /* AppDelegate+Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Recording.swift"; sourceTree = "<group>"; };
@@ -223,6 +231,7 @@
 		5B4AFAFBB376B839E41C6BDA /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTranscriptionService.swift; sourceTree = "<group>"; };
 		622D792451975A00E4A3FCBF /* HTTPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPLogger.swift; sourceTree = "<group>"; };
+		622FD84CF56FC17420114B9C /* NotchContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchContentView.swift; sourceTree = "<group>"; };
 		650D5A1F7778A1C35AD2F515 /* TranslationPairPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPairPickerControllerTests.swift; sourceTree = "<group>"; };
 		65DFFB871345DD916879CEBD /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushToTalkKey.swift; sourceTree = "<group>"; };
@@ -232,6 +241,7 @@
 		6B9D1F82FF8D90EF894B48C1 /* AsyncTranscriptionJobService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTranscriptionJobService.swift; sourceTree = "<group>"; };
 		6BBD93A73F0292748E989CA5 /* AudioRecorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderService.swift; sourceTree = "<group>"; };
 		6D6B26449C9E52BCC8DF79C7 /* AppDelegate+FileTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+FileTranscription.swift"; sourceTree = "<group>"; };
+		6ECD47EAFC19CDD9D6561326 /* RecordingFeedbackSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingFeedbackSurface.swift; sourceTree = "<group>"; };
 		7074B6A737CE72D77BD9AE8F /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
 		70DDD786E73A1532AE91FC20 /* SystemAudioCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioCaptureService.swift; sourceTree = "<group>"; };
 		7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectedLexiconServiceTests.swift; sourceTree = "<group>"; };
@@ -284,6 +294,7 @@
 		CB03AFCF7D534F613B88F580 /* AsyncTranscriptionJobFileUploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTranscriptionJobFileUploadTests.swift; sourceTree = "<group>"; };
 		CC7B8E01BE6E59078F7581EF /* MultipartFormDataFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataFileTests.swift; sourceTree = "<group>"; };
 		D1B0622318D71BD3A1EEA701 /* ShortcutsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsView.swift; sourceTree = "<group>"; };
+		D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchStateTests.swift; sourceTree = "<group>"; };
 		D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingSpeedMeasurementTests.swift; sourceTree = "<group>"; };
 		DB47383A0059A74CA8DEA1AB /* MainWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowView.swift; sourceTree = "<group>"; };
 		DCC34E52E29A97B99C122898 /* TranscriptCleanupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptCleanupServiceTests.swift; sourceTree = "<group>"; };
@@ -314,8 +325,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E6C0A2BB2B96403F5AD765B3 /* KeyboardShortcuts in Frameworks */,
-				247C7BD6AD352D40A40CCFD0 /* LaunchAtLogin in Frameworks */,
-				8089B2EF55ADCDC2F120C765 /* Sparkle in Frameworks */,
+				247C7BD6AD352D40A40CCFD0 /* DynamicNotchKit in Frameworks */,
+				8089B2EF55ADCDC2F120C765 /* LaunchAtLogin in Frameworks */,
+				5A18DAA2CFAE9E95CCA51D24 /* Sparkle in Frameworks */,
 				5C38E65B15A426A3B51A9EEB /* whisper.xcframework in Frameworks */,
 				2EF13108B3414D04405FD360 /* Accelerate.framework in Frameworks */,
 				D88F0858310A14339ADE4178 /* Metal.framework in Frameworks */,
@@ -343,6 +355,15 @@
 				2ABF3F1FBD81398469047BB4 /* DidunyTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		1D2A9DD81BDB6D428A219153 /* Notch */ = {
+			isa = PBXGroup;
+			children = (
+				622FD84CF56FC17420114B9C /* NotchContentView.swift */,
+				38BE9CBB73A253BFF5530CBD /* NotchManager.swift */,
+			);
+			path = Notch;
 			sourceTree = "<group>";
 		};
 		1FD5AFC9EA02A0334CB2B377 /* Whisper */ = {
@@ -387,6 +408,7 @@
 				67216EAEE79FD497A77BD7D6 /* PushToTalkKey.swift */,
 				158C39D9362442B65F2948C6 /* RealtimeTranscription.swift */,
 				B5D4FC33778F42CC48FF44C5 /* Recording.swift */,
+				6ECD47EAFC19CDD9D6561326 /* RecordingFeedbackSurface.swift */,
 				2557CB1E6202CAC116B9137B /* RecordingMode.swift */,
 				58445C3A1AF119838326EC9F /* RemoteConfig.swift */,
 				459DCE179DA235DE6208C013 /* SupportedLanguage.swift */,
@@ -492,6 +514,7 @@
 				73AEE95C1B136F70300747A0 /* Main */,
 				8C591E450F5E000EC7D5E839 /* Meetings */,
 				6C36C552190EC6F27298225F /* MenuBar */,
+				1D2A9DD81BDB6D428A219153 /* Notch */,
 				24CE2F228CAA8E6C664796F8 /* Onboarding */,
 				4B8A68CAD04C9047027A278E /* Overview */,
 				9DDE6C7594E6F4CA5171F56A /* RecordingsLibrary */,
@@ -647,6 +670,8 @@
 				89D392B1899E2DDB878B7F1F /* LocalWhisperStreamingServiceTests.swift */,
 				4E5E0CC22FD7FC0DA86702AF /* MeetingChunkStitcherTests.swift */,
 				CC7B8E01BE6E59078F7581EF /* MultipartFormDataFileTests.swift */,
+				12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */,
+				D34BB7F6DB9091D30035DAA0 /* NotchStateTests.swift */,
 				F6FBC676468A5F7C9F54507E /* PreConnectAudioBufferTests.swift */,
 				7144FB4309E888B25A0048C8 /* ProtectedLexiconServiceTests.swift */,
 				51CA770F4886473BDED207C7 /* PushToTalkServiceTests.swift */,
@@ -736,6 +761,7 @@
 			name = Diduny;
 			packageProductDependencies = (
 				2E72BE3A05C906A8B16DBE4E /* KeyboardShortcuts */,
+				B431F17EA826367ED3C4D989 /* DynamicNotchKit */,
 				57D44526E8ECA54C87677F5B /* LaunchAtLogin */,
 				B9A32E3B977C8D9C16E2DC20 /* Sparkle */,
 			);
@@ -791,6 +817,7 @@
 			mainGroup = B6C1477395B1431F550CF057;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				EEB3C042DE7A825E199A8D2F /* XCRemoteSwiftPackageReference "DynamicNotchKit" */,
 				44A6802ED268E042B3E340B9 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 				40D87DB8B850A83EB00FF9EE /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
 				9F0000456CA7E8DED8E2171B /* XCRemoteSwiftPackageReference "Sparkle" */,
@@ -915,6 +942,8 @@
 				EBD6CE2EED71E6F9BC63E53E /* MenuBarContentView.swift in Sources */,
 				DB3964EFB7C60E392C41A920 /* MenuBarIconView.swift in Sources */,
 				E3E8F971F59805899C8277E0 /* MultipartFormDataFile.swift in Sources */,
+				8CAA1C227A9788C6A9687E7D /* NotchContentView.swift in Sources */,
+				9876807751B2F948878C2BDF /* NotchManager.swift in Sources */,
 				BF3538E2F19CF3EB9D232E7A /* ObjCExceptionCatcher.m in Sources */,
 				951FD5A8D4F78E536BAB7740 /* OfflineModelsSettingsView.swift in Sources */,
 				214683A40F227DDAE1D64C8B /* OnboardingComponents.swift in Sources */,
@@ -931,6 +960,7 @@
 				8FA6B8A6240D6AE7AEA1754C /* RealtimeTranscription.swift in Sources */,
 				E2A1278EF4D20EC10319BBF4 /* Recording.swift in Sources */,
 				572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */,
+				6B6EA4D239D9BC8D7CB2D802 /* RecordingFeedbackSurface.swift in Sources */,
 				87F253A77ACCB17F1C432ABC /* RecordingMode.swift in Sources */,
 				DFE3D7FFABE00254D2B2F164 /* RecordingQueueService.swift in Sources */,
 				E5A43EA1048E2701A2B0498B /* RecordingRowView.swift in Sources */,
@@ -984,6 +1014,8 @@
 				0E8BEFC3F87AA11BE81CEC1F /* LocalWhisperStreamingServiceTests.swift in Sources */,
 				E7F1B035104E1A79711068B2 /* MeetingChunkStitcherTests.swift in Sources */,
 				D8A509F05B69FA514A0EDDE9 /* MultipartFormDataFileTests.swift in Sources */,
+				007C689901A82C26D1AFD661 /* NotchManagerTests.swift in Sources */,
+				474BEF9A6D5E57064A709DFD /* NotchStateTests.swift in Sources */,
 				2B75C64DA51F46DB68543EB1 /* PreConnectAudioBufferTests.swift in Sources */,
 				DE51034347AC539254418EF9 /* ProtectedLexiconServiceTests.swift in Sources */,
 				533F7EE6501E899BF20CF259 /* PushToTalkServiceTests.swift in Sources */,
@@ -1390,6 +1422,14 @@
 				version = 2.9.0;
 			};
 		};
+		EEB3C042DE7A825E199A8D2F /* XCRemoteSwiftPackageReference "DynamicNotchKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MrKai77/DynamicNotchKit";
+			requirement = {
+				kind = revision;
+				revision = cd0b3e52d537db115ad3a9d89601f20e0bee8d27;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1402,6 +1442,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 40D87DB8B850A83EB00FF9EE /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
 			productName = LaunchAtLogin;
+		};
+		B431F17EA826367ED3C4D989 /* DynamicNotchKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EEB3C042DE7A825E199A8D2F /* XCRemoteSwiftPackageReference "DynamicNotchKit" */;
+			productName = DynamicNotchKit;
 		};
 		B9A32E3B977C8D9C16E2DC20 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		572B04F3977C5BF9A6001B21 /* RecordingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741CC380B9BFEAA01C4EC5E4 /* RecordingDetailView.swift */; };
 		57FF194266BABFA6EA107750 /* HTTPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622D792451975A00E4A3FCBF /* HTTPLogger.swift */; };
 		5A0F8F3B8BA88EE0B38DCF98 /* ConnectMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452F045E726DADF6E51D7778 /* ConnectMetrics.swift */; };
-		5A18DAA2CFAE9E95CCA51D24 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 1682C3BCEB8B3B3CE61588C9 /* Supabase */; };
 		5B89431A91667B55380925FB /* MainSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15385C5553FC7E235C629D0 /* MainSection.swift */; };
 		5C38E65B15A426A3B51A9EEB /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF35CE111AABBE5F2797242F /* whisper.xcframework */; };
 		62EBB796CFA5A63DB61BA0B6 /* WhisperContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9F609481B3D9169BF4B1E8 /* WhisperContext.swift */; };

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -11,33 +11,40 @@ extension AppDelegate {
         // while permission checks and device setup run.
         ShareableContentCache.shared.prewarm()
         Task { _ = await AuthService.shared.getAccessToken() }
-        meetingPipelineTask?.cancel()
-        meetingPipelineTask = Task {
-            await self.performToggleMeetingRecording()
-        }
-    }
 
-    func performToggleMeetingRecording() async {
-        let meetingRecordingState = appState.meetingRecordingState
+        // Task ownership: the stop pipeline runs inside meetingPipelineTask,
+        // so a blanket cancel here would kill an in-flight stop (transcription
+        // upload included) and silently drop the meeting. Only the explicit
+        // cancel-while-processing branch may cancel it — from outside the
+        // task being cancelled.
         switch meetingRecordingState {
         case .idle:
-            await startMeetingRecording()
+            meetingPipelineTask?.cancel()
+            meetingPipelineTask = Task {
+                await self.startMeetingRecording()
+            }
         case .recording:
-            await stopMeetingRecording()
+            meetingPipelineTask = Task {
+                await self.stopMeetingRecording()
+            }
         case .processing:
             Log.app.info("Meeting state is processing, canceling...")
-            await cancelMeetingRecording()
+            let inFlightTask = meetingPipelineTask
+            meetingPipelineTask = Task {
+                inFlightTask?.cancel()
+                await self.cancelMeetingRecording()
+            }
         default:
             Log.app.info("Meeting state is \(meetingRecordingState), ignoring toggle")
         }
     }
 
+    /// Tears down an active or processing meeting recording. Callers that need
+    /// to abort an in-flight pipeline task must cancel it themselves before
+    /// calling — this method must never cancel the task it may be running in
+    /// (self-cancel made the save-audio-on-cancel branch fail silently).
     func cancelMeetingRecording() async {
         Log.app.info("cancelMeetingRecording: BEGIN")
-
-        // Cancel any in-flight pipeline task
-        meetingPipelineTask?.cancel()
-        meetingPipelineTask = nil
 
         let recordingStartTime = appState.meetingRecordingStartTime
         let stopTime = Date()
@@ -386,7 +393,7 @@ extension AppDelegate {
             guard let self else { return }
             do {
                 let languageHints = SettingsStorage.shared.speechLanguageHints
-                try await self.realtimeTranscriptionService.connect(
+                try await realtimeTranscriptionService.connect(
                     languageHints: languageHints,
                     strictLanguageHints: !languageHints.isEmpty
                 )
@@ -425,6 +432,16 @@ extension AppDelegate {
     }
 
     func stopMeetingRecording() async {
+        // Reentry guard: a second stop request (double-pressed shortcut, panel
+        // button + shortcut) must not run the teardown pipeline twice. The
+        // state flips to .processing synchronously below, so the next caller
+        // lands in the cancel-while-processing branch instead.
+        guard appState.meetingRecordingState == .recording else {
+            let ignoredState = appState.meetingRecordingState
+            Log.app.info("stopMeetingRecording: ignored, state is \(ignoredState)")
+            return
+        }
+
         Log.app.info("stopMeetingRecording: BEGIN")
 
         // Deactivate chapter bookmark hotkey
@@ -436,10 +453,8 @@ extension AppDelegate {
         // Capture recording start time for duration calculation
         let recordingStartTime = appState.meetingRecordingStartTime
 
-        await MainActor.run {
-            appState.meetingRecordingState = .processing
-            handleMeetingStateChange(.processing)
-        }
+        appState.meetingRecordingState = .processing
+        handleMeetingStateChange(.processing)
 
         // Finalize and disconnect real-time transcription (if active)
         let didReceiveRealtimeFinalization = await stopMeetingLiveTranscription(finalizeCloud: true)
@@ -505,6 +520,20 @@ extension AppDelegate {
                 capturedAudioURL = compressedURL
             }
 
+            // Save to the library immediately — transcription can take tens of
+            // minutes and a cancelled/failed pipeline must never lose the
+            // audio. The transcript is attached to this entry when it lands.
+            let librarySavedId = RecordingsLibraryStorage.shared.saveRecording(
+                id: recordingId,
+                audioURL: compressedURL,
+                type: .meeting,
+                duration: duration
+            )
+            if librarySavedId != nil {
+                // Library has taken ownership — remove the in-progress directory (RLR-M1).
+                cleanupInProgressDirectory()
+            }
+
             let realtimeText = await MainActor.run { store?.finalTranscriptText ?? "" }
             let cloudModeEnabled = SettingsStorage.shared.effectiveMeetingRealtimeTranscriptionEnabled
             let shouldUseRealtimeText = shouldAcceptRealtimeTranscript(
@@ -525,6 +554,13 @@ extension AppDelegate {
                         )
                 }
                 Log.app.info("No real-time transcript, falling back to async jobs API...")
+                if librarySavedId != nil {
+                    RecordingsLibraryStorage.shared.updateRecording(
+                        id: recordingId,
+                        status: .processing,
+                        error: nil
+                    )
+                }
                 let audioData = try await loadAudioData(from: compressedURL)
                 Log.app.info("Meeting recording size = \(audioData.count) bytes")
 
@@ -585,6 +621,13 @@ extension AppDelegate {
                     .warning(
                         "stopMeetingRecording: state changed during processing (now \(processingState)), dropping result"
                     )
+                if librarySavedId != nil {
+                    RecordingsLibraryStorage.shared.updateRecording(
+                        id: recordingId,
+                        status: .unprocessed,
+                        error: nil
+                    )
+                }
                 cleanupTemporaryAudio()
                 RecoveryStateManager.shared.clearState()
                 return
@@ -629,15 +672,26 @@ extension AppDelegate {
             }
             Log.app.info("stopMeetingRecording: SUCCESS")
 
-            RecordingsLibraryStorage.shared.saveRecording(
-                id: recordingId,
-                audioURL: compressedURL,
-                type: .meeting,
-                duration: duration,
-                transcriptionText: text
-            )
-            // Library has taken ownership — remove the in-progress directory (RLR-M1).
-            cleanupInProgressDirectory()
+            if librarySavedId != nil {
+                if let text {
+                    RecordingsLibraryStorage.shared.updateRecording(
+                        id: recordingId,
+                        status: .transcribed,
+                        text: text,
+                        error: nil
+                    )
+                } else {
+                    RecordingsLibraryStorage.shared.updateRecording(
+                        id: recordingId,
+                        status: .unprocessed,
+                        error: nil
+                    )
+                }
+            } else {
+                // Retention policy skipped the library save — still drop the
+                // in-progress directory now that the pipeline is done with it.
+                cleanupInProgressDirectory()
+            }
 
             if SettingsStorage.shared.playSoundOnCompletion {
                 NSSound(named: .init("Funk"))?.play()
@@ -651,6 +705,14 @@ extension AppDelegate {
 
         } catch is CancellationError {
             Log.app.info("stopMeetingRecording: Cancelled")
+            // The library entry (saved right after compression) stays — a
+            // cancelled transcription must not throw away the meeting audio.
+            // updateRecording is a no-op when the entry was never saved.
+            RecordingsLibraryStorage.shared.updateRecording(
+                id: recordingId,
+                status: .unprocessed,
+                error: nil
+            )
             cleanupTemporaryAudio()
             cleanupInProgressDirectory()
             RecoveryStateManager.shared.clearState()
@@ -663,7 +725,16 @@ extension AppDelegate {
         } catch {
             Log.app.error("Meeting transcription failed: \(error)")
 
-            if let audioURL = capturedAudioURL {
+            let alreadySaved = RecordingsLibraryStorage.shared.recordings.contains { $0.id == recordingId }
+            if alreadySaved {
+                RecordingsLibraryStorage.shared.updateRecording(
+                    id: recordingId,
+                    status: .failed,
+                    error: error.localizedDescription
+                )
+                cleanupTemporaryAudio()
+                RecoveryStateManager.shared.clearState()
+            } else if let audioURL = capturedAudioURL {
                 let duration = recordingStartTime.map { stopTime.timeIntervalSince($0) } ?? 0
                 RecordingsLibraryStorage.shared.saveRecording(
                     id: recordingId,
@@ -742,6 +813,7 @@ extension AppDelegate {
         escapeService.onCancel = { [weak self] in
             Task { @MainActor in
                 let shouldSaveAudio = SettingsStorage.shared.escapeCancelSaveAudio
+                self?.meetingPipelineTask?.cancel()
                 await self?.cancelMeetingRecording()
                 let message = shouldSaveAudio ? "Recording cancelled and saved" : "Recording cancelled"
                 DictationOverlayController.shared.showInfo(message: message)

--- a/Diduny/App/AppDelegate+MeetingRecording.swift
+++ b/Diduny/App/AppDelegate+MeetingRecording.swift
@@ -504,6 +504,10 @@ extension AppDelegate {
             }
         }
 
+        // Whether the early library save succeeded (nil when the retention
+        // policy skips saving) — read by the catch paths below.
+        var librarySavedId: UUID?
+
         do {
             guard let audioURL = try await meetingRecorderService.stopRecording() else {
                 throw MeetingRecorderError.recordingFailed
@@ -523,15 +527,20 @@ extension AppDelegate {
             // Save to the library immediately — transcription can take tens of
             // minutes and a cancelled/failed pipeline must never lose the
             // audio. The transcript is attached to this entry when it lands.
-            let librarySavedId = RecordingsLibraryStorage.shared.saveRecording(
+            // The in-progress directory is NOT cleaned up yet: compressedURL
+            // still lives inside it and is read by the jobs fallback below.
+            librarySavedId = RecordingsLibraryStorage.shared.saveRecording(
                 id: recordingId,
                 audioURL: compressedURL,
                 type: .meeting,
                 duration: duration
             )
             if librarySavedId != nil {
-                // Library has taken ownership — remove the in-progress directory (RLR-M1).
-                cleanupInProgressDirectory()
+                RecordingsLibraryStorage.shared.updateRecording(
+                    id: recordingId,
+                    status: .processing,
+                    error: nil
+                )
             }
 
             let realtimeText = await MainActor.run { store?.finalTranscriptText ?? "" }
@@ -554,13 +563,6 @@ extension AppDelegate {
                         )
                 }
                 Log.app.info("No real-time transcript, falling back to async jobs API...")
-                if librarySavedId != nil {
-                    RecordingsLibraryStorage.shared.updateRecording(
-                        id: recordingId,
-                        status: .processing,
-                        error: nil
-                    )
-                }
                 let audioData = try await loadAudioData(from: compressedURL)
                 Log.app.info("Meeting recording size = \(audioData.count) bytes")
 
@@ -687,11 +689,10 @@ extension AppDelegate {
                         error: nil
                     )
                 }
-            } else {
-                // Retention policy skipped the library save — still drop the
-                // in-progress directory now that the pipeline is done with it.
-                cleanupInProgressDirectory()
             }
+            // The pipeline is done reading compressedURL — the in-progress
+            // directory (which contains it) can go now (RLR-M1).
+            cleanupInProgressDirectory()
 
             if SettingsStorage.shared.playSoundOnCompletion {
                 NSSound(named: .init("Funk"))?.play()
@@ -725,13 +726,13 @@ extension AppDelegate {
         } catch {
             Log.app.error("Meeting transcription failed: \(error)")
 
-            let alreadySaved = RecordingsLibraryStorage.shared.recordings.contains { $0.id == recordingId }
-            if alreadySaved {
+            if librarySavedId != nil {
                 RecordingsLibraryStorage.shared.updateRecording(
                     id: recordingId,
                     status: .failed,
                     error: error.localizedDescription
                 )
+                cleanupInProgressDirectory()
                 cleanupTemporaryAudio()
                 RecoveryStateManager.shared.clearState()
             } else if let audioURL = capturedAudioURL {

--- a/Diduny/App/AppDelegate+Recording.swift
+++ b/Diduny/App/AppDelegate+Recording.swift
@@ -396,15 +396,14 @@ extension AppDelegate {
                 rawText = try await transcriptionService.transcribe(audioData: audioData)
                 Log.app.info("stopRecording: HTTP cloud transcription (\(rawText.count) chars)")
             }
-            let cleanedRawText: String
-            if !realtimeResult.text.isEmpty {
-                cleanedRawText = await cleanRealtimeResultText(
+            let cleanedRawText: String = if !realtimeResult.text.isEmpty {
+                await cleanRealtimeResultText(
                     rawText,
                     realtimeResult: realtimeResult,
                     logPrefix: "Dictation"
                 )
             } else {
-                cleanedRawText = await TranscriptCleanupService.shared.clean(
+                await TranscriptCleanupService.shared.clean(
                     rawText,
                     fillerWords: SettingsStorage.shared.fillerWords
                 )
@@ -499,7 +498,8 @@ extension AppDelegate {
                             Log.app.warning("stopRecording: Accessibility permission needed during Whisper fallback")
                             PermissionManager.shared.showPermissionAlert(for: .accessibility)
                         } catch {
-                            Log.app.error("stopRecording: Whisper fallback paste failed - \(error.localizedDescription)")
+                            Log.app
+                                .error("stopRecording: Whisper fallback paste failed - \(error.localizedDescription)")
                         }
                     }
                     guard appState.recordingState == .processing else { return }
@@ -619,9 +619,9 @@ extension AppDelegate {
     private func setupVoiceRealtimeTranscriptionIfNeeded() {
         let onNoSpeech: () -> Void = { [weak self] in
             Task { @MainActor [weak self] in
-                guard let self, self.appState.recordingState == .recording else { return }
-                await self.cancelRecording(forceDiscardAudio: true)
-                self.showRecordingFeedbackInfo(
+                guard let self, appState.recordingState == .recording else { return }
+                await cancelRecording(forceDiscardAudio: true)
+                showRecordingFeedbackInfo(
                     message: "No speech detected. Recording cancelled.",
                     mode: .voice,
                     duration: 2.5
@@ -630,6 +630,20 @@ extension AppDelegate {
         }
 
         if SettingsStorage.shared.effectiveTranscriptionProvider == .local {
+            // The notch shows no live transcript — skip the local streaming
+            // preview entirely so Whisper doesn't transcribe for a UI that
+            // never renders it. Speech gating still runs for no-speech cancel.
+            guard SettingsStorage.shared.recordingFeedbackSurface == .compactPanel else {
+                audioRecorder.onRealtimeAudioData = speechGatedAudioDelivery(
+                    deliver: { _ in },
+                    onNoSpeech: onNoSpeech
+                )
+                localVoiceStreamingService = nil
+                voiceRealtimeSessionEnabled = false
+                voiceRealtimeAccumulator = nil
+                return
+            }
+
             let whisper = whisperTranscriptionService
             let stream = LocalWhisperStreamingService(
                 transcribe: { samples in
@@ -787,11 +801,10 @@ extension AppDelegate {
             return .empty
         }
 
-        let preFinalizeText: String
-        if finalize {
-            preFinalizeText = await accumulator?.bestText(includeProvisional: true) ?? ""
+        let preFinalizeText: String = if finalize {
+            await accumulator?.bestText(includeProvisional: true) ?? ""
         } else {
-            preFinalizeText = ""
+            ""
         }
         let optimisticCleanupTask = finalize
             ? startOptimisticRealtimeCleanup(for: preFinalizeText)
@@ -802,7 +815,7 @@ extension AppDelegate {
         }
         await realtimeTranscriptionService.disconnect()
 
-        let text = (await accumulator?.bestText(includeProvisional: true) ?? "")
+        let text = await (accumulator?.bestText(includeProvisional: true) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let preFinalizeTrimmed = preFinalizeText.trimmingCharacters(in: .whitespacesAndNewlines)
         let textChangedAfterFinalize = text != preFinalizeTrimmed
@@ -851,7 +864,8 @@ extension AppDelegate {
         timeoutInterval: TimeInterval = 1.0
     ) async -> String {
         if let optimisticCleanedText = realtimeResult.optimisticCleanedText,
-           !realtimeResult.textChangedAfterFinalize {
+           !realtimeResult.textChangedAfterFinalize
+        {
             Log.app.info("[\(logPrefix)] Reusing optimistic cleanup result")
             return optimisticCleanedText
         }

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import LaunchAtLogin
 import os
 import SwiftUI
 
@@ -115,6 +116,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     let appState = AppState()
 
+    /// Whether this process was started by the system as a login item. Captured
+    /// synchronously in `applicationDidFinishLaunching` — the Apple event that
+    /// carries the flag is only current during that call.
+    private var launchedAtLogin = false
+
     /// Audio level piping to the recording feedback panel
     var audioLevelCancellable: AnyCancellable?
 
@@ -184,6 +190,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Lifecycle
 
     func applicationDidFinishLaunching(_: Notification) {
+        launchedAtLogin = LaunchAtLogin.wasLaunchedAtLogin
+        NSLog("[Diduny] applicationDidFinishLaunching: launchedAtLogin=%d", launchedAtLogin ? 1 : 0)
+
         MainWindowController.shared.configure(appDelegate: self)
         EdgeCommandPanelController.shared.configure(appDelegate: self)
 
@@ -319,12 +328,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Show main window so a Spotlight launch (fresh, app was not running)
         // actually surfaces the UI. Deferred 200 ms to let the window system
-        // settle after all setup above finishes.
+        // settle after all setup above finishes. Login-item launches stay
+        // silent — the app should only appear in the menu bar.
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(200))
-            NSLog("[Diduny] setupAfterOnboarding deferred: isVisible=%d policy=%d",
-                  MainWindowController.shared.isVisible ? 1 : 0, NSApp.activationPolicy().rawValue)
-            if !MainWindowController.shared.isVisible {
+            NSLog("[Diduny] setupAfterOnboarding deferred: isVisible=%d policy=%d launchedAtLogin=%d",
+                  MainWindowController.shared.isVisible ? 1 : 0, NSApp.activationPolicy().rawValue,
+                  launchedAtLogin ? 1 : 0)
+            if !launchedAtLogin, !MainWindowController.shared.isVisible {
                 MainWindowController.shared.showWindow()
             }
         }
@@ -589,7 +600,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         if appState.meetingTranslationRecordingState == .processing,
-           appState.meetingTranslationRecordingStartTime == nil {
+           appState.meetingTranslationRecordingStartTime == nil
+        {
             await cancelMeetingTranslationRecording()
             return
         }
@@ -599,7 +611,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         if appState.meetingRecordingState == .processing,
-           appState.meetingRecordingStartTime == nil {
+           appState.meetingRecordingStartTime == nil
+        {
             await cancelMeetingRecording()
             return
         }
@@ -609,7 +622,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         if appState.translationRecordingState == .processing,
-           appState.translationRecordingStartTime == nil {
+           appState.translationRecordingStartTime == nil
+        {
             await cancelTranslationRecording()
             return
         }
@@ -619,7 +633,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         if appState.recordingState == .processing,
-           appState.recordingStartTime == nil {
+           appState.recordingStartTime == nil
+        {
             await cancelRecording()
             return
         }
@@ -835,7 +850,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func showRecordingFeedbackInfo(
         message: String,
-        mode: RecordingMode,
+        mode _: RecordingMode,
         duration: TimeInterval = 1.5
     ) {
         DictationOverlayController.shared.showInfo(message: message, duration: duration)

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -592,6 +592,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DictationOverlayController.shared.setStopHandler { [weak self] in
             await self?.stopActiveRecordingFromFeedback()
         }
+        NotchManager.shared.setStopHandler { [weak self] in
+            await self?.stopActiveRecordingFromFeedback()
+        }
     }
 
     func stopActiveRecordingFromFeedback() async {

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -613,6 +613,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if appState.meetingRecordingState == .processing,
            appState.meetingRecordingStartTime == nil
         {
+            meetingPipelineTask?.cancel()
             await cancelMeetingRecording()
             return
         }

--- a/Diduny/Core/Models/RecordingFeedbackSurface.swift
+++ b/Diduny/Core/Models/RecordingFeedbackSurface.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum RecordingFeedbackSurface: String, CaseIterable, Identifiable {
+    case notch
+    case compactPanel
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .notch:
+            "Dynamic Notch"
+        case .compactPanel:
+            "Floating modal"
+        }
+    }
+}

--- a/Diduny/Core/Models/RecordingMode.swift
+++ b/Diduny/Core/Models/RecordingMode.swift
@@ -5,6 +5,26 @@ enum RecordingMode: Equatable {
     case meetingTranslation
     case fileTranscription
 
+    var label: String {
+        switch self {
+        case .voice: "Recording..."
+        case let .translation(targetLanguage): "Recording -> \(targetLanguage)..."
+        case .meeting: "Meeting Recording..."
+        case .meetingTranslation: "Meeting Translation..."
+        case .fileTranscription: "Transcribing File..."
+        }
+    }
+
+    var processingLabel: String {
+        switch self {
+        case .voice: "Processing..."
+        case .translation: "Translating..."
+        case .meeting: "Processing Meeting..."
+        case .meetingTranslation: "Translating Meeting..."
+        case .fileTranscription: "Transcribing File..."
+        }
+    }
+
     var icon: String {
         switch self {
         case .voice: "mic.fill"

--- a/Diduny/Core/Services/CloudTranscriptionService.swift
+++ b/Diduny/Core/Services/CloudTranscriptionService.swift
@@ -36,7 +36,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
 
         try await ensureSpeechDetected(audioData, context: "transcribe")
 
-        let languageConfig = resolveLanguageConfig(explicitLanguage: language)
+        let languageConfig = Self.resolveLanguageConfig(explicitLanguage: language)
         let config = Self.makeTranscriptionConfig(languageConfig: languageConfig)
         let response = try await proxyTranscribe(audioData: audioData, config: config)
         let text = response.text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -51,7 +51,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
 
         try await ensureSpeechDetected(audioData, context: "transcribeMeeting")
 
-        let languageConfig = resolveLanguageConfig()
+        let languageConfig = Self.resolveLanguageConfig()
         let config = Self.makeTranscriptionConfig(
             languageConfig: languageConfig,
             enableSpeakerDiarization: true
@@ -83,7 +83,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
 
         try await ensureSpeechDetected(audioData, context: "translateAndTranscribe")
 
-        let languageConfig = resolveLanguageConfig()
+        let languageConfig = Self.resolveLanguageConfig()
         let config = Self.makeOneWayTranslationConfig(
             targetLanguage: target,
             languageConfig: languageConfig
@@ -103,7 +103,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
 
         try await ensureSpeechDetected(audioData, context: "translateAndTranscribe")
 
-        let languageConfig = resolveLanguageConfig(
+        let languageConfig = Self.resolveLanguageConfig(
             forcedLanguageHints: SettingsStorage.shared.translationLanguageHints(for: languagePair)
         )
         let config = Self.makeTwoWayTranslationConfig(
@@ -138,7 +138,10 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         let configString = String(data: configData, encoding: .utf8) ?? "{}"
 
         let (filename, contentType) = detectAudioFormat(optimizedData)
-        Log.transcription.info("proxyTranscribe: audio format=\(contentType), original=\(audioData.count) bytes, optimized=\(optimizedData.count) bytes, config=\(configString)")
+        Log.transcription
+            .info(
+                "proxyTranscribe: audio format=\(contentType), original=\(audioData.count) bytes, optimized=\(optimizedData.count) bytes, config=\(configString)"
+            )
 
         // Build multipart body: audio + config
         var body = Data()
@@ -230,10 +233,10 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/afconvert")
             process.arguments = [
-                "-f", "WAVE",           // output format: WAV
-                "-d", "LEI16",          // data format: little-endian 16-bit integer
-                "-c", "1",              // mono
-                "-r", "16000",          // 16kHz sample rate
+                "-f", "WAVE", // output format: WAV
+                "-d", "LEI16", // data format: little-endian 16-bit integer
+                "-c", "1", // mono
+                "-r", "16000", // 16kHz sample rate
                 inputURL.path,
                 outputURL.path
             ]
@@ -248,7 +251,11 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
                     } else {
                         let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
                         let msg = String(data: errorData, encoding: .utf8) ?? "exit \(proc.terminationStatus)"
-                        continuation.resume(throwing: NSError(domain: "afconvert", code: Int(proc.terminationStatus), userInfo: [NSLocalizedDescriptionKey: msg]))
+                        continuation.resume(throwing: NSError(
+                            domain: "afconvert",
+                            code: Int(proc.terminationStatus),
+                            userInfo: [NSLocalizedDescriptionKey: msg]
+                        ))
                     }
                 }
                 do {
@@ -259,7 +266,8 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
             }
 
             let downsampledData = try Data(contentsOf: outputURL)
-            Log.transcription.info("Downsampled: \(audioData.count) → \(downsampledData.count) bytes (16kHz mono s16le)")
+            Log.transcription
+                .info("Downsampled: \(audioData.count) → \(downsampledData.count) bytes (16kHz mono s16le)")
             return downsampledData
         } catch {
             Log.transcription.warning("Downsample failed, using original: \(error.localizedDescription)")
@@ -322,7 +330,7 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
 
     // MARK: - Language Config
 
-    private func resolveLanguageConfig(
+    static func resolveLanguageConfig(
         explicitLanguage: String? = nil,
         forcedLanguageHints: [String]? = nil
     ) -> CloudLanguageConfig {
@@ -474,7 +482,7 @@ enum AudioSpeechDetector {
         samples.reserveCapacity(bytes.count / 2)
         for index in stride(from: 0, to: bytes.count - 1, by: 2) {
             let bits = UInt16(bytes[index]) | (UInt16(bytes[index + 1]) << 8)
-            samples.append(Float(Int16(bitPattern: bits)) / 32_768)
+            samples.append(Float(Int16(bitPattern: bits)) / 32768)
         }
         return detectSpeech(samples: samples)
     }

--- a/Diduny/Core/Services/RecordingQueueService.swift
+++ b/Diduny/Core/Services/RecordingQueueService.swift
@@ -183,25 +183,53 @@ final class RecordingQueueService {
                 historyKind = provider == .local ? .local : .cloud
                 sourceLanguageCode = nil
             case .translate:
-                let audioData = try await loadAudioData(from: audioURL)
                 let pair = SettingsStorage.shared.resolveTranslationLanguagePair()
                 let targetLanguage: String
-                if let explicitTargetLanguage = item.targetLanguage {
-                    targetLanguage = explicitTargetLanguage
-                    transcript = try await GeneratedTranscript(
-                        text: service.translateAndTranscribe(
-                            audioData: audioData,
-                            targetLanguage: explicitTargetLanguage
+                if provider == .cloud {
+                    // The synchronous POST path rejects large uploads (413) and
+                    // times out on long meetings — cloud translation must go
+                    // through the async jobs API, same as cloud transcription.
+                    let config: [String: Any]
+                    if let explicitTargetLanguage = item.targetLanguage {
+                        targetLanguage = explicitTargetLanguage
+                        config = CloudTranscriptionService.makeOneWayTranslationConfig(
+                            targetLanguage: explicitTargetLanguage,
+                            languageConfig: CloudTranscriptionService.resolveLanguageConfig()
                         )
+                    } else {
+                        targetLanguage = pair.languageB
+                        config = CloudTranscriptionService.makeTwoWayTranslationConfig(
+                            languagePair: pair,
+                            languageConfig: CloudTranscriptionService.resolveLanguageConfig(
+                                forcedLanguageHints: SettingsStorage.shared.translationLanguageHints(for: pair)
+                            )
+                        )
+                    }
+                    transcript = try await transcribeViaJobs(
+                        audioFileURL: audioURL,
+                        config: config,
+                        source: recording.audioFileName,
+                        sourceDurationSeconds: recording.durationSeconds
                     )
                 } else {
-                    targetLanguage = provider == .local ? "en" : pair.languageB
-                    transcript = try await GeneratedTranscript(
-                        text: service.translateAndTranscribe(
-                            audioData: audioData,
-                            languagePair: pair
+                    let audioData = try await loadAudioData(from: audioURL)
+                    if let explicitTargetLanguage = item.targetLanguage {
+                        targetLanguage = explicitTargetLanguage
+                        transcript = try await GeneratedTranscript(
+                            text: service.translateAndTranscribe(
+                                audioData: audioData,
+                                targetLanguage: explicitTargetLanguage
+                            )
                         )
-                    )
+                    } else {
+                        targetLanguage = "en"
+                        transcript = try await GeneratedTranscript(
+                            text: service.translateAndTranscribe(
+                                audioData: audioData,
+                                languagePair: pair
+                            )
+                        )
+                    }
                 }
                 status = .translated
                 translationTargetLanguageCode = targetLanguage
@@ -329,8 +357,8 @@ final class RecordingQueueService {
     private func configuredProvider(for item: QueueItem) -> TranscriptionProvider {
         if item.action == .transcribe,
            RecordingsLibraryStorage.shared.recordings
-            .first(where: { $0.id == item.id })?
-            .requiresLocalTranscription == true
+           .first(where: { $0.id == item.id })?
+           .requiresLocalTranscription == true
         {
             return .local
         }

--- a/Diduny/Core/Storage/SettingsStorage.swift
+++ b/Diduny/Core/Storage/SettingsStorage.swift
@@ -138,6 +138,8 @@ final class SettingsStorage {
         case userDeclinedScreenRecording
         case selectedBrowserSessionID
         case selectedChromeProfileID
+        case edgePanelDockEdge
+        case edgePanelDockOffset
         case remoteMediaRightsAcknowledged
     }
 
@@ -274,6 +276,30 @@ final class SettingsStorage {
                 defaults.set(newValue, forKey: Key.selectedChromeProfileID.rawValue)
             } else {
                 defaults.removeObject(forKey: Key.selectedChromeProfileID.rawValue)
+            }
+        }
+    }
+
+    /// Persisted edge-command-panel dock (raw edge name + offset along that
+    /// edge) so a dragged panel keeps its place across restarts.
+    var edgePanelDockEdge: String? {
+        get { defaults.string(forKey: Key.edgePanelDockEdge.rawValue) }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: Key.edgePanelDockEdge.rawValue)
+            } else {
+                defaults.removeObject(forKey: Key.edgePanelDockEdge.rawValue)
+            }
+        }
+    }
+
+    var edgePanelDockOffset: Double? {
+        get { defaults.object(forKey: Key.edgePanelDockOffset.rawValue) as? Double }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: Key.edgePanelDockOffset.rawValue)
+            } else {
+                defaults.removeObject(forKey: Key.edgePanelDockOffset.rawValue)
             }
         }
     }

--- a/Diduny/Core/Storage/SettingsStorage.swift
+++ b/Diduny/Core/Storage/SettingsStorage.swift
@@ -84,6 +84,7 @@ final class SettingsStorage {
         case autoPaste
         case playSoundOnCompletion
         case launchAtLogin
+        case recordingFeedbackSurface
         case typingSpeedWordsPerMinute
         case pushToTalkKey
         case pushToTalkHoldEnabled
@@ -323,6 +324,18 @@ final class SettingsStorage {
     var launchAtLogin: Bool {
         get { LaunchAtLogin.isEnabled }
         set { LaunchAtLogin.isEnabled = newValue }
+    }
+
+    var recordingFeedbackSurface: RecordingFeedbackSurface {
+        get {
+            guard let rawValue = defaults.string(forKey: Key.recordingFeedbackSurface.rawValue),
+                  let surface = RecordingFeedbackSurface(rawValue: rawValue)
+            else {
+                return .compactPanel
+            }
+            return surface
+        }
+        set { defaults.set(newValue.rawValue, forKey: Key.recordingFeedbackSurface.rawValue) }
     }
 
     var typingSpeedWordsPerMinute: Double {

--- a/Diduny/Features/DictationOverlay/DictationOverlayController.swift
+++ b/Diduny/Features/DictationOverlay/DictationOverlayController.swift
@@ -8,6 +8,19 @@ final class DictationOverlayController {
     private var autoHideTask: Task<Void, Never>?
     private var onStopRequested: (@MainActor () async -> Void)?
 
+    /// Surface captured when a feedback session starts. A recording finishes
+    /// on the surface it started on even if the setting flips mid-recording;
+    /// the new choice applies from the next session.
+    private var activeSurface: RecordingFeedbackSurface?
+
+    private var currentSurface: RecordingFeedbackSurface {
+        activeSurface ?? SettingsStorage.shared.recordingFeedbackSurface
+    }
+
+    private var usesNotch: Bool {
+        currentSurface == .notch
+    }
+
     private init() {}
 
     func setStopHandler(_ handler: (@MainActor () async -> Void)?) {
@@ -16,18 +29,28 @@ final class DictationOverlayController {
 
     func begin(mode: RecordingMode) {
         autoHideTask?.cancel()
+        beginSurfaceSession()
         store.reset(mode: mode)
         store.phase = .starting
-        showPanel()
+        if usesNotch {
+            NotchManager.shared.resumeRecording(mode: mode)
+        } else {
+            showPanel()
+        }
     }
 
     func startRecording(mode: RecordingMode) {
         autoHideTask?.cancel()
+        beginSurfaceSession()
         if store.mode != mode {
             store.reset(mode: mode)
         }
         store.phase = .recording
-        showPanel()
+        if usesNotch {
+            NotchManager.shared.startRecording(mode: mode)
+        } else {
+            showPanel()
+        }
     }
 
     func startFinalizing(mode: RecordingMode) {
@@ -37,7 +60,11 @@ final class DictationOverlayController {
         }
         store.phase = .finalizing
         store.audioLevel = 0
-        showPanel()
+        if usesNotch {
+            NotchManager.shared.startProcessing(mode: mode)
+        } else {
+            showPanel()
+        }
     }
 
     func startProcessing(mode: RecordingMode) {
@@ -47,7 +74,11 @@ final class DictationOverlayController {
         }
         store.phase = .processing
         store.audioLevel = 0
-        showPanel()
+        if usesNotch {
+            NotchManager.shared.startProcessing(mode: mode)
+        } else {
+            showPanel()
+        }
     }
 
     func showSuccess(text: String) {
@@ -58,6 +89,12 @@ final class DictationOverlayController {
         }
         store.phase = .pasted
         store.audioLevel = 0
+        if usesNotch {
+            // The notch schedules its own dismissal and ends the session.
+            NotchManager.shared.showSuccess(text: text)
+            endSurfaceSession()
+            return
+        }
         showPanel()
         if SettingsStorage.shared.autoPaste {
             scheduleAutoHide(delay: 0.8)
@@ -68,6 +105,11 @@ final class DictationOverlayController {
         autoHideTask?.cancel()
         store.phase = .error(message)
         store.audioLevel = 0
+        if usesNotch {
+            NotchManager.shared.showError(message: message)
+            endSurfaceSession()
+            return
+        }
         showPanel()
         scheduleAutoHide(delay: 3.0)
     }
@@ -76,11 +118,20 @@ final class DictationOverlayController {
         autoHideTask?.cancel()
         store.phase = .info(message)
         store.audioLevel = 0
+        if usesNotch {
+            NotchManager.shared.showInfo(message: message, duration: duration)
+            endSurfaceSession()
+            return
+        }
         showPanel()
         scheduleAutoHide(delay: duration)
     }
 
     func showInfoDuringRecording(message: String, mode: RecordingMode, duration: TimeInterval = 1.5) {
+        if usesNotch {
+            NotchManager.shared.showInfoDuringRecording(message: message, mode: mode, duration: duration)
+            return
+        }
         autoHideTask?.cancel()
         let savedPhase = store.phase
         let savedStart = store.startedAt
@@ -100,7 +151,7 @@ final class DictationOverlayController {
     }
 
     func hide() {
-        guard store.phase != .pasted || SettingsStorage.shared.autoPaste else { return }
+        guard usesNotch || store.phase != .pasted || SettingsStorage.shared.autoPaste else { return }
         dismiss()
     }
 
@@ -108,24 +159,50 @@ final class DictationOverlayController {
         autoHideTask?.cancel()
         autoHideTask = nil
         store.audioLevel = 0
+        if usesNotch {
+            NotchManager.shared.hide()
+        }
+        // Always release the panel's live presentation too — it no-ops when
+        // not shown, and covers a surface flip that happened mid-recording.
         EdgeCommandPanelController.shared.dismissLiveFeedback()
+        endSurfaceSession()
     }
 
     func updateAudioLevel(_ level: Float) {
-        store.audioLevel = max(0, min(level, 1))
+        let clamped = max(0, min(level, 1))
+        if usesNotch {
+            NotchManager.shared.audioLevel = clamped
+        } else {
+            store.audioLevel = clamped
+        }
     }
 
     func processTokens(_ tokens: [RealtimeToken]) {
+        // The notch deliberately shows no live transcript — skip the token
+        // pipeline entirely so it doesn't burn CPU with no UI attached.
+        guard !usesNotch else { return }
         guard !tokens.isEmpty else { return }
         store.processTokens(tokens)
     }
 
     func markSegmentBoundary() {
+        guard !usesNotch else { return }
         store.markSegmentBoundary()
     }
 
     func updateConnectionStatus(_ status: RealtimeConnectionStatus) {
+        guard !usesNotch else { return }
         store.connectionStatus = status
+    }
+
+    private func beginSurfaceSession() {
+        if activeSurface == nil {
+            activeSurface = SettingsStorage.shared.recordingFeedbackSurface
+        }
+    }
+
+    private func endSurfaceSession() {
+        activeSurface = nil
     }
 
     func copyCurrentTranscript() {

--- a/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
+++ b/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
@@ -176,11 +176,45 @@ enum EdgeCommandPanelPlacement {
     {
         min(max(offset - length / 2, minimum), maximum - length)
     }
+
+    /// Whether a pointer location counts as touching the given screen edge —
+    /// the reveal gesture for an auto-hidden tab (same idea as the Dock).
+    static func edgeHotZoneContains(
+        _ location: NSPoint,
+        screenFrame: NSRect,
+        edge: EdgeCommandPanelDockEdge,
+        threshold: CGFloat = 2
+    ) -> Bool {
+        guard NSMouseInRect(location, screenFrame, false) else { return false }
+        return switch edge {
+        case .left: location.x <= screenFrame.minX + threshold
+        case .right: location.x >= screenFrame.maxX - threshold
+        case .top: location.y >= screenFrame.maxY - threshold
+        case .bottom: location.y <= screenFrame.minY + threshold
+        }
+    }
 }
 
 enum EdgeCommandPanelHoverPolicy {
     static func shouldCollapse(pointer: NSPoint, panelFrame: NSRect, isDragging: Bool) -> Bool {
         !isDragging && !panelFrame.contains(pointer)
+    }
+}
+
+/// The collapsed edge tab auto-hides after a few idle seconds (it annoys
+/// people when it sits on the screen edge permanently). It must never hide
+/// under the pointer, mid-drag, or while the panel is doing actual work.
+enum EdgeCommandPanelAutoHidePolicy {
+    static let delay: TimeInterval = 3
+
+    static func shouldHide(
+        pointer: NSPoint,
+        panelFrame: NSRect,
+        isDragging: Bool,
+        isExpanded: Bool,
+        isShowingLiveFeedback: Bool
+    ) -> Bool {
+        !isDragging && !isExpanded && !isShowingLiveFeedback && !panelFrame.contains(pointer)
     }
 }
 
@@ -267,6 +301,14 @@ final class EdgeCommandPanelController: NSObject {
     private var dock: EdgeCommandPanelDock?
     private var dragCursorOffset: NSPoint?
 
+    // Collapsed-tab auto-hide state (the tab annoys people when it sits on
+    // the screen edge permanently).
+    private var tabAutoHideTask: Task<Void, Never>?
+    private var edgeRevealGlobalMonitor: Any?
+    private var edgeRevealLocalMonitor: Any?
+    private var isTabHidden = false
+    private var hiddenTabScreenFrame: NSRect?
+
     override private init() {
         super.init()
     }
@@ -274,7 +316,32 @@ final class EdgeCommandPanelController: NSObject {
     func configure(appDelegate: AppDelegate) {
         self.appDelegate = appDelegate
         refreshModel()
-        showCollapsed()
+        applySurfacePreference()
+    }
+
+    /// The edge panel exists only for the Floating modal surface. In Dynamic
+    /// Notch mode nothing of it may be on screen — feedback lives in the
+    /// notch. Called at launch and whenever the Settings picker changes.
+    func applySurfacePreference() {
+        if SettingsStorage.shared.recordingFeedbackSurface == .notch {
+            // An active live-feedback session finishes on the panel (the
+            // router snapshots the surface per session) — hide right after,
+            // via dismissLiveFeedback → showCollapsed's notch guard.
+            guard model?.isShowingLiveFeedback != true else { return }
+            hidePanelForNotchMode()
+        } else {
+            showCollapsed()
+        }
+    }
+
+    private func hidePanelForNotchMode() {
+        collapseTask?.cancel()
+        tabAutoHideTask?.cancel()
+        removeEdgeRevealMonitors()
+        isTabHidden = false
+        model?.isShowingLiveFeedback = false
+        model?.isExpanded = false
+        panel?.orderOut(nil)
     }
 
     private func refreshModel() {
@@ -302,16 +369,24 @@ final class EdgeCommandPanelController: NSObject {
     }
 
     private func showCollapsed() {
+        // In notch mode the panel must never surface, whatever path led here.
+        guard SettingsStorage.shared.recordingFeedbackSurface != .notch else {
+            hidePanelForNotchMode()
+            return
+        }
         collapseTask?.cancel()
+        cancelTabAutoHide()
         let panel = panel ?? makePanel()
         self.panel = panel
         model?.isShowingLiveFeedback = false
         position(panel, presentation: .collapsed)
         panel.orderFrontRegardless()
+        scheduleTabAutoHide()
     }
 
     private func showExpanded() {
         collapseTask?.cancel()
+        cancelTabAutoHide()
         refreshModel()
         let panel = panel ?? makePanel()
         self.panel = panel
@@ -322,11 +397,87 @@ final class EdgeCommandPanelController: NSObject {
 
     func showLiveFeedback(mode: RecordingMode) {
         collapseTask?.cancel()
+        cancelTabAutoHide()
         let panel = panel ?? makePanel()
         self.panel = panel
         model?.isShowingLiveFeedback = true
         position(panel, presentation: .live(mode))
         panel.orderFrontRegardless()
+    }
+
+    // MARK: - Collapsed-tab auto-hide
+
+    private func cancelTabAutoHide() {
+        tabAutoHideTask?.cancel()
+        removeEdgeRevealMonitors()
+        isTabHidden = false
+    }
+
+    private func scheduleTabAutoHide() {
+        tabAutoHideTask?.cancel()
+        tabAutoHideTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(EdgeCommandPanelAutoHidePolicy.delay))
+            guard !Task.isCancelled, let self, let panel else { return }
+            guard EdgeCommandPanelAutoHidePolicy.shouldHide(
+                pointer: NSEvent.mouseLocation,
+                panelFrame: panel.frame,
+                isDragging: dragCursorOffset != nil,
+                isExpanded: model?.isExpanded == true,
+                isShowingLiveFeedback: model?.isShowingLiveFeedback == true
+            ) else {
+                // Busy or hovered — try again after another idle interval.
+                scheduleTabAutoHide()
+                return
+            }
+            hideTab()
+        }
+    }
+
+    private func hideTab() {
+        guard let panel else { return }
+        isTabHidden = true
+        hiddenTabScreenFrame = panel.screen?.frame
+        panel.orderOut(nil)
+        installEdgeRevealMonitors()
+    }
+
+    private func revealTabIfPointerAtEdge(_ location: NSPoint) {
+        guard isTabHidden else { return }
+        let screenFrame = hiddenTabScreenFrame
+            ?? NSScreen.screens.first(where: { NSMouseInRect(location, $0.frame, false) })?.frame
+        guard let screenFrame else { return }
+        guard EdgeCommandPanelPlacement.edgeHotZoneContains(
+            location,
+            screenFrame: screenFrame,
+            edge: dock?.edge ?? .right
+        ) else { return }
+        showCollapsed()
+    }
+
+    private func installEdgeRevealMonitors() {
+        guard edgeRevealGlobalMonitor == nil else { return }
+        edgeRevealGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.revealTabIfPointerAtEdge(NSEvent.mouseLocation)
+            }
+        }
+        edgeRevealLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved]) { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.revealTabIfPointerAtEdge(NSEvent.mouseLocation)
+            }
+            return event
+        }
+    }
+
+    private func removeEdgeRevealMonitors() {
+        if let edgeRevealGlobalMonitor {
+            NSEvent.removeMonitor(edgeRevealGlobalMonitor)
+            self.edgeRevealGlobalMonitor = nil
+        }
+        if let edgeRevealLocalMonitor {
+            NSEvent.removeMonitor(edgeRevealLocalMonitor)
+            self.edgeRevealLocalMonitor = nil
+        }
     }
 
     func dismissLiveFeedback() {
@@ -338,6 +489,7 @@ final class EdgeCommandPanelController: NSObject {
         guard model?.isShowingLiveFeedback != true else { return }
         if hovering {
             collapseTask?.cancel()
+            tabAutoHideTask?.cancel()
             guard model?.isExpanded != true else { return }
             showExpanded()
         } else {
@@ -378,6 +530,9 @@ final class EdgeCommandPanelController: NSObject {
         SettingsStorage.shared.edgePanelDockEdge = newDock.edge.rawValue
         SettingsStorage.shared.edgePanelDockOffset = Double(newDock.offset)
         position(panel, presentation: currentPresentation, on: visibleFrame)
+        if currentPresentation == .collapsed {
+            scheduleTabAutoHide()
+        }
     }
 
     private func perform(_ action: EdgeCommandAction) {

--- a/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
+++ b/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
@@ -10,7 +10,9 @@ enum EdgeCommandAction: CaseIterable, Identifiable {
     case translateMeeting
     case batch
 
-    var id: Self { self }
+    var id: Self {
+        self
+    }
 
     var title: String {
         switch self {
@@ -37,7 +39,7 @@ enum EdgeCommandAction: CaseIterable, Identifiable {
     }
 }
 
-enum EdgeCommandPanelDockEdge: Equatable {
+enum EdgeCommandPanelDockEdge: String, Equatable {
     case left
     case right
     case top
@@ -47,6 +49,21 @@ enum EdgeCommandPanelDockEdge: Equatable {
 struct EdgeCommandPanelDock: Equatable {
     let edge: EdgeCommandPanelDockEdge
     let offset: CGFloat
+
+    init(edge: EdgeCommandPanelDockEdge, offset: CGFloat) {
+        self.edge = edge
+        self.offset = offset
+    }
+
+    /// Restores a dock persisted as raw values; nil when either value is
+    /// missing or the edge name is unknown. A stale offset from a
+    /// disconnected screen is safe — placement clamps it to the visible frame.
+    init?(rawEdge: String?, offset: Double?) {
+        guard let rawEdge, let edge = EdgeCommandPanelDockEdge(rawValue: rawEdge), let offset else {
+            return nil
+        }
+        self.init(edge: edge, offset: CGFloat(offset))
+    }
 }
 
 enum EdgeCommandPanelPresentation: Equatable {
@@ -77,27 +94,45 @@ enum EdgeCommandPanelPlacement {
         presentation: EdgeCommandPanelPresentation
     ) -> NSRect {
         let size = size(for: presentation, edge: dock.edge)
-        let origin: NSPoint
-
-        switch dock.edge {
+        let origin = switch dock.edge {
         case .left:
-            origin = NSPoint(
+            NSPoint(
                 x: visibleFrame.minX,
-                y: clampedOrigin(dock.offset, length: size.height, minimum: visibleFrame.minY, maximum: visibleFrame.maxY)
+                y: clampedOrigin(
+                    dock.offset,
+                    length: size.height,
+                    minimum: visibleFrame.minY,
+                    maximum: visibleFrame.maxY
+                )
             )
         case .right:
-            origin = NSPoint(
+            NSPoint(
                 x: visibleFrame.maxX - size.width,
-                y: clampedOrigin(dock.offset, length: size.height, minimum: visibleFrame.minY, maximum: visibleFrame.maxY)
+                y: clampedOrigin(
+                    dock.offset,
+                    length: size.height,
+                    minimum: visibleFrame.minY,
+                    maximum: visibleFrame.maxY
+                )
             )
         case .top:
-            origin = NSPoint(
-                x: clampedOrigin(dock.offset, length: size.width, minimum: visibleFrame.minX, maximum: visibleFrame.maxX),
+            NSPoint(
+                x: clampedOrigin(
+                    dock.offset,
+                    length: size.width,
+                    minimum: visibleFrame.minX,
+                    maximum: visibleFrame.maxX
+                ),
                 y: visibleFrame.maxY - size.height
             )
         case .bottom:
-            origin = NSPoint(
-                x: clampedOrigin(dock.offset, length: size.width, minimum: visibleFrame.minX, maximum: visibleFrame.maxX),
+            NSPoint(
+                x: clampedOrigin(
+                    dock.offset,
+                    length: size.width,
+                    minimum: visibleFrame.minX,
+                    maximum: visibleFrame.maxX
+                ),
                 y: visibleFrame.minY
             )
         }
@@ -136,7 +171,9 @@ enum EdgeCommandPanelPlacement {
         }
     }
 
-    private static func clampedOrigin(_ offset: CGFloat, length: CGFloat, minimum: CGFloat, maximum: CGFloat) -> CGFloat {
+    private static func clampedOrigin(_ offset: CGFloat, length: CGFloat, minimum: CGFloat,
+                                      maximum: CGFloat) -> CGFloat
+    {
         min(max(offset - length / 2, minimum), maximum - length)
     }
 }
@@ -230,7 +267,7 @@ final class EdgeCommandPanelController: NSObject {
     private var dock: EdgeCommandPanelDock?
     private var dragCursorOffset: NSPoint?
 
-    private override init() {
+    override private init() {
         super.init()
     }
 
@@ -308,13 +345,13 @@ final class EdgeCommandPanelController: NSObject {
             collapseTask?.cancel()
             collapseTask = Task { [weak self] in
                 try? await Task.sleep(for: .milliseconds(450))
-                guard !Task.isCancelled, let self, let panel = self.panel else { return }
+                guard !Task.isCancelled, let self, let panel else { return }
                 guard EdgeCommandPanelHoverPolicy.shouldCollapse(
                     pointer: NSEvent.mouseLocation,
                     panelFrame: panel.frame,
-                    isDragging: self.dragCursorOffset != nil
+                    isDragging: dragCursorOffset != nil
                 ) else { return }
-                self.showCollapsed()
+                showCollapsed()
             }
         }
     }
@@ -335,8 +372,11 @@ final class EdgeCommandPanelController: NSObject {
         dragCursorOffset = nil
         let screen = activeScreen() ?? panel.screen ?? NSScreen.main
         let visibleFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        dock = EdgeCommandPanelPlacement.nearestDock(to: panel.frame, in: visibleFrame)
-        model?.dockEdge = dock?.edge ?? .right
+        let newDock = EdgeCommandPanelPlacement.nearestDock(to: panel.frame, in: visibleFrame)
+        dock = newDock
+        model?.dockEdge = newDock.edge
+        SettingsStorage.shared.edgePanelDockEdge = newDock.edge.rawValue
+        SettingsStorage.shared.edgePanelDockOffset = Double(newDock.offset)
         position(panel, presentation: currentPresentation, on: visibleFrame)
     }
 
@@ -364,7 +404,8 @@ final class EdgeCommandPanelController: NSObject {
             appDelegate.toggleMeetingRecording()
         case .translateMeeting:
             if appDelegate.appState.meetingTranslationRecordingState == .idle {
-                guard appDelegate.canStartRecording(kind: .meetingTranslation), let pair else { showCollapsed(); return }
+                guard appDelegate.canStartRecording(kind: .meetingTranslation),
+                      let pair else { showCollapsed(); return }
                 Task { await appDelegate.startMeetingTranslationRecording(languagePair: pair) }
             } else {
                 appDelegate.toggleMeetingTranslationRecording()
@@ -443,11 +484,20 @@ final class EdgeCommandPanelController: NSObject {
         presentation: EdgeCommandPanelPresentation,
         on explicitVisibleFrame: NSRect? = nil
     ) {
+        // A live drag owns the frame; phase changes and toasts must not snap
+        // the panel back to its dock mid-drag. onDragEnd re-docks and calls
+        // position() again after clearing the drag offset.
+        guard dragCursorOffset == nil else { return }
         let screen = dock == nil ? activeScreen() : panel.screen ?? activeScreen()
         let visibleFrame = explicitVisibleFrame
             ?? screen?.visibleFrame
             ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
-        let resolvedDock = dock ?? EdgeCommandPanelDock(edge: .right, offset: visibleFrame.midY)
+        let resolvedDock = dock
+            ?? EdgeCommandPanelDock(
+                rawEdge: SettingsStorage.shared.edgePanelDockEdge,
+                offset: SettingsStorage.shared.edgePanelDockOffset
+            )
+            ?? EdgeCommandPanelDock(edge: .right, offset: visibleFrame.midY)
         dock = resolvedDock
         model?.dockEdge = resolvedDock.edge
         let isExpanded = presentation != .collapsed
@@ -488,8 +538,33 @@ final class EdgeCommandPanelController: NSObject {
 }
 
 private final class EdgeCommandPanel: NSPanel {
-    override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { false }
+    override var canBecomeKey: Bool {
+        true
+    }
+
+    override var canBecomeMain: Bool {
+        false
+    }
+}
+
+/// The panel is a non-activating panel of a usually-inactive app (the user is
+/// dictating into another app). Without accepting first mouse, the initial
+/// click is consumed by window-key handling and never reaches the SwiftUI
+/// drag gesture or buttons — dragging during recording required a second
+/// attempt and Stop/Copy needed a double click.
+private final class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
+    }
+
+    required init(rootView: Content) {
+        super.init(rootView: rootView)
+    }
+
+    @available(*, unavailable)
+    @MainActor @preconcurrency dynamic required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
 private final class EdgeCommandPanelContentView: NSView {
@@ -503,8 +578,8 @@ private final class EdgeCommandPanelContentView: NSView {
         expandedView: EdgeCommandExpandedView,
         onHoverChange: @escaping (Bool) -> Void
     ) {
-        tabHostingView = NSHostingView(rootView: tabView)
-        expandedHostingView = NSHostingView(rootView: expandedView)
+        tabHostingView = FirstMouseHostingView(rootView: tabView)
+        expandedHostingView = FirstMouseHostingView(rootView: expandedView)
         self.onHoverChange = onHoverChange
         super.init(frame: .zero)
 
@@ -518,8 +593,12 @@ private final class EdgeCommandPanelContentView: NSView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
     }
 
     override func layout() {
@@ -742,7 +821,10 @@ private struct EdgeCommandExpandedView: View {
             .foregroundStyle(selected ? Color.primary : Color.secondary)
             .frame(maxWidth: .infinity, minHeight: 24)
             .padding(.horizontal, 6)
-            .background(selected ? Color.primary.opacity(0.08) : .clear, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .background(
+                selected ? Color.primary.opacity(0.08) : .clear,
+                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+            )
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(selected ? .isSelected : [])

--- a/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
+++ b/Diduny/Features/EdgeCommandPanel/EdgeCommandPanelController.swift
@@ -341,7 +341,29 @@ final class EdgeCommandPanelController: NSObject {
         isTabHidden = false
         model?.isShowingLiveFeedback = false
         model?.isExpanded = false
-        panel?.orderOut(nil)
+        concealPanel()
+    }
+
+    /// Hides the panel by fading it out instead of ordering it out of the
+    /// window list — orderOut drops the visual-effect view's shape mask, and
+    /// the material comes back with square corners on the next show.
+    private func concealPanel() {
+        guard let panel else { return }
+        panel.ignoresMouseEvents = true
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.25
+            panel.animator().alphaValue = 0
+        }
+    }
+
+    private func revealPanelIfConcealed() {
+        guard let panel else { return }
+        panel.ignoresMouseEvents = false
+        guard panel.alphaValue < 1 else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.15
+            panel.animator().alphaValue = 1
+        }
     }
 
     private func refreshModel() {
@@ -380,6 +402,7 @@ final class EdgeCommandPanelController: NSObject {
         self.panel = panel
         model?.isShowingLiveFeedback = false
         position(panel, presentation: .collapsed)
+        revealPanelIfConcealed()
         panel.orderFrontRegardless()
         scheduleTabAutoHide()
     }
@@ -392,6 +415,7 @@ final class EdgeCommandPanelController: NSObject {
         self.panel = panel
         model?.isShowingLiveFeedback = false
         position(panel, presentation: commandPresentation)
+        revealPanelIfConcealed()
         panel.orderFrontRegardless()
     }
 
@@ -402,6 +426,7 @@ final class EdgeCommandPanelController: NSObject {
         self.panel = panel
         model?.isShowingLiveFeedback = true
         position(panel, presentation: .live(mode))
+        revealPanelIfConcealed()
         panel.orderFrontRegardless()
     }
 
@@ -437,7 +462,7 @@ final class EdgeCommandPanelController: NSObject {
         guard let panel else { return }
         isTabHidden = true
         hiddenTabScreenFrame = panel.screen?.frame
-        panel.orderOut(nil)
+        concealPanel()
         installEdgeRevealMonitors()
     }
 
@@ -658,6 +683,12 @@ final class EdgeCommandPanelController: NSObject {
         let isExpanded = presentation != .collapsed
         model?.isExpanded = isExpanded
         panelContentView?.setExpanded(isExpanded)
+        // Backstop clip: the SwiftUI material's shape mask can be lost by the
+        // window server; the layer clip keeps expanded corners rounded no
+        // matter what. The collapsed tab keeps its own edge-flush shape.
+        panelContentView?.applyCornerMask(
+            isExpanded ? EdgeCommandPanelPlacement.expandedCornerRadius : 0
+        )
 
         let frame = EdgeCommandPanelPlacement.frame(
             in: visibleFrame,
@@ -760,6 +791,13 @@ private final class EdgeCommandPanelContentView: NSView {
         super.layout()
         tabHostingView.frame = bounds
         expandedHostingView.frame = bounds
+    }
+
+    func applyCornerMask(_ radius: CGFloat) {
+        wantsLayer = true
+        layer?.cornerRadius = radius
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = radius > 0
     }
 
     func setExpanded(_ expanded: Bool) {

--- a/Diduny/Features/Notch/NotchContentView.swift
+++ b/Diduny/Features/Notch/NotchContentView.swift
@@ -1,0 +1,383 @@
+import SwiftUI
+
+// MARK: - Compact Leading (Left side of notch)
+
+struct NotchCompactLeadingView: View {
+    var manager: NotchManager
+
+    var body: some View {
+        Group {
+            switch manager.state {
+            case let .recording(mode):
+                HStack(spacing: 6) {
+                    RecordingCompactView(mode: mode)
+                    NotchAudioMeterView(manager: manager)
+                }
+
+            case let .processing(mode):
+                ProcessingCompactView(mode: mode)
+
+            default:
+                EmptyView()
+            }
+        }
+        .allowsHitTesting(false)
+        .animation(.easeInOut(duration: 0.2), value: manager.state)
+    }
+}
+
+// MARK: - Compact Trailing (Right side of notch)
+
+struct NotchCompactTrailingView: View {
+    var manager: NotchManager
+
+    var body: some View {
+        Group {
+            switch manager.state {
+            case .recording:
+                HStack(spacing: 6) {
+                    PulsingDotView()
+                        .allowsHitTesting(false)
+                    RecordingTimerView(startTime: manager.recordingStartTime)
+                        .allowsHitTesting(false)
+                    StopRecordingButton { manager.requestStopActiveRecording() }
+                }
+
+            case .processing:
+                ProgressView()
+                    .scaleEffect(0.5)
+                    .frame(width: 16, height: 16)
+                    .allowsHitTesting(false)
+
+            default:
+                EmptyView()
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: manager.state)
+    }
+}
+
+// MARK: - Expanded (Below notch)
+
+struct NotchExpandedView: View {
+    var manager: NotchManager
+
+    var body: some View {
+        Group {
+            switch manager.state {
+            case let .success(text):
+                SuccessExpandedView(text: text)
+                    .allowsHitTesting(false)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+
+            case let .error(message):
+                ErrorExpandedView(message: message)
+                    .allowsHitTesting(false)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+
+            case let .info(message):
+                InfoExpandedView(message: message)
+                    .allowsHitTesting(false)
+                    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+
+            case let .recording(mode):
+                RecordingExpandedView(mode: mode)
+                    .transition(.opacity)
+
+            case let .processing(mode):
+                ProcessingExpandedView(mode: mode)
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+
+            case .idle:
+                EmptyView()
+            }
+        }
+        .frame(minHeight: 20)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .animation(.easeInOut(duration: 0.35), value: manager.state)
+    }
+}
+
+// MARK: - Compact Components
+
+private struct RecordingCompactView: View {
+    let mode: RecordingMode
+
+    var body: some View {
+        Image(systemName: mode.icon)
+            .font(.system(size: 14, weight: .medium))
+            .foregroundStyle(.red)
+    }
+}
+
+private struct ProcessingCompactView: View {
+    let mode: RecordingMode
+
+    var body: some View {
+        Image(systemName: mode.icon)
+            .font(.system(size: 14, weight: .medium))
+            .foregroundStyle(.orange)
+    }
+}
+
+private struct PulsingDotView: View {
+    @State private var isPulsing = false
+
+    var body: some View {
+        Circle()
+            .fill(.red)
+            .frame(width: 8, height: 8)
+            .scaleEffect(isPulsing ? 1.4 : 1.0)
+            .opacity(isPulsing ? 0.6 : 1.0)
+            .frame(width: 14, height: 14)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
+                    isPulsing = true
+                }
+            }
+    }
+}
+
+/// Isolated leaf so only this view re-evaluates when audioLevel changes (~25/sec).
+private struct NotchAudioMeterView: View {
+    var manager: NotchManager
+
+    var body: some View {
+        AudioLevelView(level: manager.audioLevel)
+    }
+}
+
+private struct AudioLevelView: View {
+    let level: Float
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(0 ..< 3, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(.red)
+                    .frame(width: 3, height: barHeight(for: index))
+            }
+        }
+        .frame(width: 14, height: 14)
+    }
+
+    private func barHeight(for index: Int) -> CGFloat {
+        let threshold = Float(index + 1) / 4.0
+        let normalized = max(0, min(1, level))
+        let height = normalized > threshold ? CGFloat(normalized) * 14 : 4
+        return max(4, min(14, height))
+    }
+}
+
+private struct RecordingTimerView: View {
+    let startTime: Date?
+
+    var body: some View {
+        if let startTime {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                let elapsed = context.date.timeIntervalSince(startTime)
+                Text(formatDuration(elapsed))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.primary)
+            }
+        }
+    }
+
+    private func formatDuration(_ interval: TimeInterval) -> String {
+        let totalSeconds = Int(max(0, interval))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return "\(minutes):\(String(format: "%02d", seconds))"
+    }
+}
+
+// MARK: - Expanded Components
+
+private struct RecordingExpandedView: View {
+    let mode: RecordingMode
+    @State private var isPulsing = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(.red)
+                .frame(width: 8, height: 8)
+                .scaleEffect(isPulsing ? 1.3 : 1.0)
+                .opacity(isPulsing ? 0.7 : 1.0)
+
+            Image(systemName: mode.icon)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.red)
+
+            Text(mode.label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+
+            Spacer()
+
+            StopRecordingButton { NotchManager.shared.requestStopActiveRecording() }
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+                isPulsing = true
+            }
+        }
+    }
+}
+
+private struct ProcessingExpandedView: View {
+    let mode: RecordingMode
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .scaleEffect(0.6)
+                .frame(width: 14, height: 14)
+
+            Text(mode.processingLabel)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.orange)
+        }
+    }
+}
+
+private struct SuccessExpandedView: View {
+    let text: String
+    @State private var appeared = false
+
+    private var preview: String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count > 35 {
+            return String(trimmed.prefix(35)) + "..."
+        }
+        return trimmed
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.green)
+                .scaleEffect(appeared ? 1.0 : 0.3)
+                .opacity(appeared ? 1.0 : 0.0)
+
+            Text(preview)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .opacity(appeared ? 1.0 : 0.0)
+                .offset(x: appeared ? 0 : -5)
+
+            Spacer()
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 18, height: 18)
+                .scaleEffect(appeared ? 1.0 : 0.5)
+                .opacity(appeared ? 1.0 : 0.0)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.75)) {
+                appeared = true
+            }
+        }
+    }
+}
+
+private struct ErrorExpandedView: View {
+    let message: String
+    @State private var appeared = false
+
+    private var shortMessage: String {
+        if message.count > 40 {
+            return String(message.prefix(40)) + "..."
+        }
+        return message
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.red)
+                .scaleEffect(appeared ? 1.0 : 0.3)
+                .opacity(appeared ? 1.0 : 0.0)
+
+            Text(shortMessage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.red)
+                .lineLimit(1)
+                .opacity(appeared ? 1.0 : 0.0)
+                .offset(x: appeared ? 0 : -5)
+
+            Spacer()
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 18, height: 18)
+                .scaleEffect(appeared ? 1.0 : 0.5)
+                .opacity(appeared ? 0.6 : 0.0)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.75)) {
+                appeared = true
+            }
+        }
+    }
+}
+
+private struct StopRecordingButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "stop.fill")
+                .font(.system(size: 8, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(.red.opacity(0.95)))
+        }
+        .buttonStyle(.plain)
+        .help("Stop recording")
+    }
+}
+
+private struct InfoExpandedView: View {
+    let message: String
+    @State private var appeared = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "escape")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.orange)
+                .scaleEffect(appeared ? 1.0 : 0.3)
+                .opacity(appeared ? 1.0 : 0.0)
+
+            Text(message)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .opacity(appeared ? 1.0 : 0.0)
+                .offset(x: appeared ? 0 : -5)
+
+            Spacer()
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 18, height: 18)
+                .scaleEffect(appeared ? 1.0 : 0.5)
+                .opacity(appeared ? 0.8 : 0.0)
+        }
+        .onAppear {
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.75)) {
+                appeared = true
+            }
+        }
+    }
+}

--- a/Diduny/Features/Notch/NotchManager.swift
+++ b/Diduny/Features/Notch/NotchManager.swift
@@ -1,0 +1,184 @@
+import AppKit
+import DynamicNotchKit
+import Observation
+import SwiftUI
+
+enum NotchState: Equatable {
+    case idle
+    case recording(mode: RecordingMode)
+    case processing(mode: RecordingMode)
+    case success(text: String)
+    case error(message: String)
+    case info(message: String)
+}
+
+@Observable
+@MainActor
+final class NotchManager {
+    static let shared = NotchManager()
+
+    private(set) var state: NotchState = .idle
+    private(set) var recordingStartTime: Date?
+    var audioLevel: Float = 0
+
+    private var notch: DynamicNotch<NotchExpandedView, NotchCompactLeadingView, NotchCompactTrailingView>?
+    private var autoDismissTask: Task<Void, Never>?
+    private var notchTransitionTask: Task<Void, Never>?
+    private var onStopRequested: (@MainActor () async -> Void)?
+    private var operationSequence: UInt64 = 0
+
+    private init() {}
+
+    func startRecording(mode: RecordingMode = .voice) {
+        recordingStartTime = Date()
+        resumeRecording(mode: mode)
+    }
+
+    func resumeRecording(mode: RecordingMode = .voice) {
+        autoDismissTask?.cancel()
+        state = .recording(mode: mode)
+        showCompact()
+    }
+
+    func startProcessing(mode: RecordingMode = .voice) {
+        autoDismissTask?.cancel()
+        recordingStartTime = nil
+        audioLevel = 0
+        state = .processing(mode: mode)
+        showCompact()
+    }
+
+    func showSuccess(text: String) {
+        autoDismissTask?.cancel()
+        recordingStartTime = nil
+        audioLevel = 0
+        state = .success(text: text)
+        showExpanded()
+        scheduleAutoDismiss(delay: 2.0)
+    }
+
+    func showError(message: String) {
+        autoDismissTask?.cancel()
+        recordingStartTime = nil
+        audioLevel = 0
+        state = .error(message: message)
+        showExpanded()
+        scheduleAutoDismiss(delay: 3.0)
+    }
+
+    func showInfo(message: String, duration: TimeInterval = 1.5) {
+        autoDismissTask?.cancel()
+        state = .info(message: message)
+        showExpanded()
+        scheduleAutoDismiss(delay: duration)
+    }
+
+    /// Show info message during active recording, then auto-restore recording UI with preserved timer.
+    func showInfoDuringRecording(message: String, mode: RecordingMode, duration: TimeInterval = 1.5) {
+        autoDismissTask?.cancel()
+        let savedStartTime = recordingStartTime
+        state = .info(message: message)
+        showExpanded()
+        autoDismissTask = Task {
+            try? await Task.sleep(for: .seconds(duration))
+            guard !Task.isCancelled else { return }
+            recordingStartTime = savedStartTime
+            state = .recording(mode: mode)
+            showCompact()
+        }
+    }
+
+    func hide() {
+        autoDismissTask?.cancel()
+        recordingStartTime = nil
+        audioLevel = 0
+        state = .idle
+        operationSequence &+= 1
+        let seq = operationSequence
+        runNotchTransition(sequence: seq) {
+            await self.notch?.hide()
+        }
+    }
+
+    func setStopHandler(_ handler: (@MainActor () async -> Void)?) {
+        onStopRequested = handler
+    }
+
+    func requestStopActiveRecording() {
+        guard case .recording = state else { return }
+        guard let onStopRequested else { return }
+        Task { @MainActor in
+            await onStopRequested()
+        }
+    }
+
+    private func ensureNotch() {
+        if notch == nil {
+            notch = DynamicNotch {
+                NotchExpandedView(manager: self)
+            } compactLeading: {
+                NotchCompactLeadingView(manager: self)
+            } compactTrailing: {
+                NotchCompactTrailingView(manager: self)
+            }
+        }
+    }
+
+    private func activeScreen() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        if let mouseScreen = NSScreen.screens.first(where: { NSMouseInRect(mouseLocation, $0.frame, false) }) {
+            return mouseScreen
+        }
+
+        return NSScreen.main ?? NSScreen.screens.first
+    }
+
+    private func screenHasNotch(_ screen: NSScreen) -> Bool {
+        screen.auxiliaryTopLeftArea != nil && screen.auxiliaryTopRightArea != nil
+    }
+
+    private func showCompact() {
+        ensureNotch()
+        guard let screen = activeScreen() else { return }
+
+        operationSequence &+= 1
+        let seq = operationSequence
+        runNotchTransition(sequence: seq) {
+            if self.screenHasNotch(screen) {
+                await self.notch?.compact(on: screen)
+            } else {
+                await self.notch?.expand(on: screen)
+            }
+        }
+    }
+
+    private func showExpanded() {
+        ensureNotch()
+        guard let screen = activeScreen() else { return }
+        operationSequence &+= 1
+        let seq = operationSequence
+        runNotchTransition(sequence: seq) {
+            await self.notch?.expand(on: screen)
+        }
+    }
+
+    private func runNotchTransition(
+        sequence: UInt64,
+        operation: @escaping @MainActor () async -> Void
+    ) {
+        let previousTask = notchTransitionTask
+        notchTransitionTask = Task { @MainActor in
+            await previousTask?.value
+            guard self.operationSequence == sequence else { return }
+            await operation()
+        }
+    }
+
+    private func scheduleAutoDismiss(delay: TimeInterval) {
+        autoDismissTask = Task {
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            hide()
+        }
+    }
+}

--- a/Diduny/Features/Settings/GeneralSettingsView.swift
+++ b/Diduny/Features/Settings/GeneralSettingsView.swift
@@ -45,6 +45,7 @@ struct GeneralSettingsView: View {
                 .pickerStyle(.segmented)
                 .onChange(of: recordingFeedbackSurface) { _, newValue in
                     SettingsStorage.shared.recordingFeedbackSurface = newValue
+                    EdgeCommandPanelController.shared.applySurfacePreference()
                 }
 
             } header: {

--- a/Diduny/Features/Settings/GeneralSettingsView.swift
+++ b/Diduny/Features/Settings/GeneralSettingsView.swift
@@ -5,6 +5,7 @@ struct GeneralSettingsView: View {
     @State private var autoPaste = SettingsStorage.shared.autoPaste
     @State private var playSound = SettingsStorage.shared.playSoundOnCompletion
     @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var recordingFeedbackSurface = SettingsStorage.shared.recordingFeedbackSurface
     @State private var typingSpeedWordsPerMinute = SettingsStorage.shared.typingSpeedWordsPerMinute
     @State private var screenRecordingPromptEnabled = !SettingsStorage.shared.userDeclinedScreenRecording
     @State private var dictationRetention = SettingsStorage.shared.dictationTranslationHistoryRetentionPolicy
@@ -13,6 +14,7 @@ struct GeneralSettingsView: View {
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
     }
+
     private var buildNumber: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
     }
@@ -35,8 +37,22 @@ struct GeneralSettingsView: View {
                         LaunchAtLogin.isEnabled = newValue
                     }
 
+                Picker("Recording feedback", selection: $recordingFeedbackSurface) {
+                    ForEach(RecordingFeedbackSurface.allCases) { surface in
+                        Text(surface.displayName).tag(surface)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: recordingFeedbackSurface) { _, newValue in
+                    SettingsStorage.shared.recordingFeedbackSurface = newValue
+                }
+
             } header: {
                 Text("Behavior")
+            } footer: {
+                Text(
+                    "Dynamic Notch shows a compact indicator without the live transcript; Floating modal shows the transcript as you speak."
+                )
             }
 
             Section {
@@ -86,7 +102,9 @@ struct GeneralSettingsView: View {
             } header: {
                 Text("History & Storage")
             } footer: {
-                Text("Choose how long Diduny keeps recordings in the library. Meeting recordings remain available under Recordings while Meetings is in beta.")
+                Text(
+                    "Choose how long Diduny keeps recordings in the library. Meeting recordings remain available under Recordings while Meetings is in beta."
+                )
             }
 
             Section {
@@ -98,7 +116,9 @@ struct GeneralSettingsView: View {
             } header: {
                 Text("Onboarding")
             } footer: {
-                Text("When enabled, Diduny will prompt you to grant Screen Recording permission on next launch if it is not yet granted.")
+                Text(
+                    "When enabled, Diduny will prompt you to grant Screen Recording permission on next launch if it is not yet granted."
+                )
             }
 
             Section {
@@ -146,6 +166,7 @@ struct GeneralSettingsView: View {
         .formStyle(.grouped)
         .onAppear {
             launchAtLogin = LaunchAtLogin.isEnabled
+            recordingFeedbackSurface = SettingsStorage.shared.recordingFeedbackSurface
             typingSpeedWordsPerMinute = SettingsStorage.shared.typingSpeedWordsPerMinute
             screenRecordingPromptEnabled = !SettingsStorage.shared.userDeclinedScreenRecording
             dictationRetention = SettingsStorage.shared.dictationTranslationHistoryRetentionPolicy

--- a/DidunyTests/EdgeCommandPanelModelTests.swift
+++ b/DidunyTests/EdgeCommandPanelModelTests.swift
@@ -175,6 +175,59 @@ struct EdgeCommandPanelModelTests {
         #expect(EdgeCommandPanelDock(rawEdge: nil, offset: 100) == nil)
         #expect(EdgeCommandPanelDock(rawEdge: "top", offset: nil) == nil)
     }
+
+    @Test("The collapsed tab auto-hides only when idle and untouched")
+    func tabAutoHidesOnlyWhenIdleAndUntouched() {
+        let panelFrame = NSRect(x: 1426, y: 418, width: 14, height: 64)
+        let outside = NSPoint(x: 700, y: 400)
+        let inside = NSPoint(x: 1430, y: 440)
+
+        #expect(EdgeCommandPanelAutoHidePolicy.shouldHide(
+            pointer: outside, panelFrame: panelFrame,
+            isDragging: false, isExpanded: false, isShowingLiveFeedback: false
+        ))
+        #expect(!EdgeCommandPanelAutoHidePolicy.shouldHide(
+            pointer: inside, panelFrame: panelFrame,
+            isDragging: false, isExpanded: false, isShowingLiveFeedback: false
+        ))
+        #expect(!EdgeCommandPanelAutoHidePolicy.shouldHide(
+            pointer: outside, panelFrame: panelFrame,
+            isDragging: true, isExpanded: false, isShowingLiveFeedback: false
+        ))
+        #expect(!EdgeCommandPanelAutoHidePolicy.shouldHide(
+            pointer: outside, panelFrame: panelFrame,
+            isDragging: false, isExpanded: true, isShowingLiveFeedback: false
+        ))
+        #expect(!EdgeCommandPanelAutoHidePolicy.shouldHide(
+            pointer: outside, panelFrame: panelFrame,
+            isDragging: false, isExpanded: false, isShowingLiveFeedback: true
+        ))
+    }
+
+    @Test("A hidden tab reveals when the pointer touches the docked screen edge")
+    func hiddenTabRevealsAtDockedEdge() {
+        let screenFrame = NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+        #expect(EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 1439, y: 500), screenFrame: screenFrame, edge: .right
+        ))
+        #expect(!EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 1400, y: 500), screenFrame: screenFrame, edge: .right
+        ))
+        #expect(EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 1, y: 500), screenFrame: screenFrame, edge: .left
+        ))
+        #expect(EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 700, y: 899), screenFrame: screenFrame, edge: .top
+        ))
+        #expect(EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 700, y: 1), screenFrame: screenFrame, edge: .bottom
+        ))
+        // A point on another screen's edge line but outside this screen is ignored.
+        #expect(!EdgeCommandPanelPlacement.edgeHotZoneContains(
+            NSPoint(x: 1439, y: 1200), screenFrame: screenFrame, edge: .right
+        ))
+    }
 }
 
 @MainActor

--- a/DidunyTests/EdgeCommandPanelModelTests.swift
+++ b/DidunyTests/EdgeCommandPanelModelTests.swift
@@ -1,6 +1,6 @@
 import AppKit
-import Testing
 @testable import Diduny
+import Testing
 
 @MainActor
 struct EdgeCommandPanelModelTests {
@@ -100,11 +100,19 @@ struct EdgeCommandPanelModelTests {
 
         #expect(EdgeCommandPanelPlacement.frame(in: visibleFrame, dock: rightDock, presentation: .collapsed)
             == NSRect(x: 1426, y: 418, width: 14, height: 64))
-        #expect(EdgeCommandPanelPlacement.frame(in: visibleFrame, dock: rightDock, presentation: .commands(isCloud: true))
+        #expect(EdgeCommandPanelPlacement.frame(
+            in: visibleFrame,
+            dock: rightDock,
+            presentation: .commands(isCloud: true)
+        )
             == NSRect(x: 1154, y: 287, width: 286, height: 326))
         #expect(EdgeCommandPanelPlacement.frame(in: visibleFrame, dock: bottomDock, presentation: .collapsed)
             == NSRect(x: 688, y: 0, width: 64, height: 14))
-        #expect(EdgeCommandPanelPlacement.frame(in: visibleFrame, dock: bottomDock, presentation: .commands(isCloud: true))
+        #expect(EdgeCommandPanelPlacement.frame(
+            in: visibleFrame,
+            dock: bottomDock,
+            presentation: .commands(isCloud: true)
+        )
             == NSRect(x: 577, y: 0, width: 286, height: 326))
     }
 
@@ -157,6 +165,16 @@ struct EdgeCommandPanelModelTests {
             isDragging: false
         ))
     }
+
+    @Test("A persisted dock position restores across app restarts")
+    func dockRestoresFromPersistedRawValues() {
+        let saved = EdgeCommandPanelDock(edge: .left, offset: 321)
+
+        #expect(EdgeCommandPanelDock(rawEdge: saved.edge.rawValue, offset: Double(saved.offset)) == saved)
+        #expect(EdgeCommandPanelDock(rawEdge: "diagonal", offset: 100) == nil)
+        #expect(EdgeCommandPanelDock(rawEdge: nil, offset: 100) == nil)
+        #expect(EdgeCommandPanelDock(rawEdge: "top", offset: nil) == nil)
+    }
 }
 
 @MainActor
@@ -207,15 +225,15 @@ struct EdgeCommandPanelLiveTextTests {
         store.reset(mode: .meeting)
 
         store.processTokens([
-            RealtimeToken(text: "Hello", isFinal: true, speaker: "1", startMs: 1_200),
-            RealtimeToken(text: "Hi", isFinal: true, speaker: "2", startMs: 65_000)
+            RealtimeToken(text: "Hello", isFinal: true, speaker: "1", startMs: 1200),
+            RealtimeToken(text: "Hi", isFinal: true, speaker: "2", startMs: 65000)
         ])
 
         #expect(store.displayText.contains("[00:01] Speaker 1: Hello"))
         #expect(store.displayText.contains("[01:05] Speaker 2: Hi"))
 
         store.processTokens([
-            RealtimeToken(text: "Still speaking", isFinal: false, speaker: "2", startMs: 66_000)
+            RealtimeToken(text: "Still speaking", isFinal: false, speaker: "2", startMs: 66000)
         ])
 
         #expect(store.displayText.contains("Still speaking"))
@@ -227,11 +245,11 @@ struct EdgeCommandPanelLiveTextTests {
         store.reset(mode: .meeting)
 
         store.processTokens([
-            RealtimeToken(text: "First phrase", isFinal: true, speaker: "1", startMs: 1_000)
+            RealtimeToken(text: "First phrase", isFinal: true, speaker: "1", startMs: 1000)
         ])
         store.markSegmentBoundary()
         store.processTokens([
-            RealtimeToken(text: "Second phrase", isFinal: true, speaker: "1", startMs: 8_000)
+            RealtimeToken(text: "Second phrase", isFinal: true, speaker: "1", startMs: 8000)
         ])
 
         #expect(store.displayText.contains("[00:01] Speaker 1: First phrase"))

--- a/DidunyTests/NotchManagerTests.swift
+++ b/DidunyTests/NotchManagerTests.swift
@@ -1,0 +1,234 @@
+@testable import Diduny
+import Testing
+
+@MainActor
+struct NotchManagerTests {
+    private var sut: NotchManager {
+        NotchManager.shared
+    }
+
+    init() {
+        NotchManager.shared.hide()
+        NotchManager.shared.setStopHandler(nil)
+    }
+
+    // MARK: - startRecording
+
+    @Test("startRecording sets recordingStartTime and transitions to recording state")
+    func startRecordingSetsTimestamp() throws {
+        let before = Date()
+        sut.startRecording(mode: .voice)
+        let after = Date()
+
+        #expect(sut.state == .recording(mode: .voice))
+        #expect(sut.recordingStartTime != nil)
+        #expect(try #require(sut.recordingStartTime) >= before)
+        #expect(try #require(sut.recordingStartTime) <= after)
+    }
+
+    @Test("startRecording with different modes", arguments: [
+        RecordingMode.voice,
+        RecordingMode.meeting,
+        RecordingMode.meetingTranslation,
+        RecordingMode.fileTranscription
+    ])
+    func startRecordingWithMode(mode: RecordingMode) {
+        sut.startRecording(mode: mode)
+        #expect(sut.state == .recording(mode: mode))
+        #expect(sut.recordingStartTime != nil)
+    }
+
+    // MARK: - resumeRecording (timer restart bug fix)
+
+    @Test("resumeRecording preserves existing recordingStartTime")
+    func resumeRecordingPreservesTimestamp() {
+        sut.startRecording(mode: .voice)
+        let originalStartTime = sut.recordingStartTime
+
+        sut.resumeRecording(mode: .voice)
+
+        #expect(sut.state == .recording(mode: .voice))
+        #expect(sut.recordingStartTime == originalStartTime,
+                "resumeRecording must NOT reset recordingStartTime")
+    }
+
+    @Test("resumeRecording without prior startRecording leaves recordingStartTime nil")
+    func resumeRecordingWithoutStart() {
+        sut.resumeRecording(mode: .voice)
+
+        #expect(sut.state == .recording(mode: .voice))
+        #expect(sut.recordingStartTime == nil)
+    }
+
+    @Test("startRecording after resumeRecording sets a NEW timestamp")
+    func startAfterResumeResetsTimestamp() {
+        sut.resumeRecording(mode: .voice)
+        #expect(sut.recordingStartTime == nil)
+
+        sut.startRecording(mode: .voice)
+        #expect(sut.recordingStartTime != nil)
+    }
+
+    // MARK: - startProcessing
+
+    @Test("startProcessing clears recording metadata")
+    func startProcessingClearsMetadata() {
+        sut.startRecording(mode: .voice)
+        sut.audioLevel = 0.5
+        #expect(sut.recordingStartTime != nil)
+
+        sut.startProcessing(mode: .voice)
+
+        #expect(sut.state == .processing(mode: .voice))
+        #expect(sut.recordingStartTime == nil)
+        #expect(sut.audioLevel == 0)
+    }
+
+    // MARK: - showSuccess
+
+    @Test("showSuccess sets state and clears recording metadata")
+    func showSuccessSetsState() {
+        sut.startRecording(mode: .voice)
+        sut.audioLevel = 0.5
+
+        sut.showSuccess(text: "Hello world")
+
+        #expect(sut.state == .success(text: "Hello world"))
+        #expect(sut.recordingStartTime == nil)
+        #expect(sut.audioLevel == 0)
+    }
+
+    // MARK: - showError
+
+    @Test("showError sets state and clears recording metadata")
+    func showErrorSetsState() {
+        sut.startRecording(mode: .voice)
+
+        sut.showError(message: "Something went wrong")
+
+        #expect(sut.state == .error(message: "Something went wrong"))
+        #expect(sut.recordingStartTime == nil)
+    }
+
+    // MARK: - showInfo
+
+    @Test("showInfo sets info state")
+    func showInfoSetsState() {
+        sut.showInfo(message: "Press Esc 1 more time to cancel")
+        #expect(sut.state == .info(message: "Press Esc 1 more time to cancel"))
+    }
+
+    @Test("showInfo during recording does not clear recordingStartTime")
+    func showInfoPreservesRecordingStartTime() {
+        sut.startRecording(mode: .voice)
+        let originalStartTime = sut.recordingStartTime
+
+        sut.showInfo(message: "hint")
+
+        #expect(sut.state == .info(message: "hint"))
+        #expect(sut.recordingStartTime == originalStartTime)
+    }
+
+    // MARK: - hide
+
+    @Test("hide resets all state to idle")
+    func hideResetsToIdle() {
+        sut.startRecording(mode: .voice)
+        sut.audioLevel = 0.8
+
+        sut.hide()
+
+        #expect(sut.state == .idle)
+        #expect(sut.recordingStartTime == nil)
+        #expect(sut.audioLevel == 0)
+    }
+
+    // MARK: - requestStopActiveRecording
+
+    @Test("requestStopActiveRecording fires handler when recording")
+    func requestStopFiresHandler() async {
+        var handlerCalled = false
+        sut.setStopHandler { handlerCalled = true }
+        sut.startRecording(mode: .voice)
+
+        sut.requestStopActiveRecording()
+
+        // Handler runs in a Task — yield to let it execute
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(handlerCalled)
+    }
+
+    @Test("requestStopActiveRecording does nothing when idle")
+    func requestStopNoopWhenIdle() async {
+        var handlerCalled = false
+        sut.setStopHandler { handlerCalled = true }
+
+        sut.requestStopActiveRecording()
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(!handlerCalled)
+    }
+
+    @Test("requestStopActiveRecording does nothing when processing")
+    func requestStopNoopWhenProcessing() async {
+        var handlerCalled = false
+        sut.setStopHandler { handlerCalled = true }
+        sut.startProcessing(mode: .voice)
+
+        sut.requestStopActiveRecording()
+
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(!handlerCalled)
+    }
+
+    @Test("requestStopActiveRecording does nothing without handler")
+    func requestStopNoopWithoutHandler() {
+        sut.startRecording(mode: .voice)
+        sut.requestStopActiveRecording()
+        #expect(sut.state == .recording(mode: .voice))
+    }
+
+    // MARK: - Full flow
+
+    @Test("Complete flow: start -> process -> success -> hide")
+    func completeFlow() {
+        sut.startRecording(mode: .voice)
+        #expect(sut.state == .recording(mode: .voice))
+        #expect(sut.recordingStartTime != nil)
+
+        sut.startProcessing(mode: .voice)
+        #expect(sut.state == .processing(mode: .voice))
+        #expect(sut.recordingStartTime == nil)
+
+        sut.showSuccess(text: "Done")
+        #expect(sut.state == .success(text: "Done"))
+
+        sut.hide()
+        #expect(sut.state == .idle)
+    }
+
+    @Test("Error flow: start -> process -> error")
+    func errorFlow() {
+        sut.startRecording(mode: .meeting)
+        sut.startProcessing(mode: .meeting)
+        sut.showError(message: "Timeout")
+
+        #expect(sut.state == .error(message: "Timeout"))
+    }
+
+    @Test("ESC info flow: start -> showInfo -> resumeRecording preserves timer")
+    func escInfoFlowPreservesTimer() {
+        sut.startRecording(mode: .voice)
+        let originalStartTime = sut.recordingStartTime
+
+        // First ESC press shows info
+        sut.showInfo(message: "Press Esc 1 more time to cancel")
+        #expect(sut.state == .info(message: "Press Esc 1 more time to cancel"))
+
+        // After info auto-dismisses, recording resumes
+        sut.resumeRecording(mode: .voice)
+        #expect(sut.state == .recording(mode: .voice))
+        #expect(sut.recordingStartTime == originalStartTime,
+                "Timer must continue from original start time after ESC info")
+    }
+}

--- a/DidunyTests/NotchStateTests.swift
+++ b/DidunyTests/NotchStateTests.swift
@@ -1,0 +1,33 @@
+@testable import Diduny
+import Testing
+
+struct NotchStateTests {
+    @Test("Equal states are equal")
+    func equalStates() {
+        #expect(NotchState.idle == NotchState.idle)
+        #expect(NotchState.recording(mode: .voice) == NotchState.recording(mode: .voice))
+        #expect(NotchState.success(text: "a") == NotchState.success(text: "a"))
+        #expect(NotchState.error(message: "x") == NotchState.error(message: "x"))
+        #expect(NotchState.info(message: "i") == NotchState.info(message: "i"))
+    }
+
+    @Test("Different states are not equal")
+    func differentStates() {
+        #expect(NotchState.idle != NotchState.recording(mode: .voice))
+        #expect(NotchState.recording(mode: .voice) != NotchState.recording(mode: .meeting))
+        #expect(NotchState.success(text: "a") != NotchState.success(text: "b"))
+        #expect(NotchState.recording(mode: .voice) != NotchState.processing(mode: .voice))
+    }
+
+    @Test("RecordingMode labels and icons are non-empty")
+    func recordingModeProperties() {
+        let modes: [RecordingMode] = [
+            .voice, .translation(), .meeting, .meetingTranslation, .fileTranscription
+        ]
+        for mode in modes {
+            #expect(!mode.label.isEmpty)
+            #expect(!mode.processingLabel.isEmpty)
+            #expect(!mode.icon.isEmpty)
+        }
+    }
+}

--- a/DidunyTests/RecordingFeedbackControllerTests.swift
+++ b/DidunyTests/RecordingFeedbackControllerTests.swift
@@ -1,8 +1,6 @@
+@testable import Diduny
 import Testing
 
-@testable import Diduny
-
-@Suite("Recording feedback controls")
 @MainActor
 struct RecordingFeedbackControllerTests {
     @Test("Stop cancels voice recording while it is still starting")
@@ -24,5 +22,48 @@ struct RecordingFeedbackControllerTests {
         await delegate.stopActiveRecordingFromFeedback()
 
         #expect(delegate.appState.recordingState == .processing)
+    }
+
+    @Test("Dynamic Notch surface never feeds the live transcript")
+    func notchSurfaceSkipsLiveTranscriptTokens() {
+        let previousSurface = SettingsStorage.shared.recordingFeedbackSurface
+        defer {
+            SettingsStorage.shared.recordingFeedbackSurface = previousSurface
+            DictationOverlayController.shared.dismiss()
+        }
+        let sut = DictationOverlayController.shared
+
+        SettingsStorage.shared.recordingFeedbackSurface = .notch
+        sut.begin(mode: .voice)
+        sut.processTokens([RealtimeToken(text: "hidden", isFinal: true)])
+        #expect(!sut.store.displayText.contains("hidden"))
+        sut.dismiss()
+
+        SettingsStorage.shared.recordingFeedbackSurface = .compactPanel
+        sut.begin(mode: .voice)
+        sut.processTokens([RealtimeToken(text: "visible", isFinal: true)])
+        #expect(sut.store.displayText.contains("visible"))
+    }
+
+    @Test("A mid-recording surface flip keeps the session on its starting surface")
+    func surfaceFlipMidRecordingDoesNotRerouteSession() {
+        let previousSurface = SettingsStorage.shared.recordingFeedbackSurface
+        defer {
+            SettingsStorage.shared.recordingFeedbackSurface = previousSurface
+            DictationOverlayController.shared.dismiss()
+        }
+        let sut = DictationOverlayController.shared
+
+        SettingsStorage.shared.recordingFeedbackSurface = .compactPanel
+        sut.begin(mode: .voice)
+        SettingsStorage.shared.recordingFeedbackSurface = .notch
+        sut.processTokens([RealtimeToken(text: "still panel", isFinal: true)])
+        #expect(sut.store.displayText.contains("still panel"))
+        sut.dismiss()
+
+        // Next session picks up the flipped setting.
+        sut.begin(mode: .voice)
+        sut.processTokens([RealtimeToken(text: "now notch", isFinal: true)])
+        #expect(!sut.store.displayText.contains("now notch"))
     }
 }

--- a/DidunyTests/SettingsStorageProviderTests.swift
+++ b/DidunyTests/SettingsStorageProviderTests.swift
@@ -101,8 +101,10 @@ final class SettingsStorageProviderTests: XCTestCase {
         storedTranslationLanguageA = UserDefaults.standard.object(forKey: translationLanguageAKey)
         storedTranslationLanguageB = UserDefaults.standard.object(forKey: translationLanguageBKey)
         storedTranslationLanguagePairs = UserDefaults.standard.object(forKey: translationLanguagePairsKey)
-        storedDefaultTranslationLanguagePairID = UserDefaults.standard.object(forKey: defaultTranslationLanguagePairIDKey)
-        storedLastUsedTranslationLanguagePairID = UserDefaults.standard.object(forKey: lastUsedTranslationLanguagePairIDKey)
+        storedDefaultTranslationLanguagePairID = UserDefaults.standard
+            .object(forKey: defaultTranslationLanguagePairIDKey)
+        storedLastUsedTranslationLanguagePairID = UserDefaults.standard
+            .object(forKey: lastUsedTranslationLanguagePairIDKey)
         storedTranslationTargetLanguages = UserDefaults.standard.object(forKey: translationTargetLanguagesKey)
         storedVoiceTranslationTargetLanguage = UserDefaults.standard.object(forKey: voiceTranslationTargetLanguageKey)
         storedTextTranslationSourceLanguage = UserDefaults.standard.object(forKey: textTranslationSourceLanguageKey)
@@ -352,6 +354,13 @@ final class SettingsStorageProviderTests: XCTestCase {
         XCTAssertEqual(translation?["type"] as? String, "two_way")
         XCTAssertEqual(translation?["language_a"] as? String, "en")
         XCTAssertEqual(translation?["language_b"] as? String, "uk")
+    }
+
+    func test_resolveLanguageConfig_trimsForcedHintsAndTreatsThemAsStrict() {
+        let config = CloudTranscriptionService.resolveLanguageConfig(forcedLanguageHints: [" pl ", "", "en"])
+
+        XCTAssertEqual(config.hints, ["pl", "en"])
+        XCTAssertTrue(config.strict)
     }
 
     func test_realtimeTranslationConfig_includesTwoWayPayloadAndStrictLanguageHints() {

--- a/project.yml
+++ b/project.yml
@@ -9,6 +9,9 @@ packages:
   KeyboardShortcuts:
     url: https://github.com/sindresorhus/KeyboardShortcuts
     exactVersion: 2.4.0
+  DynamicNotchKit:
+    url: https://github.com/MrKai77/DynamicNotchKit
+    revision: cd0b3e52d537db115ad3a9d89601f20e0bee8d27
   LaunchAtLogin:
     url: https://github.com/sindresorhus/LaunchAtLogin-Modern
     exactVersion: 1.1.0
@@ -74,6 +77,7 @@ targets:
           - "**/.claude"
     dependencies:
       - package: KeyboardShortcuts
+      - package: DynamicNotchKit
       - package: LaunchAtLogin
       - package: Sparkle
       - framework: Frameworks/whisper.xcframework


### PR DESCRIPTION
## Summary
- Restore the Dynamic Notch recording surface (removed in #59) with a Settings toggle between "Dynamic Notch" (no live transcript) and "Floating modal" (default, shows transcript) — includes a live-testing follow-up: the edge panel is now fully hidden in notch mode, and its collapsed tab auto-hides after 3s idle (reveals at the docked screen edge).
- Fix launch-at-login opening the main window — login-item launches now stay in the menu bar only; manual Finder/Spotlight launches are unaffected.
- Fix the floating panel not being draggable during recording (first-mouse click swallowed on the non-activating panel) and add dock position persistence across restarts.
- Fix meeting recording: stop-via-shortcut could be killed by a blanket task cancel (losing the recording), cloud Translate went through a sync upload that 413'd on long meetings (now via the async jobs API), and the meeting is now saved to Recordings immediately after stop instead of only after transcription completes.
- Fix a corner-rounding regression on the edge panel introduced by the hide/show cycles added above (window-server mask loss on `orderOut`).

## Test plan
- [x] Full `xcodebuild test` suite green (209 XCTest + 82 Swift Testing, 0 failures)
- [x] `xcodebuild build` clean for Diduny DEV
- [x] Manual verification in Diduny DEV: notch/floating-modal toggle, panel drag while recording, launch-at-login window suppression, meeting stop-and-transcribe, edge panel corner rounding after hide/reveal cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsFJw24fSU8ypZZ7weKU3P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notch-based recording feedback with animated recording, processing, success, error, and informational states.
  * Added a setting to choose between notch and compact edge-panel feedback.
  * Added persistent edge-panel docking, edge selection, positioning, auto-hide, and edge-triggered reveal behavior.
  * Improved recording status labels and feedback transitions.
  * Added asynchronous cloud translation support for one-way and two-way translations.

* **Bug Fixes**
  * Improved recording cancellation, processing, transcription status updates, and cleanup reliability.
  * Login-item launches no longer unnecessarily display the main window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->