### PR TITLE
fix: copy meeting transcripts with timestamps and speakers, close detail sheet

### DIFF
--- a/Diduny/Core/Models/Recording.swift
+++ b/Diduny/Core/Models/Recording.swift
@@ -46,6 +46,38 @@ struct TimedTranscriptSegment: Codable, Equatable {
             ? String(format: "%d:%02d:%02d", hours, minutes, seconds)
             : String(format: "%02d:%02d", minutes, seconds)
     }
+
+    /// Human readable speaker name, e.g. `Speaker 1`. `nil` when the provider
+    /// returned no diarization for this segment.
+    var speakerLabel: String? {
+        guard let speaker else { return nil }
+        let trimmed = speaker.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.range(of: "speaker", options: [.caseInsensitive, .anchored]) != nil {
+            return trimmed
+        }
+        return "Speaker \(trimmed)"
+    }
+
+    /// One transcript line carrying the timestamp and, when available, the speaker.
+    var formattedLine: String {
+        if let speakerLabel {
+            return "[\(timestampLabel)] \(speakerLabel): \(text)"
+        }
+        return "[\(timestampLabel)] \(text)"
+    }
+}
+
+enum TimedTranscriptRenderer {
+    /// Renders timed segments as `[mm:ss] Speaker N: text` blocks, falling back to
+    /// the plain transcript when no timed segments exist.
+    static func render(segments: [TimedTranscriptSegment]?, fallbackText: String) -> String {
+        guard let segments, !segments.isEmpty else { return fallbackText }
+        let rendered = segments
+            .map(\.formattedLine)
+            .joined(separator: "\n\n")
+        return rendered.isEmpty ? fallbackText : rendered
+    }
 }
 
 struct TranscriptVersion: Identifiable, Codable, Equatable {
@@ -88,6 +120,13 @@ struct TranscriptVersion: Identifiable, Codable, Equatable {
         self.text = text
         self.segments = segments
         self.provenance = provenance
+    }
+
+    /// Transcript exactly as shown in the UI: timestamps and speaker labels when the
+    /// version carries timed segments, plain text otherwise. Use this for copy/export
+    /// so the clipboard matches what the user sees on screen.
+    var displayText: String {
+        TimedTranscriptRenderer.render(segments: segments, fallbackText: text)
     }
 }
 
