### PR TITLE
feat: Diduny Pro billing UI on current main (WayForPay)

### DIFF
--- a/Diduny.xcodeproj/project.pbxproj
+++ b/Diduny.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		6B6EA4D239D9BC8D7CB2D802 /* RecordingFeedbackSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECD47EAFC19CDD9D6561326 /* RecordingFeedbackSurface.swift */; };
 		6E95C33622E89CBD05C763D5 /* EscapeCancelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A0045FAC17572590BE16F /* EscapeCancelService.swift */; };
 		728A1A58EC0A9C07D7EA9CFC /* LiveDictationOverlayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C737BE018A4A18E4479FAD1F /* LiveDictationOverlayStore.swift */; };
+		72CF87B2D5A8C2BA20F6ACC5 /* BillingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E486E3E8E143E1BD8E64A03 /* BillingServiceTests.swift */; };
 		733D324CBB0ADB12B3780BF8 /* WhisperTranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6206FCF30AD9AFE3530CB50 /* WhisperTranscriptionService.swift */; };
 		760CD3415170E644BC1DDCBB /* AudioDictationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAB5C5B84DF4B8F5E37A9FF /* AudioDictationSettingsView.swift */; };
 		78E2E9B4903AA5A8A50AA6FC /* AppDelegate+Hotkeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2CC58C907B4985941DCDA9 /* AppDelegate+Hotkeys.swift */; };
@@ -159,6 +160,7 @@
 		F64CD3B70A52B315B4110B8C /* CloudRealtimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001D5E66F362C783C621055C /* CloudRealtimeService.swift */; };
 		F6597F7A3262A493D769B85B /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECAEC93BAEBC7FB0CE79126 /* Errors.swift */; };
 		F82648095DB4730684FC8688 /* ReleaseHighlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CA3466DC76D4C3741A1663 /* ReleaseHighlights.swift */; };
+		F7F5AA9312C984130F8EDF6B /* BillingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68E6ADF7F2CCF978E972FDB /* BillingService.swift */; };
 		F9204E8BCBCCA977B096A3D2 /* AudioPlaybackControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C88AE153FCAA14A227A7E16 /* AudioPlaybackControlView.swift */; };
 		FFBC1497C42CFFB50037E3EA /* TypingSpeedMeasurementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E3CC8287108DD5E1CCD081 /* TypingSpeedMeasurementTests.swift */; };
 /* End PBXBuildFile section */
@@ -183,6 +185,7 @@
 		0B43D2844894F848F20BFDEB /* MenuBarIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarIconView.swift; sourceTree = "<group>"; };
 		0C49EEDF9A5AEED5B941A6AF /* Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Test.xcconfig; sourceTree = "<group>"; };
 		1023A30E21CD6C2DF35A832B /* ImportedMediaAudioPreparerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportedMediaAudioPreparerTests.swift; sourceTree = "<group>"; };
+		0E486E3E8E143E1BD8E64A03 /* BillingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingServiceTests.swift; sourceTree = "<group>"; };
 		118CE8BCA0160E31FD916B10 /* AudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevice.swift; sourceTree = "<group>"; };
 		1297828B8BD8BEDBAFD9F235 /* RealtimeTokenCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeTokenCoalescer.swift; sourceTree = "<group>"; };
 		12B40184B3E0CE6E0736EE82 /* NotchManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotchManagerTests.swift; sourceTree = "<group>"; };
@@ -295,6 +298,7 @@
 		B3A09F4B066D5CA8FBA776EB /* UsageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageService.swift; sourceTree = "<group>"; };
 		B569D84FAAF108A8B313E86B /* RecordingFeedbackControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingFeedbackControllerTests.swift; sourceTree = "<group>"; };
 		B5D4FC33778F42CC48FF44C5 /* Recording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Recording.swift; sourceTree = "<group>"; };
+		B68E6ADF7F2CCF978E972FDB /* BillingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingService.swift; sourceTree = "<group>"; };
 		B850C5D55AE7652A88CE36F5 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		BA64DC6EAB5D1FB38CF7F517 /* MeetingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSettingsView.swift; sourceTree = "<group>"; };
 		BB0020FC49058C60D9F2F8B4 /* LiveDictationOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveDictationOverlayView.swift; sourceTree = "<group>"; };
@@ -467,6 +471,7 @@
 				39F37FBC8AD6C2935F89C66D /* AudioPlaybackService.swift */,
 				6BBD93A73F0292748E989CA5 /* AudioRecorderService.swift */,
 				31E7F6FB04A54A9F5A3F9A8F /* AuthService.swift */,
+				B68E6ADF7F2CCF978E972FDB /* BillingService.swift */,
 				459B59FAABA91EB9AD4EB4EF /* ClipboardService.swift */,
 				001D5E66F362C783C621055C /* CloudRealtimeService.swift */,
 				5D808ED223F5466862CE124F /* CloudTranscriptionService.swift */,