@@ -182,10 +221,10 @@ struct Recording: Identifiable, Codable, Equatable {
 
     var displayTranscriptText: String? {
         guard let transcriptionText, !transcriptionText.isEmpty else { return nil }
-        guard let transcriptSegments, !transcriptSegments.isEmpty else { return transcriptionText }
-        return transcriptSegments
-            .map { "[\($0.timestampLabel)] \($0.text)" }
-            .joined(separator: "\n\n")
+        return TimedTranscriptRenderer.render(
+            segments: transcriptSegments,
+            fallbackText: transcriptionText
+        )
     }
 
     var requiresLocalTranscription: Bool {

--- a/Diduny/Core/Storage/TranscriptionBatchStorage.swift
+++ b/Diduny/Core/Storage/TranscriptionBatchStorage.swift
@@ -147,7 +147,7 @@ struct TranscriptionBatch: Codable, Equatable, Identifiable {
                 var details = ["Processed: \(version.createdAt.formatted(.iso8601))"]
                 if let provider = version.provider { details.append("Provider: \(provider)") }
                 if let model = version.modelIdentifier { details.append("Model: \(model)") }
-                return "### \(heading)\n\n\(details.joined(separator: "\n"))\n\n\(version.text)"
+                return "### \(heading)\n\n\(details.joined(separator: "\n"))\n\n\(version.displayText)"
             }.joined(separator: "\n\n")
         return "## \(recording.displayTitle)\n\n\(metadata.joined(separator: "\n"))\n\n\(history)"
     }

--- a/Diduny/Features/Meetings/MeetingsView.swift
+++ b/Diduny/Features/Meetings/MeetingsView.swift
@@ -72,7 +72,7 @@ struct MeetingsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .sheet(item: $selectedRecording) { recording in
-            RecordingDetailView(recording: recording)
+            RecordingDetailView(recording: recording, onClose: { selectedRecording = nil })
                 .frame(minWidth: 640, idealWidth: 700, minHeight: 500)
         }
         .alert("Delete Selected Meetings", isPresented: $showBulkDeleteConfirmation) {

--- a/Diduny/Features/Overview/OverviewView.swift
+++ b/Diduny/Features/Overview/OverviewView.swift
@@ -209,7 +209,7 @@ struct OverviewView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .sheet(item: $selectedRecording) { recording in
-            RecordingDetailView(recording: recording)
+            RecordingDetailView(recording: recording, onClose: { selectedRecording = nil })
                 .frame(minWidth: 640, idealWidth: 700, minHeight: 500)
         }
         .onReceive(NotificationCenter.default.publisher(for: .typingSpeedSettingsChanged)) { _ in

--- a/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
+++ b/Diduny/Features/RecordingsLibrary/RecordingDetailView.swift
@@ -25,7 +25,7 @@ struct RecordingDetailView: View {
         recording: Recording,
         parentBatchName: String? = nil,
         onBack: (() -> Void)? = nil,
-        onClose: @escaping () -> Void = {}
+        onClose: @escaping () -> Void
     ) {
         self.recording = recording
         self.parentBatchName = parentBatchName
@@ -397,14 +397,14 @@ struct RecordingDetailView: View {
                 }
                 Spacer()
                 Button {
-                    ClipboardService.shared.copy(text: version.text, behavior: .raw)
+                    ClipboardService.shared.copy(text: version.displayText, behavior: .raw)
                 } label: {
                     Label("Copy Transcript", systemImage: "doc.on.doc")
                 }
                 .controlSize(.small)
             }
             ScrollView {
-                Text(transcriptVersionText(version))
+                Text(version.displayText)
                     .textSelection(.enabled)
                     .font(.body)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -427,11 +427,6 @@ struct RecordingDetailView: View {
             }
             return "Translation"
         }
-    }
-
-    private func transcriptVersionText(_ version: TranscriptVersion) -> String {
-        guard let segments = version.segments, !segments.isEmpty else { return version.text }
-        return segments.map { "[\($0.timestampLabel)] \($0.text)" }.joined(separator: "\n\n")
     }
 
     // MARK: - Processing actions

--- a/Diduny/Features/Transcription/TranscriptionBatchesView.swift
+++ b/Diduny/Features/Transcription/TranscriptionBatchesView.swift
@@ -274,7 +274,7 @@ struct TranscriptionBatchInspectorView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 if let latest = recording.resolvedTranscriptHistory.last {
                                     Button("Copy") {
-                                        ClipboardService.shared.copy(text: latest.text, behavior: .raw)
+                                        ClipboardService.shared.copy(text: latest.displayText, behavior: .raw)
                                     }
                                     .controlSize(.small)
                                 }

--- a/Diduny/Resources/ReleaseHighlights.json
+++ b/Diduny/Resources/ReleaseHighlights.json
@@ -1,9 +1,8 @@
 {
   "schemaVersion": 1,
-  "headline": "A clearer update and a faster first run",
+  "headline": "Meeting transcripts copy in full",
   "highlights": [
-    "See what changed before an update installs and after Diduny relaunches.",
-    "Set up cloud dictation from Overview and try your first phrase immediately.",
-    "Grant auto-paste and meeting permissions only when you need them."
+    "Copying a transcript keeps its timestamps and speaker labels.",
+    "Recording details close again from the X button or Esc."
   ]
 }

--- a/DidunyTests/TimedTranscriptRendererTests.swift
+++ b/DidunyTests/TimedTranscriptRendererTests.swift
@@ -1,0 +1,96 @@
+@testable import Diduny
+import XCTest
+
+/// Copying a meeting transcript must hand over the same text the detail view shows:
+/// timestamps plus speaker labels, not the flattened plain transcript.
+final class TimedTranscriptRendererTests: XCTestCase {
+    private func segment(
+        startMilliseconds: Int,
+        speaker: String?,
+        text: String
+    ) -> TimedTranscriptSegment {
+        TimedTranscriptSegment(
+            startMilliseconds: startMilliseconds,
+            endMilliseconds: startMilliseconds + 1000,
+            speaker: speaker,
+            text: text
+        )
+    }
+
+    func test_renderIncludesTimestampsAndSpeakerLabels() {
+        let rendered = TimedTranscriptRenderer.render(
+            segments: [
+                segment(startMilliseconds: 0, speaker: "1", text: "Hello team."),
+                segment(startMilliseconds: 65_000, speaker: "2", text: "Hi there.")
+            ],
+            fallbackText: "Hello team. Hi there."
+        )
+
+        XCTAssertEqual(rendered, "[00:00] Speaker 1: Hello team.\n\n[01:05] Speaker 2: Hi there.")
+    }
+
+    func test_renderKeepsProviderSuppliedSpeakerNameAsIs() {
+        let rendered = TimedTranscriptRenderer.render(
+            segments: [segment(startMilliseconds: 3_600_000, speaker: "Speaker A", text: "Wrapping up.")],
+            fallbackText: "Wrapping up."
+        )
+
+        XCTAssertEqual(rendered, "[1:00:00] Speaker A: Wrapping up.")
+    }
+
+    func test_renderOmitsSpeakerPrefixWhenDiarizationIsMissing() {
+        let rendered = TimedTranscriptRenderer.render(
+            segments: [
+                segment(startMilliseconds: 2000, speaker: nil, text: "Solo note."),
+                segment(startMilliseconds: 4000, speaker: "   ", text: "Blank speaker.")
+            ],
+            fallbackText: "Solo note. Blank speaker."
+        )
+
+        XCTAssertEqual(rendered, "[00:02] Solo note.\n\n[00:04] Blank speaker.")
+    }
+
+    func test_renderFallsBackToPlainTextWithoutSegments() {
+        XCTAssertEqual(
+            TimedTranscriptRenderer.render(segments: nil, fallbackText: "Plain transcript."),
+            "Plain transcript."
+        )
+        XCTAssertEqual(
+            TimedTranscriptRenderer.render(segments: [], fallbackText: "Plain transcript."),
+            "Plain transcript."
+        )
+    }
+
+    func test_transcriptVersionDisplayTextMatchesRenderedSegments() {
+        let version = TranscriptVersion(
+            kind: .cloud,
+            text: "Hello team.",
+            segments: [segment(startMilliseconds: 0, speaker: "1", text: "Hello team.")]
+        )
+
+        XCTAssertEqual(version.displayText, "[00:00] Speaker 1: Hello team.")
+    }
+
+    func test_recordingDisplayTranscriptTextUsesSpeakerLabels() {
+        var recording = Recording(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            type: .meeting,
+            audioFileName: "meeting.wav",
+            durationSeconds: 120,
+            fileSizeBytes: 42,
+            status: .transcribed,
+            transcriptionText: "Hello team. Hi there.",
+            sourceDevice: nil
+        )
+        recording.transcriptSegments = [
+            segment(startMilliseconds: 0, speaker: "1", text: "Hello team."),
+            segment(startMilliseconds: 5000, speaker: "2", text: "Hi there.")
+        ]
+
+        XCTAssertEqual(
+            recording.displayTranscriptText,
+            "[00:00] Speaker 1: Hello team.\n\n[00:05] Speaker 2: Hi there."
+        )
+    }
+}

--- a/scripts/test_release_highlights.py
+++ b/scripts/test_release_highlights.py
@@ -33,10 +33,9 @@ class ReleaseHighlightsPipelineTests(unittest.TestCase):
 
             self.run_script("render", str(PAYLOAD), str(markdown))
             expected = (
-                "# A clearer update and a faster first run\n\n"
-                "- See what changed before an update installs and after Diduny relaunches.\n"
-                "- Set up cloud dictation from Overview and try your first phrase immediately.\n"
-                "- Grant auto-paste and meeting permissions only when you need them.\n"
+                "# Meeting transcripts copy in full\n\n"
+                "- Copying a transcript keeps its timestamps and speaker labels.\n"
+                "- Recording details close again from the X button or Esc.\n"
             )
             self.assertEqual(markdown.read_text(encoding="utf-8"), expected)
 


### PR DESCRIPTION
## Problems

1. **Copy Transcript dropped timestamps and speakers.** Opening a saved meeting recording and pressing *Copy Transcript* put the flattened `TranscriptVersion.text` on the clipboard, so the `[mm:ss]` marks visible on screen were lost — and speaker attribution was never rendered anywhere, even in the detail view itself.
2. **The recording detail window could not be closed.** `RecordingDetailView.onClose` defaulted to `{}`, and the sheets in Overview and Meetings were built without passing a handler. Both the X button (`.keyboardShortcut(.cancelAction)`) and Esc (`.onExitCommand`) called that no-op, leaving the sheet stuck open.

## Changes

- `TimedTranscriptSegment` gained `speakerLabel` (normalizes `"1"` → `"Speaker 1"`, keeps a provider-supplied `"Speaker A"` as is, `nil` when diarization is absent) and `formattedLine`.
- New `TimedTranscriptRenderer.render(segments:fallbackText:)` is the single place transcripts are laid out as `[mm:ss] Speaker N: text`, falling back to plain text when there are no timed segments.
- `TranscriptVersion.displayText` and `Recording.displayTranscriptText` both go through the renderer, so on-screen text and clipboard text can no longer drift apart.
- Copy/export paths now use it: detail-view *Copy Transcript*, the batch inspector *Copy*, and batch markdown export.
- Overview and Meetings pass `onClose: { selectedRecording = nil }`; `onClose` lost its default value so a future call site cannot silently ship an un-dismissable sheet.

## Tests

Added `DidunyTests/TimedTranscriptRendererTests.swift` covering speaker-label normalization, the hour-long timestamp form, segments without diarization, the plain-text fallback, and `Recording.displayTranscriptText`.

Not compiled or run here — this session has no macOS/Swift toolchain, so the build and test run happen in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_015bHxuqmVcUMDrto487riUi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copied transcripts now preserve timestamps and speaker labels when available.
  * Transcript displays use consistent formatting across recording details, batch views, and exports.
  * Plain-text transcripts remain available when timed segments are unavailable.
  * Recording details can be closed with the X button or Escape key.

* **Bug Fixes**
  * Improved consistency between displayed, copied, and exported transcript content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->