@@ -682,6 +687,7 @@
 			children = (
 				CB03AFCF7D534F613B88F580 /* AsyncTranscriptionJobFileUploadTests.swift */,
 				A90DC34399C728FB2BD9C292 /* AuthServiceTests.swift */,
+				0E486E3E8E143E1BD8E64A03 /* BillingServiceTests.swift */,
 				FB2D4C4C36B3BB89D1A2E8BD /* CloudTranscriptionServiceE2ETests.swift */,
 				53DBF08EF8AA75C055A631A2 /* EdgeCommandPanelModelTests.swift */,
 				C46453045F6E830B4B5B48D4 /* EscapeCancelServiceTests.swift */,
@@ -934,6 +940,7 @@
 				948ADBEBD5ED5D02955F7E28 /* AudioRecorderService.swift in Sources */,
 				6947A364CF4E8E1A7AC3018C /* AuthService.swift in Sources */,
 				D6937717EE280CA3B8339D53 /* BatchTranscriptionProgressViews.swift in Sources */,
+				F7F5AA9312C984130F8EDF6B /* BillingService.swift in Sources */,
 				C6297FB1BED3D932E43C6C7E /* ClipboardService.swift in Sources */,
 				F64CD3B70A52B315B4110B8C /* CloudRealtimeService.swift in Sources */,
 				8652A9D79DB6EF0EA183113A /* CloudTranscriptionService.swift in Sources */,
@@ -1035,6 +1042,7 @@
 			files = (
 				40F99144735911B3C0DF19AC /* AsyncTranscriptionJobFileUploadTests.swift in Sources */,
 				BF50A7600E9D175A63D987E7 /* AuthServiceTests.swift in Sources */,
+				72CF87B2D5A8C2BA20F6ACC5 /* BillingServiceTests.swift in Sources */,
 				154F9E85CEDA37FE7E88EE36 /* CloudTranscriptionServiceE2ETests.swift in Sources */,
 				B3CE664BDDC9318406AC2BC0 /* EdgeCommandPanelModelTests.swift in Sources */,
 				03386BD1EB00ACDF8DD60759 /* EscapeCancelServiceTests.swift in Sources */,

--- a/Diduny/App/AppDelegate.swift
+++ b/Diduny/App/AppDelegate.swift
@@ -318,6 +318,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
+        // Warm billing/usage state so the Pro badge and entitlement are
+        // correct right after launch, not only after opening Settings.
+        if AuthService.hasStoredSession {
+            Task {
+                await BillingService.shared.refresh()
+                await UsageService.shared.refresh()
+            }
+        }
+
         // Avoid initializing AuthService just for this log line.
         if !AuthService.hasStoredSession {
             Log.app.info("[Auth] No stored session — cloud preferences remain stored, runtime uses local fallback")

--- a/Diduny/Core/Models/Errors.swift
+++ b/Diduny/Core/Models/Errors.swift
@@ -24,7 +24,7 @@ enum TranscriptionError: LocalizedError {
         case .invalidURL:
             "Invalid API URL"
         case let .usageLimitExceeded(usedHours, limitHours):
-            "Cloud usage limit reached (\(String(format: "%.1f", usedHours))h / \(String(format: "%.0f", limitHours))h). Using local model."
+            "Cloud usage limit reached (\(String(format: "%.1f", usedHours))h / \(String(format: "%.0f", limitHours))h). Upgrade to Diduny Pro or use the local model."
         }
     }
 }
@@ -68,7 +68,7 @@ enum RealtimeTranscriptionError: LocalizedError {
         case let .webSocketError(error):
             "WebSocket error: \(error.localizedDescription)"
         case let .usageLimitExceeded(usedHours, limitHours):
-            "Cloud usage limit reached (\(String(format: "%.1f", usedHours))h / \(String(format: "%.0f", limitHours))h). Using local model."
+            "Cloud usage limit reached (\(String(format: "%.1f", usedHours))h / \(String(format: "%.0f", limitHours))h). Upgrade to Diduny Pro or use the local model."
         }
     }
 }

--- a/Diduny/Core/Models/RemoteConfig.swift
+++ b/Diduny/Core/Models/RemoteConfig.swift
@@ -12,6 +12,7 @@ struct RemoteConfig: Codable {
         let meetingRealtimeTranscriptionEnabled: Bool?
         let textCleanupEnabled: Bool?
         let escapeCancelEnabled: Bool?
+        let billingEnabled: Bool?
     }
 
     struct Endpoints: Codable {

--- a/Diduny/Core/Services/AsyncTranscriptionJobService.swift
+++ b/Diduny/Core/Services/AsyncTranscriptionJobService.swift
@@ -581,7 +581,10 @@ final class AsyncTranscriptionJobService {
     ) throws -> JobSubmission {
         if httpResponse.statusCode == 402 {
             Log.transcription.warning("submitJob: 402 — usage limit exceeded")
-            Task { await UsageService.shared.refresh() }
+            Task {
+                await UsageService.shared.refresh()
+                await BillingService.shared.refresh()
+            }
             if let body = try? JSONDecoder().decode(UsageLimitErrorResponse.self, from: data) {
                 throw TranscriptionError.usageLimitExceeded(
                     usedHours: body.usedHours,

--- a/Diduny/Core/Services/BillingService.swift
+++ b/Diduny/Core/Services/BillingService.swift
@@ -1,0 +1,181 @@
+import AppKit
+import Foundation
+
+@Observable
+@MainActor
+final class BillingService {
+    static let shared = BillingService()
+
+    private(set) var cachedStatus: BillingStatusResponse?
+    private(set) var isLoading = false
+    private(set) var lastFetched: Date?
+
+    private init() {}
+
+    var isPro: Bool {
+        cachedStatus?.plan == .pro
+    }
+
+    var hasVisibleBillingState: Bool {
+        cachedStatus != nil || RemoteConfigService.shared.billingEnabled
+    }
+
+    func refresh() async {
+        let proxyBase = SettingsStorage.shared.proxyBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let url = URL(string: "\(proxyBase)/api/v1/billing/me") else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let (data, httpResponse) = try await AuthService.shared.performWithAuth(request)
+            guard (200 ... 299).contains(httpResponse.statusCode) else {
+                Log.app.warning("[Billing] Failed to fetch billing: HTTP \(httpResponse.statusCode)")
+                return
+            }
+            cachedStatus = try JSONDecoder().decode(BillingStatusResponse.self, from: data)
+            lastFetched = Date()
+            Log.app.info("[Billing] Refreshed: \(self.cachedStatus?.status.rawValue ?? "unknown")")
+        } catch {
+            Log.app.warning("[Billing] Failed to fetch billing: \(error.localizedDescription)")
+        }
+    }
+
+    func startCheckout() async throws {
+        let checkout = try await post(path: "/checkout", body: EmptyBillingBody(), as: BillingCheckoutResponse.self)
+        cachedStatus = BillingStatusResponse.checkoutPending(orderReference: checkout.orderReference)
+        guard let url = URL(string: checkout.paymentUrl) else {
+            throw BillingError.invalidCheckoutURL
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    func sync(orderReference: String? = nil) async throws {
+        cachedStatus = try await post(
+            path: "/sync",
+            body: BillingSyncRequest(orderReference: orderReference),
+            as: BillingStatusResponse.self
+        )
+        lastFetched = Date()
+    }
+
+    func cancelRenewal() async throws {
+        cachedStatus = try await post(path: "/cancel", body: EmptyBillingBody(), as: BillingStatusResponse.self)
+        lastFetched = Date()
+    }
+
+    func resumeRenewal() async throws {
+        try await startCheckout()
+    }
+
+    private func post<Body: Encodable, Response: Decodable>(
+        path: String,
+        body: Body,
+        as responseType: Response.Type
+    ) async throws -> Response {
+        let proxyBase = SettingsStorage.shared.proxyBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let url = URL(string: "\(proxyBase)/api/v1/billing\(path)") else {
+            throw BillingError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+
+        isLoading = true
+        defer { isLoading = false }
+
+        let (data, httpResponse) = try await AuthService.shared.performWithAuth(request)
+        guard (200 ... 299).contains(httpResponse.statusCode) else {
+            if let errorBody = try? JSONDecoder().decode(BillingErrorResponse.self, from: data) {
+                throw BillingError.server(errorBody.error)
+            }
+            throw BillingError.server("HTTP \(httpResponse.statusCode)")
+        }
+        return try JSONDecoder().decode(responseType, from: data)
+    }
+}
+
+enum BillingPlan: String, Decodable {
+    case free
+    case pro
+}
+
+enum BillingEntitlement: String, Decodable {
+    case free
+    case paid
+    case grant
+    case legacyUnlimited = "legacy_unlimited"
+}
+
+enum BillingStatus: String, Decodable {
+    case active
+    case checkoutPending = "checkout_pending"
+    case cancelled
+    case pastDue = "past_due"
+    case expired
+}
+
+struct BillingStatusResponse: Decodable {
+    let plan: BillingPlan
+    let entitlement: BillingEntitlement
+    let status: BillingStatus
+    let renewsAt: String?
+    let activeUntil: String?
+    let cancelAtPeriodEnd: Bool
+    let pendingOrderReference: String?
+    let usage: UsageResponse?
+
+    var hasUnlimitedAccess: Bool {
+        plan == .pro || entitlement == .paid || entitlement == .grant || entitlement == .legacyUnlimited
+    }
+
+    static func checkoutPending(orderReference: String) -> BillingStatusResponse {
+        BillingStatusResponse(
+            plan: .free,
+            entitlement: .free,
+            status: .checkoutPending,
+            renewsAt: nil,
+            activeUntil: nil,
+            cancelAtPeriodEnd: false,
+            pendingOrderReference: orderReference,
+            usage: nil
+        )
+    }
+}
+
+struct BillingCheckoutResponse: Decodable {
+    let orderReference: String
+    let paymentUrl: String
+}
+
+private struct BillingSyncRequest: Encodable {
+    let orderReference: String?
+}
+
+private struct EmptyBillingBody: Encodable {}
+
+private struct BillingErrorResponse: Decodable {
+    let error: String
+}
+
+enum BillingError: LocalizedError {
+    case invalidURL
+    case invalidCheckoutURL
+    case server(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "Invalid billing URL"
+        case .invalidCheckoutURL:
+            "Invalid checkout URL"
+        case let .server(message):
+            message
+        }
+    }
+}

--- a/Diduny/Core/Services/BillingService.swift
+++ b/Diduny/Core/Services/BillingService.swift
@@ -36,8 +36,7 @@ final class BillingService {
                 Log.app.warning("[Billing] Failed to fetch billing: HTTP \(httpResponse.statusCode)")
                 return
             }
-            cachedStatus = try JSONDecoder().decode(BillingStatusResponse.self, from: data)
-            lastFetched = Date()
+            updateStatus(try JSONDecoder().decode(BillingStatusResponse.self, from: data))
             Log.app.info("[Billing] Refreshed: \(self.cachedStatus?.status.rawValue ?? "unknown")")
         } catch {
             Log.app.warning("[Billing] Failed to fetch billing: \(error.localizedDescription)")
@@ -46,29 +45,50 @@ final class BillingService {
 
     func startCheckout() async throws {
         let checkout = try await post(path: "/checkout", body: EmptyBillingBody(), as: BillingCheckoutResponse.self)
+        openCheckout(checkout)
+    }
+
+    func sync(orderReference: String? = nil) async throws {
+        let reference = orderReference ?? SettingsStorage.shared.billingPendingOrderReference
+        updateStatus(try await post(
+            path: "/sync",
+            body: BillingSyncRequest(orderReference: reference),
+            as: BillingStatusResponse.self
+        ))
+    }
+
+    func cancelRenewal() async throws {
+        updateStatus(try await post(path: "/cancel", body: EmptyBillingBody(), as: BillingStatusResponse.self))
+    }
+
+    /// Within the paid period the backend resumes the suspended WayForPay rule
+    /// and returns billing state; after expiry it returns a fresh checkout.
+    func resumeRenewal() async throws {
+        let data = try await postRaw(path: "/resume", body: EmptyBillingBody())
+        if let checkout = try? JSONDecoder().decode(BillingCheckoutResponse.self, from: data) {
+            openCheckout(checkout)
+            return
+        }
+        updateStatus(try JSONDecoder().decode(BillingStatusResponse.self, from: data))
+    }
+
+    private func openCheckout(_ checkout: BillingCheckoutResponse) {
+        SettingsStorage.shared.billingPendingOrderReference = checkout.orderReference
         cachedStatus = BillingStatusResponse.checkoutPending(orderReference: checkout.orderReference)
         guard let url = URL(string: checkout.paymentUrl) else {
-            throw BillingError.invalidCheckoutURL
+            return
         }
         NSWorkspace.shared.open(url)
     }
 
-    func sync(orderReference: String? = nil) async throws {
-        cachedStatus = try await post(
-            path: "/sync",
-            body: BillingSyncRequest(orderReference: orderReference),
-            as: BillingStatusResponse.self
-        )
+    private func updateStatus(_ status: BillingStatusResponse) {
+        cachedStatus = status
         lastFetched = Date()
-    }
-
-    func cancelRenewal() async throws {
-        cachedStatus = try await post(path: "/cancel", body: EmptyBillingBody(), as: BillingStatusResponse.self)
-        lastFetched = Date()
-    }
-
-    func resumeRenewal() async throws {
-        try await startCheckout()
+        // A checkout survives app restarts only through this stored reference;
+        // any settled state clears it.
+        if status.status != .checkoutPending {
+            SettingsStorage.shared.billingPendingOrderReference = nil
+        }
     }
 
     private func post<Body: Encodable, Response: Decodable>(
@@ -76,6 +96,10 @@ final class BillingService {
         body: Body,
         as responseType: Response.Type
     ) async throws -> Response {
+        try JSONDecoder().decode(responseType, from: try await postRaw(path: path, body: body))
+    }
+
+    private func postRaw<Body: Encodable>(path: String, body: Body) async throws -> Data {
         let proxyBase = SettingsStorage.shared.proxyBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard let url = URL(string: "\(proxyBase)/api/v1/billing\(path)") else {
             throw BillingError.invalidURL
@@ -96,13 +120,22 @@ final class BillingService {
             }
             throw BillingError.server("HTTP \(httpResponse.statusCode)")
         }
-        return try JSONDecoder().decode(responseType, from: data)
+        return data
     }
 }
 
+// Billing enums decode unknown backend values into `.unknown` instead of
+// failing the whole response — a new lifecycle state on the server must never
+// blank the entire billing UI in older app builds.
 enum BillingPlan: String, Decodable {
     case free
     case pro
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = BillingPlan(rawValue: raw) ?? .unknown
+    }
 }
 
 enum BillingEntitlement: String, Decodable {
@@ -110,6 +143,12 @@ enum BillingEntitlement: String, Decodable {
     case paid
     case grant
     case legacyUnlimited = "legacy_unlimited"
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = BillingEntitlement(rawValue: raw) ?? .unknown
+    }
 }
 
 enum BillingStatus: String, Decodable {
@@ -118,6 +157,25 @@ enum BillingStatus: String, Decodable {
     case cancelled
     case pastDue = "past_due"
     case expired
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = BillingStatus(rawValue: raw) ?? .unknown
+    }
+}
+
+struct BillingPrice: Decodable {
+    let amount: Double
+    let currency: String
+
+    var formattedMonthly: String {
+        let value = amount.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(amount))
+            : String(format: "%.2f", amount)
+        let symbol = currency == "UAH" ? "₴" : currency
+        return "\(value) \(symbol)/month"
+    }
 }
 
 struct BillingStatusResponse: Decodable {
@@ -128,6 +186,7 @@ struct BillingStatusResponse: Decodable {
     let activeUntil: String?
     let cancelAtPeriodEnd: Bool
     let pendingOrderReference: String?
+    let price: BillingPrice?
     let usage: UsageResponse?
 
     var hasUnlimitedAccess: Bool {
@@ -143,6 +202,7 @@ struct BillingStatusResponse: Decodable {
             activeUntil: nil,
             cancelAtPeriodEnd: false,
             pendingOrderReference: orderReference,
+            price: nil,
             usage: nil
         )
     }

--- a/Diduny/Core/Services/CloudRealtimeService.swift
+++ b/Diduny/Core/Services/CloudRealtimeService.swift
@@ -115,7 +115,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
 
     private func connectWebSocket() async throws {
         // Pre-check cached usage to avoid unnecessary connection attempt
-        if let usage = await UsageService.shared.cachedUsage, !usage.isWhitelisted,
+        if let usage = await UsageService.shared.cachedUsage, !usage.isUnlimited,
            let remaining = usage.remainingMs, remaining <= 0 {
             throw RealtimeTranscriptionError.usageLimitExceeded(
                 usedHours: usage.usedHours, limitHours: usage.limitHours ?? 5
@@ -699,6 +699,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
         }
         let usage = await UsageService.shared.cachedUsage
         await UsageService.shared.refresh()
+        await BillingService.shared.refresh()
         return .usageLimitExceeded(
             usedHours: usage?.usedHours ?? 0,
             limitHours: usage?.limitHours ?? 5
@@ -737,6 +738,7 @@ final class CloudRealtimeService: NSObject, @unchecked Sendable {
                 guard let self else { return }
                 let usage = await UsageService.shared.cachedUsage
                 await UsageService.shared.refresh()
+                await BillingService.shared.refresh()
                 self.onError?(RealtimeTranscriptionError.usageLimitExceeded(
                     usedHours: usage?.usedHours ?? 0,
                     limitHours: usage?.limitHours ?? 5

--- a/Diduny/Core/Services/CloudTranscriptionService.swift
+++ b/Diduny/Core/Services/CloudTranscriptionService.swift
@@ -175,7 +175,10 @@ final class CloudTranscriptionService: TranscriptionServiceProtocol {
         // 402: usage limit exceeded
         if httpResponse.statusCode == 402 {
             Log.transcription.warning("proxyTranscribe: 402 — usage limit exceeded")
-            Task { await UsageService.shared.refresh() }
+            Task {
+                await UsageService.shared.refresh()
+                await BillingService.shared.refresh()
+            }
             if let body = try? JSONDecoder().decode(UsageLimitErrorResponse.self, from: data) {
                 throw TranscriptionError.usageLimitExceeded(
                     usedHours: body.usedHours, limitHours: body.limitHours

--- a/Diduny/Core/Services/RemoteConfigService.swift
+++ b/Diduny/Core/Services/RemoteConfigService.swift
@@ -49,6 +49,12 @@ final class RemoteConfigService: @unchecked Sendable {
         return cachedConfig?.messages?.updateAvailableMessage
     }
 
+    var billingEnabled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedConfig?.featureFlags?.billingEnabled ?? false
+    }
+
     func sttBaseURL(default fallback: String) -> String {
         lock.lock()
         defer { lock.unlock() }

--- a/Diduny/Core/Services/UsageService.swift
+++ b/Diduny/Core/Services/UsageService.swift
@@ -14,13 +14,13 @@ final class UsageService {
 
     var formattedRemaining: String {
         guard let usage = cachedUsage else { return "—" }
-        if usage.isWhitelisted { return "Unlimited" }
+        if usage.isUnlimited { return "Unlimited" }
         guard let remaining = usage.remainingHours else { return "—" }
         return String(format: "%.1fh remaining", remaining)
     }
 
     var usagePercent: Double {
-        guard let usage = cachedUsage, !usage.isWhitelisted,
+        guard let usage = cachedUsage, !usage.isUnlimited,
               let limitMs = usage.limitMs, limitMs > 0
         else { return 0 }
         return Double(usage.usedMs) / Double(limitMs)
@@ -53,12 +53,39 @@ final class UsageService {
 
 struct UsageResponse: Decodable {
     let isWhitelisted: Bool
+    let isUnlimited: Bool
+    let entitlement: String?
     let usedHours: Double
     let limitHours: Double?
     let remainingHours: Double?
     let usedMs: Int
     let limitMs: Int?
     let remainingMs: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case isWhitelisted
+        case isUnlimited
+        case entitlement
+        case usedHours
+        case limitHours
+        case remainingHours
+        case usedMs
+        case limitMs
+        case remainingMs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isWhitelisted = try container.decode(Bool.self, forKey: .isWhitelisted)
+        isUnlimited = try container.decodeIfPresent(Bool.self, forKey: .isUnlimited) ?? isWhitelisted
+        entitlement = try container.decodeIfPresent(String.self, forKey: .entitlement)
+        usedHours = try container.decode(Double.self, forKey: .usedHours)
+        limitHours = try container.decodeIfPresent(Double.self, forKey: .limitHours)
+        remainingHours = try container.decodeIfPresent(Double.self, forKey: .remainingHours)
+        usedMs = try container.decode(Int.self, forKey: .usedMs)
+        limitMs = try container.decodeIfPresent(Int.self, forKey: .limitMs)
+        remainingMs = try container.decodeIfPresent(Int.self, forKey: .remainingMs)
+    }
 }
 
 struct UsageLimitErrorResponse: Decodable {

--- a/Diduny/Core/Storage/SettingsStorage.swift
+++ b/Diduny/Core/Storage/SettingsStorage.swift
@@ -141,6 +141,7 @@ final class SettingsStorage {
         case meetingHistoryRetentionPolicy
         case whisperModelUnloadPolicy
         case proxyBaseURL
+        case billingPendingOrderReference
         case remoteConfigURL
         case userDeclinedScreenRecording
         case selectedBrowserSessionID
@@ -1272,6 +1273,20 @@ final class SettingsStorage {
     var proxyBaseURL: String {
         get { defaults.string(forKey: Key.proxyBaseURL.rawValue) ?? Self.defaultProxyBaseURL }
         set { defaults.set(newValue, forKey: Key.proxyBaseURL.rawValue) }
+    }
+
+    // Order reference of a WayForPay checkout that was opened in the browser
+    // but not yet confirmed — survives app restarts so billing sync can
+    // resolve the payment after relaunch.
+    var billingPendingOrderReference: String? {
+        get { defaults.string(forKey: Key.billingPendingOrderReference.rawValue) }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: Key.billingPendingOrderReference.rawValue)
+            } else {
+                defaults.removeObject(forKey: Key.billingPendingOrderReference.rawValue)
+            }
+        }
     }
 
     var remoteConfigURL: String? {

--- a/Diduny/Features/Main/SidebarView.swift
+++ b/Diduny/Features/Main/SidebarView.swift
@@ -73,13 +73,27 @@ struct SidebarView: View {
         }
     }
 
+    @ViewBuilder
     private var proBadge: some View {
-        Text("PRO")
-            .font(.system(size: 9, weight: .bold))
-            .foregroundColor(Color("ProBadgeText"))
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(Color("ProBadgeBg"), in: Capsule())
+        if let status = BillingService.shared.cachedStatus, status.hasUnlimitedAccess {
+            Text(sidebarBadgeText(status))
+                .font(.system(size: 9, weight: .bold))
+                .foregroundColor(Color("ProBadgeText"))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Color("ProBadgeBg"), in: Capsule())
+        }
+    }
+
+    private func sidebarBadgeText(_ status: BillingStatusResponse) -> String {
+        switch status.entitlement {
+        case .grant:
+            "GRANT"
+        case .legacyUnlimited:
+            "LEGACY"
+        default:
+            "PRO"
+        }
     }
 
     // MARK: - Footer CTA

--- a/Diduny/Features/Settings/AccountSettingsView.swift
+++ b/Diduny/Features/Settings/AccountSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct AccountSettingsView: View {
@@ -6,6 +7,8 @@ struct AccountSettingsView: View {
     @State private var isTestingProxy = false
     @State private var proxyTestResult: ProxyTestResult?
     @State private var isRefreshingConfig = false
+    @State private var billingError: String?
+    @State private var isBillingActionLoading = false
 
     private var authService: AuthService { AuthService.shared }
 
@@ -57,6 +60,8 @@ struct AccountSettingsView: View {
 #endif
             }
 
+            billingSection
+
             cloudUsageSection
 
             usageSection
@@ -65,7 +70,85 @@ struct AccountSettingsView: View {
         .onAppear {
             proxyBaseURL = SettingsStorage.shared.proxyBaseURL
             if authService.isLoggedIn {
-                Task { await UsageService.shared.refresh() }
+                Task { await refreshAccountData() }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            guard authService.isLoggedIn else { return }
+            Task { await refreshAccountData(syncBilling: true) }
+        }
+    }
+
+    // MARK: - Billing Section
+
+    @ViewBuilder
+    private var billingSection: some View {
+        if authService.isLoggedIn, BillingService.shared.hasVisibleBillingState {
+            Section("Diduny Pro") {
+                let billing = BillingService.shared
+
+                if let status = billing.cachedStatus {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(alignment: .firstTextBaseline) {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(billingTitle(status))
+                                    .font(.headline)
+                                Text(billingSubtitle(status))
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Spacer()
+
+                            Text(billingBadge(status))
+                                .font(.caption.weight(.bold))
+                                .foregroundColor(billingBadgeColor(status))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(billingBadgeColor(status).opacity(0.14), in: Capsule())
+                        }
+
+                        HStack(spacing: 8) {
+                            billingPrimaryAction(status)
+
+                            Button {
+                                Task { await refreshAccountData(syncBilling: true) }
+                            } label: {
+                                Label("Refresh Status", systemImage: "arrow.clockwise")
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(billing.isLoading || isBillingActionLoading)
+
+                            if billing.isLoading || isBillingActionLoading {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                        }
+                    }
+                } else if billing.isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Free")
+                            .font(.headline)
+                        Text("Cloud dictation includes 5 hours per month.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Button("Upgrade to Diduny Pro") {
+                            performBillingAction { try await BillingService.shared.startCheckout() }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                    }
+                }
+
+                if let billingError {
+                    Text(billingError)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
             }
         }
     }
@@ -79,11 +162,11 @@ struct AccountSettingsView: View {
                 let usageService = UsageService.shared
 
                 if let usage = usageService.cachedUsage {
-                    if usage.isWhitelisted {
+                    if usage.isUnlimited {
                         HStack {
                             Image(systemName: "infinity")
                                 .foregroundColor(.green)
-                            Text("Unlimited (whitelisted)")
+                            Text(unlimitedUsageLabel(usage))
                                 .foregroundColor(.secondary)
                         }
                     } else {
@@ -129,6 +212,159 @@ struct AccountSettingsView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func billingPrimaryAction(_ status: BillingStatusResponse) -> some View {
+        switch status.status {
+        case .checkoutPending:
+            Button("Refresh Status") {
+                Task { await refreshAccountData(syncBilling: true) }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        case .active:
+            if status.entitlement == .paid {
+                Button("Cancel Renewal") {
+                    performBillingAction { try await BillingService.shared.cancelRenewal() }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            } else {
+                Button("Upgrade to Diduny Pro") {
+                    performBillingAction { try await BillingService.shared.startCheckout() }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        case .cancelled:
+            Button("Resume Renewal") {
+                performBillingAction { try await BillingService.shared.resumeRenewal() }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        case .expired, .pastDue:
+            Button("Upgrade to Diduny Pro") {
+                performBillingAction { try await BillingService.shared.startCheckout() }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+    }
+
+    private func billingTitle(_ status: BillingStatusResponse) -> String {
+        switch (status.entitlement, status.status) {
+        case (.grant, _):
+            "Unlimited Access"
+        case (.legacyUnlimited, _):
+            "Unlimited Access"
+        case (.paid, .cancelled):
+            "Diduny Pro"
+        case (.paid, _):
+            "Diduny Pro"
+        case (_, .checkoutPending):
+            "Checkout Pending"
+        default:
+            "Free"
+        }
+    }
+
+    private func billingSubtitle(_ status: BillingStatusResponse) -> String {
+        switch status.status {
+        case .active where status.entitlement == .paid:
+            if let renewsAt = formatISODate(status.renewsAt) {
+                return "Renews \(renewsAt)"
+            }
+            return "Unlimited cloud usage"
+        case .cancelled:
+            if let activeUntil = formatISODate(status.activeUntil) {
+                return "Active until \(activeUntil)"
+            }
+            return "Renewal cancelled"
+        case .checkoutPending:
+            return "Waiting for WayForPay confirmation"
+        case .active where status.entitlement == .grant:
+            return "Manual whitelist grant"
+        case .active where status.entitlement == .legacyUnlimited:
+            return "Legacy unlimited access"
+        case .pastDue:
+            return "Payment needs attention"
+        case .expired:
+            return "5 hours of cloud usage per month"
+        default:
+            return "5 hours of cloud usage per month"
+        }
+    }
+
+    private func billingBadge(_ status: BillingStatusResponse) -> String {
+        switch status.entitlement {
+        case .paid:
+            status.cancelAtPeriodEnd ? "CANCELLED" : "PRO"
+        case .grant:
+            "GRANT"
+        case .legacyUnlimited:
+            "LEGACY"
+        case .free:
+            status.status == .checkoutPending ? "PENDING" : "FREE"
+        }
+    }
+
+    private func billingBadgeColor(_ status: BillingStatusResponse) -> Color {
+        switch status.entitlement {
+        case .paid:
+            return status.cancelAtPeriodEnd ? .orange : Color("BrandAccentDeep")
+        case .grant, .legacyUnlimited:
+            return .green
+        case .free:
+            return status.status == .checkoutPending ? .orange : .secondary
+        }
+    }
+
+    private func unlimitedUsageLabel(_ usage: UsageResponse) -> String {
+        switch usage.entitlement {
+        case "paid":
+            "Unlimited cloud usage"
+        case "grant":
+            "Unlimited (whitelisted)"
+        case "legacy_unlimited":
+            "Unlimited (legacy)"
+        default:
+            "Unlimited"
+        }
+    }
+
+    private func refreshAccountData(syncBilling: Bool = false) async {
+        if syncBilling {
+            try? await BillingService.shared.sync(
+                orderReference: BillingService.shared.cachedStatus?.pendingOrderReference
+            )
+        } else {
+            await BillingService.shared.refresh()
+        }
+        await UsageService.shared.refresh()
+    }
+
+    private func performBillingAction(_ action: @escaping () async throws -> Void) {
+        isBillingActionLoading = true
+        billingError = nil
+        Task {
+            do {
+                try await action()
+                await refreshAccountData()
+            } catch {
+                billingError = error.localizedDescription
+            }
+            isBillingActionLoading = false
+        }
+    }
+
+    private func formatISODate(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+        guard let date else { return nil }
+        return date.formatted(.dateTime.day().month(.abbreviated).year())
     }
 
     private func usageProgressColor(_ percent: Double) -> Color {

--- a/Diduny/Features/Settings/AccountSettingsView.swift
+++ b/Diduny/Features/Settings/AccountSettingsView.swift
@@ -231,7 +231,7 @@ struct AccountSettingsView: View {
                 .buttonStyle(.bordered)
                 .controlSize(.small)
             } else {
-                Button("Upgrade to Diduny Pro") {
+                Button(upgradeLabel(status.price)) {
                     performBillingAction { try await BillingService.shared.startCheckout() }
                 }
                 .buttonStyle(.borderedProminent)
@@ -243,13 +243,20 @@ struct AccountSettingsView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
-        case .expired, .pastDue:
-            Button("Upgrade to Diduny Pro") {
+        case .expired, .pastDue, .unknown:
+            Button(upgradeLabel(status.price)) {
                 performBillingAction { try await BillingService.shared.startCheckout() }
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)
         }
+    }
+
+    private func upgradeLabel(_ price: BillingPrice?) -> String {
+        if let price {
+            return "Upgrade to Diduny Pro — \(price.formattedMonthly)"
+        }
+        return "Upgrade to Diduny Pro"
     }
 
     private func billingTitle(_ status: BillingStatusResponse) -> String {
@@ -288,7 +295,7 @@ struct AccountSettingsView: View {
         case .active where status.entitlement == .legacyUnlimited:
             return "Legacy unlimited access"
         case .pastDue:
-            return "Payment needs attention"
+            return "Payment failed — WayForPay retries automatically. Update your card in WayForPay, or re-subscribe."
         case .expired:
             return "5 hours of cloud usage per month"
         default:
@@ -299,23 +306,25 @@ struct AccountSettingsView: View {
     private func billingBadge(_ status: BillingStatusResponse) -> String {
         switch status.entitlement {
         case .paid:
-            status.cancelAtPeriodEnd ? "CANCELLED" : "PRO"
+            if status.status == .pastDue { return "PAST DUE" }
+            return status.cancelAtPeriodEnd ? "CANCELLED" : "PRO"
         case .grant:
-            "GRANT"
+            return "GRANT"
         case .legacyUnlimited:
-            "LEGACY"
-        case .free:
-            status.status == .checkoutPending ? "PENDING" : "FREE"
+            return "LEGACY"
+        case .free, .unknown:
+            return status.status == .checkoutPending ? "PENDING" : "FREE"
         }
     }
 
     private func billingBadgeColor(_ status: BillingStatusResponse) -> Color {
         switch status.entitlement {
         case .paid:
+            if status.status == .pastDue { return .orange }
             return status.cancelAtPeriodEnd ? .orange : Color("BrandAccentDeep")
         case .grant, .legacyUnlimited:
             return .green
-        case .free:
+        case .free, .unknown:
             return status.status == .checkoutPending ? .orange : .secondary
         }
     }

--- a/Diduny/Resources/ReleaseHighlights.json
+++ b/Diduny/Resources/ReleaseHighlights.json
@@ -1,8 +1,9 @@
 {
   "schemaVersion": 1,
-  "headline": "Meeting transcripts copy in full",
+  "headline": "Diduny Pro subscription",
   "highlights": [
-    "Copying a transcript keeps its timestamps and speaker labels.",
-    "Recording details close again from the X button or Esc."
+    "Upgrade to Diduny Pro for unlimited cloud dictation, billed monthly through WayForPay.",
+    "Manage your subscription from Settings → Account: renewal status, cancel, and resume.",
+    "The sidebar badge now reflects your plan right after launch."
   ]
 }

--- a/DidunyTests/BillingServiceTests.swift
+++ b/DidunyTests/BillingServiceTests.swift
@@ -1,0 +1,73 @@
+@testable import Diduny
+import XCTest
+
+final class BillingServiceTests: XCTestCase {
+    func testBillingStatusDecodesProActiveState() throws {
+        let json = """
+        {
+          "plan": "pro",
+          "entitlement": "paid",
+          "status": "active",
+          "renewsAt": "2026-08-14T00:00:00.000Z",
+          "activeUntil": "2026-08-14T00:00:00.000Z",
+          "cancelAtPeriodEnd": false,
+          "pendingOrderReference": null,
+          "usage": {
+            "isWhitelisted": false,
+            "isUnlimited": true,
+            "entitlement": "paid",
+            "usedHours": 3.8,
+            "limitHours": null,
+            "remainingHours": null,
+            "usedMs": 13680000,
+            "limitMs": null,
+            "remainingMs": null
+          }
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(BillingStatusResponse.self, from: json)
+
+        XCTAssertEqual(status.plan, .pro)
+        XCTAssertEqual(status.entitlement, .paid)
+        XCTAssertEqual(status.status, .active)
+        XCTAssertTrue(status.hasUnlimitedAccess)
+        XCTAssertEqual(status.usage?.entitlement, "paid")
+        XCTAssertEqual(status.usage?.isUnlimited, true)
+    }
+
+    func testBillingStatusDecodesCancelledAndGrantStates() throws {
+        let cancelled = """
+        {
+          "plan": "pro",
+          "entitlement": "paid",
+          "status": "cancelled",
+          "renewsAt": null,
+          "activeUntil": "2026-08-14T00:00:00.000Z",
+          "cancelAtPeriodEnd": true,
+          "pendingOrderReference": null,
+          "usage": null
+        }
+        """.data(using: .utf8)!
+        let grant = """
+        {
+          "plan": "pro",
+          "entitlement": "grant",
+          "status": "active",
+          "renewsAt": null,
+          "activeUntil": null,
+          "cancelAtPeriodEnd": false,
+          "pendingOrderReference": null,
+          "usage": null
+        }
+        """.data(using: .utf8)!
+
+        let cancelledStatus = try JSONDecoder().decode(BillingStatusResponse.self, from: cancelled)
+        let grantStatus = try JSONDecoder().decode(BillingStatusResponse.self, from: grant)
+
+        XCTAssertEqual(cancelledStatus.status, .cancelled)
+        XCTAssertTrue(cancelledStatus.cancelAtPeriodEnd)
+        XCTAssertEqual(grantStatus.entitlement, .grant)
+        XCTAssertTrue(grantStatus.hasUnlimitedAccess)
+    }
+}

--- a/DidunyTests/BillingServiceTests.swift
+++ b/DidunyTests/BillingServiceTests.swift
@@ -70,4 +70,49 @@ final class BillingServiceTests: XCTestCase {
         XCTAssertEqual(grantStatus.entitlement, .grant)
         XCTAssertTrue(grantStatus.hasUnlimitedAccess)
     }
+
+    func testBillingStatusDecodesUnknownEnumValuesWithoutFailing() throws {
+        let json = """
+        {
+          "plan": "team",
+          "entitlement": "trialing",
+          "status": "on_hold",
+          "renewsAt": null,
+          "activeUntil": null,
+          "cancelAtPeriodEnd": false,
+          "pendingOrderReference": null,
+          "usage": null
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(BillingStatusResponse.self, from: json)
+
+        XCTAssertEqual(status.plan, .unknown)
+        XCTAssertEqual(status.entitlement, .unknown)
+        XCTAssertEqual(status.status, .unknown)
+        XCTAssertFalse(status.hasUnlimitedAccess)
+    }
+
+    func testBillingStatusDecodesPastDueWithPrice() throws {
+        let json = """
+        {
+          "plan": "pro",
+          "entitlement": "paid",
+          "status": "past_due",
+          "renewsAt": null,
+          "activeUntil": "2026-08-14T00:00:00.000Z",
+          "cancelAtPeriodEnd": false,
+          "pendingOrderReference": null,
+          "price": { "amount": 205, "currency": "UAH" },
+          "usage": null
+        }
+        """.data(using: .utf8)!
+
+        let status = try JSONDecoder().decode(BillingStatusResponse.self, from: json)
+
+        XCTAssertEqual(status.status, .pastDue)
+        XCTAssertEqual(status.price?.amount, 205)
+        XCTAssertEqual(status.price?.formattedMonthly, "205 ₴/month")
+        XCTAssertTrue(status.hasUnlimitedAccess)
+    }
 }

--- a/scripts/test_release_highlights.py
+++ b/scripts/test_release_highlights.py
@@ -33,9 +33,10 @@ class ReleaseHighlightsPipelineTests(unittest.TestCase):
 
             self.run_script("render", str(PAYLOAD), str(markdown))
             expected = (
-                "# Meeting transcripts copy in full\n\n"
-                "- Copying a transcript keeps its timestamps and speaker labels.\n"
-                "- Recording details close again from the X button or Esc.\n"
+                "# Diduny Pro subscription\n\n"
+                "- Upgrade to Diduny Pro for unlimited cloud dictation, billed monthly through WayForPay.\n"
+                "- Manage your subscription from Settings → Account: renewal status, cancel, and resume.\n"
+                "- The sidebar badge now reflects your plan right after launch.\n"
             )
             self.assertEqual(markdown.read_text(encoding="utf-8"), expected)
 


### PR DESCRIPTION
## Summary

Replacement for PR #54: only the billing commit (`e8b0494`) cherry-picked onto current `main`, plus launch-hardening fixes. The edge-panel/Dynamic-Notch commits from #54 are intentionally left behind — main has since landed its own versions (PRs #61/#62).

**Commit 1 — billing UI (cherry-pick of `e8b0494`):**
- `BillingService` for authenticated `/api/v1/billing/*` calls
- Account screen billing states: Free, Checkout Pending, Pro, Cancelled, Grant, Legacy unlimited, Past due — spliced into main's post-onboarding `AccountSettingsView` layout (sign-in stays in `AccountSignInView`)
- Upgrade opens the backend-provided WayForPay checkout URL in the browser; sync on foreground return and explicit Refresh Status
- Dynamic sidebar badge: `PRO` / `GRANT` / `LEGACY`
- 402 usage-limit errors refresh billing/usage and surface upgrade messaging
- `UsageService` decodes `isUnlimited` + `entitlement` with backward compatibility

**Commit 2 — launch hardening:**
- Billing enums decode unknown backend values into `.unknown` instead of failing the whole `/billing/me` decode (a new server-side state can no longer blank the billing UI)
- "Resume Renewal" calls `POST /api/v1/billing/resume` — the backend resumes the suspended WayForPay rule within the paid period (no double charge) and only returns a fresh checkout after expiry
- Pending checkout order reference persists in `UserDefaults`, so a payment completes correctly across an app restart
- Billing/usage refresh at launch when a session exists — the Pro badge no longer waits for Settings → Account to be opened
- Price from the backend (`price: {amount, currency}`) shown on the upgrade button (no hardcoded pricing)
- `past_due` gets a PAST DUE badge and actionable copy; billing refresh restored in the async-job 402 path (lost in #54's merge)

## Dependency

Backend PR: rmarinsky/diduny-backend#21 (SQLite-native WayForPay billing). The app expects `GET /billing/me`, `POST /checkout|sync|cancel|resume`, `featureFlags.billingEnabled` in `/api/v1/config`, and `entitlement` on `/usage/me` — all provided there. UI stays hidden until the backend flag is on.

## Validation

- Conflict-free cherry-pick verified: pbxproj wired for `BillingService.swift`/`BillingServiceTests.swift` (build files, file refs, groups, Sources phases); no conflict markers remain
- `DidunyTests/BillingServiceTests.swift` extended: unknown enum values decode to `.unknown`, `past_due` + price decode
- **Not compiled**: this change was authored in a Linux environment without an Xcode toolchain — please run `xcodegen generate && xcodebuild test -scheme 'Diduny DEV' -only-testing:DidunyTests/BillingServiceTests` locally before marking ready

Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmxJFxz2CqgBQFuMG2zpoj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmxJFxz2CqgBQFuMG2zpoj)_